### PR TITLE
bitpit: fix range loop iterations over list of exchange sources and targets

### DIFF
--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -263,7 +263,7 @@ void LevelSetCachedObject::propagateSign() {
         }
 
         // Set the sends
-        for (const auto entry : mesh.getGhostExchangeSources()) {
+        for (const auto &entry : mesh.getGhostExchangeSources()) {
             const int rank = entry.first;
             auto &list = entry.second;
 
@@ -273,7 +273,7 @@ void LevelSetCachedObject::propagateSign() {
         // Communicate the sign among the partitions
         while (nGlobalWaiting != 0) {
             // Start the receives
-            for (const auto entry : mesh.getGhostExchangeTargets()) {
+            for (const auto &entry : mesh.getGhostExchangeTargets()) {
                 const int rank = entry.first;
                 dataCommunicator.startRecv(rank);
             }

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -222,7 +222,7 @@ void PatchNumberingInfo::_extract()
 	// Communicate the consecutive id of the ghost cells
 	if (m_patch->getProcessorCount() > 1) {
 		// Set and start the sends
-		for (const auto entry : m_patch->getGhostExchangeSources()) {
+		for (const auto &entry : m_patch->getGhostExchangeSources()) {
 			const int rank = entry.first;
 			auto &list = entry.second;
 

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -1410,7 +1410,7 @@ std::unordered_map<long, int> PatchKernel::_partitioningAlter_evalGhostOwnership
     //
     // Data buffer is filled with the ranks that will own source cells after
     // the partitioning.
-    for (const auto entry : getGhostExchangeSources()) {
+    for (const auto &entry : getGhostExchangeSources()) {
         const int rank = entry.first;
         auto &sourceCells = entry.second;
 


### PR DESCRIPTION
Use reference when iterating over lists of exchange sources and targets.