### PR TITLE
patchkernel: fix data types of VTK geometry fields

### DIFF
--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -400,12 +400,14 @@ class VTKUnstructuredGrid : public VTK {
             private:
                 VTKElementType          m_type ;                    /**< the type of cells */
                 long                    m_nCells ;                  /**< numer of cells */
+                const VTKField         *m_connectivity ;            /**< connectivity field */
 
                 void                    flushData( std::fstream &, const std::string &, VTKFormat) override ;
 
             public:
                 void                    setElementType( VTKElementType) ;
                 void                    setCellCount( long) ;
+                void                    setConnectivityField( const VTKField *connectivity) ;
         };
 
         uint64_t                m_nConnectivityEntries ;            /**< size of the connectivity information */

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -55,6 +55,16 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::setCellCount( long n){
 }
 
 /*!
+ * Sets the connectivity field associated with the offsets
+ * @param[in] connectivity connectivity field associated with the offsets
+ */
+void VTKUnstructuredGrid::HomogeneousInfoStreamer::setConnectivityField( const VTKField *connectivity){
+
+    m_connectivity = connectivity ;
+
+}
+
+/*!
  * Writes data to stream 
  * @param[in] str file stream for writing
  * @param[in] name name of field
@@ -63,6 +73,8 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::setCellCount( long n){
 void VTKUnstructuredGrid::HomogeneousInfoStreamer::flushData( std::fstream &str, const std::string &name, VTKFormat format){
 
     assert( m_type != VTKElementType::UNDEFINED ) ;
+
+    VTKDataType connectivityDataType = m_connectivity->getDataType();
 
     if( format == VTKFormat::APPENDED){
 
@@ -74,10 +86,30 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::flushData( std::fstream &str,
         
         } else if(name == "offsets" ){
             uint8_t     n = vtk::getElementNodeCount(m_type) ;
-            uint64_t    offset(0) ;
-            for( unsigned int i=0; i<m_nCells; ++i){
-                offset += n ;
-                genericIO::flushBINARY(str, offset );
+            if (connectivityDataType == VTKDataType::Int64 || connectivityDataType == VTKDataType::UInt64) {
+                uint64_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushBINARY(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int32 || connectivityDataType == VTKDataType::UInt32) {
+                uint32_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushBINARY(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int16 || connectivityDataType == VTKDataType::UInt16) {
+                uint16_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushBINARY(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int8 || connectivityDataType == VTKDataType::UInt8) {
+                uint8_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushBINARY(str, offset );
+                }
             }
         
         }
@@ -90,10 +122,30 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::flushData( std::fstream &str,
         
         } else if(name == "offsets" ){
             uint8_t     n = vtk::getElementNodeCount(m_type) ;
-            uint64_t    offset(0) ;
-            for( unsigned int i=0; i<m_nCells; ++i){
-                offset += n ;
-                genericIO::flushASCII(str, offset );
+            if (connectivityDataType == VTKDataType::Int64 || connectivityDataType == VTKDataType::UInt64) {
+                uint64_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushASCII(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int32 || connectivityDataType == VTKDataType::UInt32) {
+                uint32_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushASCII(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int16 || connectivityDataType == VTKDataType::UInt16) {
+                uint16_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushASCII(str, offset );
+                }
+            } else if (connectivityDataType == VTKDataType::Int8 || connectivityDataType == VTKDataType::UInt8) {
+                uint8_t    offset(0) ;
+                for( unsigned int i=0; i<m_nCells; ++i){
+                    offset += n ;
+                    genericIO::flushASCII(str, offset );
+                }
             }
         
         }
@@ -181,6 +233,7 @@ void VTKUnstructuredGrid::setElementType( VTKElementType elementType ){
 
     // Set homogeneous info streamer properties
     m_homogeneousInfoStreamer.setElementType( m_elementType );
+    m_homogeneousInfoStreamer.setConnectivityField( &(m_geometry[getFieldGeomId(VTKUnstructuredField::CONNECTIVITY)]) );
 
     // Types
     int types_gid = getFieldGeomId(VTKUnstructuredField::TYPES);
@@ -190,7 +243,6 @@ void VTKUnstructuredGrid::setElementType( VTKElementType elementType ){
     // Offsets
     if ( m_elementType != VTKElementType::POLYGON && m_elementType != VTKElementType::POLYHEDRON) {
         int offsets_gid = getFieldGeomId(VTKUnstructuredField::OFFSETS);
-        m_geometry[offsets_gid].setDataType( VTKDataType::UInt64) ;
         m_geometry[offsets_gid].setStreamer(m_homogeneousInfoStreamer) ;
     }
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -295,11 +295,11 @@ void PatchKernel::initialize()
 
 	// Set VTK Geom Data
 	m_vtk.setGeomData<double>(VTKUnstructuredField::POINTS, this);
-	m_vtk.setGeomData<int>(VTKUnstructuredField::OFFSETS, this);
+	m_vtk.setGeomData<long>(VTKUnstructuredField::OFFSETS, this);
 	m_vtk.setGeomData<int>(VTKUnstructuredField::TYPES, this);
 	m_vtk.setGeomData<long>(VTKUnstructuredField::CONNECTIVITY, this);
 	m_vtk.setGeomData<long>(VTKUnstructuredField::FACE_STREAMS, this);
-	m_vtk.setGeomData<int>(VTKUnstructuredField::FACE_OFFSETS, this);
+	m_vtk.setGeomData<long>(VTKUnstructuredField::FACE_OFFSETS, this);
 
 	// Add VTK basic patch data
 	m_vtk.addData<long>("cellIndex", VTKFieldType::SCALAR, VTKLocation::CELL, this);
@@ -5523,7 +5523,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			}
 		}
 	} else if (name == "offsets") {
-		int offset = 0;
+		long offset = 0;
 		for (const Cell &cell : getVTKCellWriteRange()) {
 			offset += cell.getVertexCount();
 			genericIO::flushBINARY(stream, offset);
@@ -5613,7 +5613,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			}
 		}
 	} else if (name == "faceoffsets") {
-		int offset = 0;
+		long offset = 0;
 		for (const Cell &cell : getVTKCellWriteRange()) {
 			if (cell.getDimension() <= 2 || cell.hasInfo()) {
 				offset += 1;

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5636,7 +5636,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			std::size_t vertexRawId = itr.getRawIndex();
 			long vertexVTKId = m_vtkVertexMap.rawAt(vertexRawId);
 			if (vertexVTKId != Vertex::NULL_ID) {
-				std::size_t vertexId = itr.getId();
+				long vertexId = itr.getId();
 				genericIO::flushBINARY(stream, vertexId);
 			}
 		}


### PR DESCRIPTION
Data type of offset field should match the data type of the connectivity. 

This is the error raised by Paraview 5.8 while opening a VolOctree patch:
```
vtkXMLUnstructuredGridReader (0x5594e13b0b20): Cannot read cell data from Cells. Offsets and connectivity arrays must be the same type.
```

@haysam The change to the IO module is not strictly needed to fix the issue because PatchKernel is not using VTK homogeneous grids, but I think we shouldn't set the type of the offset field to UInt64 unconditionally (it may not match the data type of the connectivity field). 