### PR TITLE
make ParaTree class destructor virtual

### DIFF
--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -196,7 +196,7 @@ namespace bitpit {
         ParaTree(uint8_t dim, std::string logfile = DEFAULT_LOG_FILE);
         ParaTree(std::istream &stream, std::string logfile = DEFAULT_LOG_FILE);
 #endif
-        ~ParaTree();
+        virtual ~ParaTree();
 
         ParaTree(const ParaTree & other);
 


### PR DESCRIPTION
ParaTree is a base class derived in PabloUniform; its destructor needs to be virtual