### PR TITLE
LA: add support for custom rows/columns permutations

### DIFF
--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -232,9 +232,11 @@ void SparseMatrix::_initialize(bool partitioned, long nRows, long nCols, long nN
     // Parallel initialization
     m_partitioned = partitioned;
 
+    m_global_nRows = m_nRows;
+    m_global_nCols = m_nCols;
     if (m_partitioned) {
-        MPI_Allreduce(&m_nRows, &m_global_nRows, 1, MPI_LONG, MPI_SUM, m_communicator);
-        MPI_Allreduce(&m_nCols, &m_global_nCols, 1, MPI_LONG, MPI_SUM, m_communicator);
+        MPI_Allreduce(MPI_IN_PLACE, &m_global_nRows, 1, MPI_LONG, MPI_SUM, m_communicator);
+        MPI_Allreduce(MPI_IN_PLACE, &m_global_nCols, 1, MPI_LONG, MPI_SUM, m_communicator);
     }
 
     m_global_rowOffset = 0;

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1006,16 +1006,6 @@ void SystemSolver::setUp()
  */
 void SystemSolver::preKSPSetupActions()
 {
-    // Solver configuration
-    KSPSetType(m_KSP, KSPFGMRES);
-    if (m_KSPOptions.restart != PETSC_DEFAULT) {
-        KSPGMRESSetRestart(m_KSP, m_KSPOptions.restart);
-    }
-    if (m_KSPOptions.rtol != PETSC_DEFAULT || m_KSPOptions.maxits != PETSC_DEFAULT) {
-        KSPSetTolerances(m_KSP, m_KSPOptions.rtol, PETSC_DEFAULT, PETSC_DEFAULT, m_KSPOptions.maxits);
-    }
-    KSPSetInitialGuessNonzero(m_KSP, PETSC_TRUE);
-
     // Preconditioner configuration
     PCType preconditionerType;
 #if BITPIT_ENABLE_MPI == 1
@@ -1040,6 +1030,16 @@ void SystemSolver::preKSPSetupActions()
             PCFactorSetLevels(preconditioner, m_KSPOptions.levels);
         }
     }
