### PR TITLE
patchkernel: allow to get local offset of consecutive numbering

### DIFF
--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -152,6 +152,7 @@ void PatchNumberingInfo::_init()
 */
 void PatchNumberingInfo::_reset()
 {
+	m_cellConsecutiveOffset = -1;
 	m_cellLocalToConsecutiveMap.clear();
 #if BITPIT_ENABLE_MPI==1
 	m_nGlobalInternals.clear();
@@ -207,10 +208,12 @@ void PatchNumberingInfo::_extract()
 		}
 
 #if BITPIT_ENABLE_MPI==1
-		consecutiveId = getCellGlobalCountOffset();
+		m_cellConsecutiveOffset = getCellGlobalCountOffset();
 #else
-		consecutiveId = 0;
+		m_cellConsecutiveOffset = 0;
 #endif
+
+		consecutiveId = m_cellConsecutiveOffset;
 		for (auto itr = nativeIds.begin(); itr != nativeIds.end(); ++itr) {
 			m_cellLocalToConsecutiveMap.insert({itr->second, consecutiveId++});
 		}
@@ -253,6 +256,16 @@ void PatchNumberingInfo::_extract()
 		dataCommunicator->waitAllSends();
 	}
 #endif
+}
+
+/*!
+	Return the consecutive offset for the local ells
+
+	\return The consecutive offset for the local cells.
+*/
+long PatchNumberingInfo::getCellConsecutiveOffset() const
+{
+	return m_cellConsecutiveOffset;
 }
 
 /*!

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -57,6 +57,16 @@ PatchInfo::~PatchInfo()
 }
 
 /*!
+	Gets the patch associated with the info.
+
+	\result Returns the patch associated with the info.
+*/
+PatchKernel const & PatchInfo::getPatch() const
+{
+	return *m_patch;
+}
+
+/*!
 	Sets the patch associated to the info.
 
 	\param patch is patch from which the informations will be extracted

--- a/src/patchkernel/patch_info.hpp
+++ b/src/patchkernel/patch_info.hpp
@@ -37,6 +37,7 @@ class PatchInfo {
 public:
 	virtual ~PatchInfo();
 
+	PatchKernel const & getPatch() const;
 	void setPatch(PatchKernel const *patch);
 
 	void reset();

--- a/src/patchkernel/patch_info.hpp
+++ b/src/patchkernel/patch_info.hpp
@@ -61,6 +61,7 @@ class PatchNumberingInfo : public PatchInfo {
 public:
 	PatchNumberingInfo(PatchKernel const *patch = nullptr);
 
+	long getCellConsecutiveOffset() const;
 	long getCellConsecutiveId(long id) const;
 	const std::unordered_map<long, long> & getCellConsecutiveMap() const;
 
@@ -83,6 +84,7 @@ protected:
 	void _extract() override;
 
 private:
+	long m_cellConsecutiveOffset;
 	std::unordered_map<long, long> m_cellLocalToConsecutiveMap;
 #if BITPIT_ENABLE_MPI==1
 	std::vector<long> m_nGlobalInternals;


### PR DESCRIPTION
Add a function to get the local offset of consecutive numbering.