### PR TITLE
Fix Octant.cpp

### DIFF
--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -1562,7 +1562,7 @@ Octant Octant::computePeriodicOctant(uint8_t iface) const {
 		break;
 		case 5 :
 		{
-			degOct.m_y = 0;
+			degOct.m_z = 0;
 		}
 		break;
 		}


### PR DESCRIPTION
Fix periodic border condition; there was a typo in the way periodic octant through a z face (face = 5) is computed.