+
+    // Solver configuration
+    KSPSetType(m_KSP, KSPFGMRES);
+    if (m_KSPOptions.restart != PETSC_DEFAULT) {
+        KSPGMRESSetRestart(m_KSP, m_KSPOptions.restart);
+    }
+    if (m_KSPOptions.rtol != PETSC_DEFAULT || m_KSPOptions.maxits != PETSC_DEFAULT) {
+        KSPSetTolerances(m_KSP, m_KSPOptions.rtol, PETSC_DEFAULT, PETSC_DEFAULT, m_KSPOptions.maxits);
+    }
+    KSPSetInitialGuessNonzero(m_KSP, PETSC_TRUE);
 }
 
 /*!

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -33,6 +33,7 @@
 namespace bitpit {
 
 int SystemSolver::m_nInstances = 0;
+bool SystemSolver::m_optionsEditable = true;
 std::vector<std::string> SystemSolver::m_options = std::vector<std::string>(1, "bitpit");
 
 /*!
@@ -42,7 +43,7 @@ std::vector<std::string> SystemSolver::m_options = std::vector<std::string>(1, "
  */
 void SystemSolver::addInitOption(const std::string &option)
 {
-    if (m_nInstances != 0) {
+    if (!m_optionsEditable) {
         throw std::runtime_error("Initialization opions can be set only before initializing the solver.");
     }
 
@@ -65,7 +66,7 @@ void SystemSolver::addInitOption(const std::string &option)
  */
 void SystemSolver::addInitOptions(int argc, char **argv)
 {
-    if (m_nInstances != 0) {
+    if (!m_optionsEditable) {
         throw std::runtime_error("Initialization opions can be set only before initializing the solver.");
     }
 
@@ -81,7 +82,7 @@ void SystemSolver::addInitOptions(int argc, char **argv)
  */
 void SystemSolver::addInitOptions(const std::vector<std::string> &options)
 {
-    if (m_nInstances != 0) {
+    if (!m_optionsEditable) {
         throw std::runtime_error("Initialization opions can be set only before initializing the solver.");
     }
 
@@ -200,6 +201,10 @@ void SystemSolver::clear()
 #endif
 
     m_assembled = false;
+
+    if (m_nInstances == 0) {
+        m_optionsEditable = true;
+    }
 }
 
 /*!
@@ -963,6 +968,7 @@ void SystemSolver::KSPInit()
     preKSPSetupActions();
 
     // Setup Krylov space
+    m_optionsEditable = false;
     KSPSetFromOptions(m_KSP);
     KSPSetUp(m_KSP);
 

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -118,7 +118,7 @@ SystemSolver::SystemSolver(bool debug)
 SystemSolver::SystemSolver(const std::string &prefix, bool debug)
     : m_A(nullptr), m_rhs(nullptr), m_solution(nullptr),
       m_KSP(nullptr),
-      m_prefix(prefix), m_assembled(false)
+      m_prefix(prefix), m_assembled(false), m_setUp(false)
 #if BITPIT_ENABLE_MPI==1
       , m_communicator(MPI_COMM_SELF), m_partitioned(false),
       m_rowGlobalOffset(0), m_colGlobalOffset(0)
@@ -186,21 +186,24 @@ SystemSolver::~SystemSolver()
  */
 void SystemSolver::clear()
 {
-    if (!isAssembled()) {
-        return;
+    if (isSetUp()) {
+        KSPDestroy(&m_KSP);
+        m_KSP = nullptr;
+
+        m_setUp = false;
     }
 
-    MatDestroy(&m_A);
-    VecDestroy(&m_rhs);
-    VecDestroy(&m_solution);
-
-    KSPDestroy(&m_KSP);
+    if (!isAssembled()) {
+        MatDestroy(&m_A);
+        VecDestroy(&m_rhs);
+        VecDestroy(&m_solution);
 
 #if BITPIT_ENABLE_MPI==1
-    freeCommunicator();
+        freeCommunicator();
 #endif
 
-    m_assembled = false;
+        m_assembled = false;
+    }
 
     if (m_nInstances == 0) {
         m_optionsEditable = true;
@@ -240,9 +243,6 @@ void SystemSolver::assembly(const SparseMatrix &matrix)
 #else
     vectorsInit();
 #endif
-
-    // Initialize Krylov solver
-    KSPInit();
 
     // The system is now assembled
     m_assembled = true;
@@ -364,6 +364,16 @@ bool SystemSolver::isAssembled() const
 }
 
 /*!
+ * Check if the system is set up.
+ *
+ * \return Returns true if the system is set up, false otherwise.
+ */
+bool SystemSolver::isSetUp() const
+{
+    return m_setUp;
+}
+
+/*!
  * Solve the system
  */
 void SystemSolver::solve()
@@ -371,6 +381,11 @@ void SystemSolver::solve()
     // Check if the system is assembled
     if (!isAssembled()) {
         throw std::runtime_error("Unable to solve the system. The system is not yet assembled.");
+    }
+
+    // Check if the system is set up
+    if (!isSetUp()) {
+        setUp();
     }
 
     // Perfrom actions before KSP solution
@@ -946,10 +961,20 @@ void SystemSolver::unsetNullSpace()
 }
 
 /*!
- * Initialize the Krylov solver.
+ * Setup the system.
  */
-void SystemSolver::KSPInit()
+void SystemSolver::setUp()
 {
+    // Check if the system is assembled
+    if (!isAssembled()) {
+        throw std::runtime_error("Unable to solve the system. The system is not yet assembled.");
+    }
+
+    // Destroy existing Krylov space
+    if (m_KSP) {
+        KSPDestroy(&m_KSP);
+    }
+
     // Set options prefix
     if (!m_prefix.empty()) {
         KSPSetOptionsPrefix(m_KSP, m_prefix.c_str());

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -115,13 +115,13 @@ SystemSolver::SystemSolver(bool debug)
  * \param debug if set to true, debug information will be printed
  */
 SystemSolver::SystemSolver(const std::string &prefix, bool debug)
-    : m_prefix(prefix), m_assembled(false),
+    : m_A(nullptr), m_rhs(nullptr), m_solution(nullptr),
+      m_KSP(nullptr),
+      m_prefix(prefix), m_assembled(false)
 #if BITPIT_ENABLE_MPI==1
-      m_communicator(MPI_COMM_SELF), m_partitioned(false),
-      m_rowGlobalOffset(0), m_colGlobalOffset(0),
+      , m_communicator(MPI_COMM_SELF), m_partitioned(false),
+      m_rowGlobalOffset(0), m_colGlobalOffset(0)
 #endif
-      m_A(nullptr), m_rhs(nullptr), m_solution(nullptr),
-      m_KSP(nullptr)
 {
     // Add debug options
     if (debug) {

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -168,7 +168,7 @@ SystemSolver::SystemSolver(const std::string &prefix, bool debug)
  */
 SystemSolver::~SystemSolver()
 {
-    // Clear the patch
+    // Clear the solver
     clear();
 
     // Decrease the number of instances
@@ -267,7 +267,6 @@ void SystemSolver::assembly(const SparseMatrix &matrix, PivotType pivotType)
 void SystemSolver::update(const std::vector<long> &rows, const SparseMatrix &elements)
 {
     // Check if the element storage is assembled
-    // Check if the matrix is assembled
     if (!elements.isAssembled()) {
         throw std::runtime_error("Unable to update the system. The element storage is not yet assembled.");
     }

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -368,6 +368,9 @@ void SystemSolver::solve()
         throw std::runtime_error("Unable to solve the system. The system is not yet assembled.");
     }
 
+    // Perfrom actions before KSP solution
+    preKSPSolveActions();
+
     // Solve the system
     m_KSPStatus.error = KSPSolve(m_KSP, m_rhs, m_solution);
 
@@ -379,6 +382,9 @@ void SystemSolver::solve()
         m_KSPStatus.its         = -1;
         m_KSPStatus.convergence = KSP_DIVERGED_BREAKDOWN;
     }
+
+    // Perfrom actions after KSP solution
+    postKSPSolveActions();
 }
 
 /*!
@@ -398,6 +404,20 @@ void SystemSolver::solve(const std::vector<double> &rhs, std::vector<double> *so
 
     // Export the solution
     vectorsExport(solution);
+}
+
+/*!
+ * Pre-solve actions.
+ */
+void SystemSolver::preKSPSolveActions()
+{
+}
+
+/*!
+ * Post-solve actions.
+ */
+void SystemSolver::postKSPSolveActions()
+{
 }
 
 /*!

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -89,6 +89,9 @@ public:
 
     void update(const std::vector<long> &rows, const SparseMatrix &elements);
 
+    void setUp();
+    bool isSetUp() const;
+
     long getRowCount() const;
     long getColCount() const;
 #if BITPIT_ENABLE_MPI==1
@@ -163,6 +166,7 @@ private:
     std::string m_prefix;
 
     bool m_assembled;
+    bool m_setUp;
 
 #if BITPIT_ENABLE_MPI==1
     MPI_Comm m_communicator;
@@ -172,8 +176,6 @@ private:
     long m_rowGlobalOffset;
     long m_colGlobalOffset;
 #endif
-
-    void KSPInit();
 
 #if BITPIT_ENABLE_MPI==1
     void setCommunicator(MPI_Comm communicator);

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -125,6 +125,14 @@ public:
     void restoreSolutionRawReadPtr(const double *raw_solution) const;
 
 protected:
+    Mat m_A;
+    Vec m_rhs;
+    Vec m_solution;
+
+    KSP m_KSP;
+    KSPOptions m_KSPOptions;
+    KSPStatus m_KSPStatus;
+
     void matrixInit(const SparseMatrix &matrix);
     void matrixFill(const SparseMatrix &matrix);
     void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
@@ -157,14 +165,6 @@ private:
     long m_rowGlobalOffset;
     long m_colGlobalOffset;
 #endif
-
-    Mat m_A;
-    Vec m_rhs;
-    Vec m_solution;
-
-    KSP m_KSP;
-    KSPOptions m_KSPOptions;
-    KSPStatus m_KSPStatus;
 
     void KSPInit();
 

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -68,14 +68,6 @@ struct KSPStatus {
 class SystemSolver {
 
 public:
-    enum PivotType {
-        PIVOT_NONE,  // Natural
-        PIVOT_ND,    // Nested Dissection
-        PIVOT_1WD,   // One-way Dissection
-        PIVOT_RCM,   // Reverse Cuthill-McKee
-        PIVOT_MD     // Quotient Minimum Degree
-    };
-
     enum DumpFormat {
         DUMP_BINARY,
         DUMP_ASCII
@@ -92,7 +84,7 @@ public:
     virtual ~SystemSolver();
 
     void clear();
-    void assembly(const SparseMatrix &matrix, PivotType pivotType = PIVOT_NONE);
+    void assembly(const SparseMatrix &matrix);
     bool isAssembled() const;
 
     void update(const std::vector<long> &rows, const SparseMatrix &elements);
@@ -112,8 +104,6 @@ public:
     void dump(const std::string &directory, const std::string &prefix = "",
               DumpFormat matrixFormat = DUMP_BINARY, DumpFormat rhsFormat = DUMP_BINARY,
               DumpFormat solutionFormat = DUMP_BINARY) const;
-
-    PivotType getPivotType();
 
     void setNullSpace();
     void unsetNullSpace();
@@ -138,14 +128,12 @@ protected:
     void matrixInit(const SparseMatrix &matrix);
     void matrixFill(const SparseMatrix &matrix);
     void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
-    void matrixReorder();
 
 #if BITPIT_ENABLE_MPI == 1
     void vectorsInit(const std::vector<long> &ghosts);
 #else
     void vectorsInit();
 #endif
-    void vectorsReorder(PetscBool inv);
     void vectorsFill(const std::vector<double> &rhs, std::vector<double> *solution);
     void vectorsExport(std::vector<double> *solution);
 
@@ -160,7 +148,6 @@ private:
     std::string m_prefix;
 
     bool m_assembled;
-    PivotType m_pivotType;
 
 #if BITPIT_ENABLE_MPI==1
     MPI_Comm m_communicator;
@@ -175,14 +162,9 @@ private:
     Vec m_rhs;
     Vec m_solution;
 
-    IS m_rpivot;
-    IS m_cpivot;
-
     KSP m_KSP;
     KSPOptions m_KSPOptions;
     KSPStatus m_KSPStatus;
-
-    void pivotInit(PivotType pivotType);
 
     void KSPInit();
 

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -148,6 +148,9 @@ protected:
     virtual void preKSPSetupActions();
     virtual void postKSPSetupActions();
 
+    virtual void preKSPSolveActions();
+    virtual void postKSPSolveActions();
+
 #if BITPIT_ENABLE_MPI==1
     const MPI_Comm & getCommunicator() const;
 #endif

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -145,6 +145,9 @@ protected:
     void vectorsFill(const std::vector<double> &rhs, std::vector<double> *solution);
     void vectorsExport(std::vector<double> *solution);
 
+    virtual void preKSPSetupActions();
+    virtual void postKSPSetupActions();
+
 #if BITPIT_ENABLE_MPI==1
     const MPI_Comm & getCommunicator() const;
 #endif

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -84,6 +84,9 @@ public:
     virtual ~SystemSolver();
 
     void clear();
+
+    void setPermutations(long nRows, const long *rowRanks, long nCols, const long *colRanks);
+
     void assembly(const SparseMatrix &matrix);
     bool isAssembled() const;
 
@@ -145,6 +148,7 @@ protected:
 #else
     void vectorsInit();
 #endif
+    void vectorsPermute(bool invert);
     void vectorsFill(const std::vector<double> &rhs, std::vector<double> *solution);
     void vectorsExport(std::vector<double> *solution);
 
@@ -177,10 +181,15 @@ private:
     long m_colGlobalOffset;
 #endif
 
+    IS m_rowPermutation;
+    IS m_colPermutation;
+
 #if BITPIT_ENABLE_MPI==1
     void setCommunicator(MPI_Comm communicator);
     void freeCommunicator();
 #endif
+
+    void resetPermutations();
 
 };
 

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -166,10 +166,10 @@ private:
     MPI_Comm m_communicator;
 
     bool m_partitioned;
-#endif
 
     long m_rowGlobalOffset;
     long m_colGlobalOffset;
+#endif
 
     Mat m_A;
     Vec m_rhs;

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -157,6 +157,7 @@ protected:
 
 private:
     static int m_nInstances;
+    static bool m_optionsEditable;
     static std::vector<std::string> m_options;
 
     std::string m_prefix;


### PR DESCRIPTION
Permutations are applied internally by the solver, this means that matrix permutations are applied when initializing the system, whereas permutations on the right hand side and on the solution are applied before solving the system and unapplied right after.

When the system is partitioned, only local permutations are supported.