### PR TITLE
cmake: allow to oversubscribe the machine during MPI tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -159,6 +159,11 @@ function(addTest TEST_NAME TEST_SOURCES TEST_LIBRARIES WORKING_DIRECTORY N_PROCS
     # Add test
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_EXEC} ${TEST_ARGS} WORKING_DIRECTORY "${WORKING_DIRECTORY}")
 
+    # Set test variables
+    if (${N_PROCS} GREATER 1)
+        set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT OMPI_MCA_rmaps_base_oversubscribe=1)
+    endif()
+
 endfunction()
 
 #------------------------------------------------------------------------------------#


### PR DESCRIPTION
Beginning with version 3.0, OpenMPI's mpirun refuses to start more processes than there are physical processor cores on the machine.

To allow oversubcribing, the 'OMPI_MCA_rmaps_base_oversubscribe' environment variable can be set to 1.