### PR TITLE
PABLO: fix iterators in update ghosts method

### DIFF
--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -5453,7 +5453,9 @@ namespace bitpit {
                 }
             }
         }
+        m_pborders.resize(countpbd);
         m_pborders.shrink_to_fit();
+        m_internals.resize(countint);
         m_internals.shrink_to_fit();
 
         // Build ghosts


### PR DESCRIPTION
Fixed updating of iterators for internal and border of process octants during ghosts recovering