### PR TITLE
bitpit: fixes for some misusage related to references

### DIFF
--- a/examples/POD_application_example_00001.cpp
+++ b/examples/POD_application_example_00001.cpp
@@ -156,7 +156,7 @@ InfoBitpodPP readArguments(int argc, char*argv[] ){
      * clean the entry from key, give her the key map marker and store it in the final map.
      */
 
-    for(auto val: input){
+    for(const auto &val: input){
         std::size_t pos = std::string::npos;
         int counter=0;
         while (pos == std::string::npos && counter <3){

--- a/examples/voloctree_mapper_example_00003.cpp
+++ b/examples/voloctree_mapper_example_00003.cpp
@@ -284,14 +284,14 @@ void run()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(sizeof(double));
-            for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
                 dataCommunicator.setSend(rank,buffSize);
                 //fill buffer with octants
                 SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     sendBuffer << data[ID];
                 }
             }
@@ -300,11 +300,11 @@ void run()
             dataCommunicator.startAllRecvs();
             dataCommunicator.startAllSends();
 
-            for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+            for (const auto &val : rankIDrec){
                 int rank = val.first;
                 dataCommunicator.waitRecv(rank);
                 RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     recvBuffer >> datarec[rank][ID];
                 }
             }
@@ -408,7 +408,7 @@ void run()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(sizeof(double) + sizeof(long));
-            for (std::pair<const int, std::set<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;

--- a/examples/voloctree_mapper_example_00004.cpp
+++ b/examples/voloctree_mapper_example_00004.cpp
@@ -282,14 +282,14 @@ void runReferenceAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double));
-            for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
                 dataCommunicator.setSend(rank,buffSize);
                 //fill buffer with octants
                 SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     sendBuffer << data[ID];
                     sendBuffer << patch_2D_original->evalCellVolume(ID);
                 }
@@ -299,11 +299,11 @@ void runReferenceAdaptation()
             dataCommunicator.startAllRecvs();
             dataCommunicator.startAllSends();
 
-            for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+            for (const auto &val : rankIDrec){
                 int rank = val.first;
                 dataCommunicator.waitRecv(rank);
                 RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     recvBuffer >> datarec[rank][ID];
                     recvBuffer >> volrec[rank][ID];
                 }
@@ -461,14 +461,14 @@ void runReferenceAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double));
-            for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
                 dataCommunicator.setSend(rank,buffSize);
                 //fill buffer with octants
                 SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     sendBuffer << data[ID];
                     sendBuffer << patch_2D_original->evalCellVolume(ID);
                 }
@@ -478,11 +478,11 @@ void runReferenceAdaptation()
             dataCommunicator.startAllRecvs();
             dataCommunicator.startAllSends();
 
-            for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+            for (const auto &val : rankIDrec){
                 int rank = val.first;
                 dataCommunicator.waitRecv(rank);
                 RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     recvBuffer >> datarec[rank][ID];
                     recvBuffer >> volrec[rank][ID];
                 }
@@ -590,7 +590,7 @@ void runReferenceAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double) + sizeof(long));
-            for (std::pair<const int, std::set<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
@@ -946,7 +946,7 @@ void runMappedAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double) + sizeof(long));
-            for (std::pair<const int, std::set<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
@@ -1150,7 +1150,7 @@ void runMappedAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double) + sizeof(long));
-            for (std::pair<const int, std::set<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
@@ -1280,14 +1280,14 @@ void runMappedAdaptation()
             DataCommunicator dataCommunicator(comm);
             MPI_Barrier(comm);
             std::size_t bytes = uint8_t(2*sizeof(double));
-            for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+            for (const auto &val : rankIDsend){
                 int rank = val.first;
                 //set size
                 std::size_t buffSize = val.second.size() * bytes;
                 dataCommunicator.setSend(rank,buffSize);
                 //fill buffer with octants
                 SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     sendBuffer << data2[ID];
                     sendBuffer << patch_2D->evalCellVolume(ID);
                 }
@@ -1297,11 +1297,11 @@ void runMappedAdaptation()
             dataCommunicator.startAllRecvs();
             dataCommunicator.startAllSends();
 
-            for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+            for (const auto &val : rankIDrec){
                 int rank = val.first;
                 dataCommunicator.waitRecv(rank);
                 RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-                for (long & ID : val.second){
+                for (long ID : val.second){
                     recvBuffer >> datarec[rank][ID];
                     recvBuffer >> volrec[rank][ID];
                 }

--- a/src/CG/CG.hpp
+++ b/src/CG/CG.hpp
@@ -116,7 +116,7 @@ array3D projectPointPolygon( array3D const &, std::size_t, array3D const * );
 array3D projectPointPolygon( array3D const &, std::vector<array3D> const &, std::vector<double> & );
 array3D projectPointPolygon( array3D const &, std::size_t, array3D const *, std::vector<double> & );
 array3D projectPointPolygon( array3D const &, std::size_t, array3D const *, double * );
-array3D projectPointCone( array3D const &, array3D const &, array3D const &, double const &);
+array3D projectPointCone( array3D const &, array3D const &, array3D const &, double );
 std::vector<array3D> projectCloudTriangle( std::vector<array3D> const &, array3D const &, array3D const &, array3D const &, std::vector<array3D> &);
 
 array3D restrictPointTriangle( array3D const &, array3D const &, array3D const &, array3D &);
@@ -139,7 +139,7 @@ double distancePointPolygon( array3D const &, std::vector<array3D> const &, std:
 double distancePointPolygon( array3D const &, std::size_t, array3D const *, std::vector<double> & );
 double distancePointPolygon( array3D const &, std::size_t, array3D const *, double * );
 
-double distancePointCone( array3D const &, array3D const &, array3D const &, double const &);
+double distancePointCone( array3D const &, array3D const &, array3D const &, double );
 
 std::vector<double> distanceCloudTriangle( std::vector<array3D> const &, array3D const &, array3D const &, array3D const &);
 std::vector<double> distanceCloudTriangle( std::vector<array3D> const &, array3D const &, array3D const &, array3D const &, std::vector<array3D> & );
@@ -209,23 +209,23 @@ void unionAABB( std::vector<array3D>  const &, std::vector<array3D> const &, arr
 array3D rotateVector( array3D const &, array3D const &, double);
 double areaTriangle( array3D const &, array3D const &, array3D const &);
 
-void vertexOfSegment( int const &, array3D const &, array3D const &, array3D &);
+void vertexOfSegment( int, array3D const &, array3D const &, array3D &);
 
-void vertexOfTriangle( int const &, array3D const &, array3D const &, array3D const &, array3D &);
-void edgeOfTriangle( int const &, array3D const &, array3D const &, array3D const &, array3D &, array3D &);
+void vertexOfTriangle( int, array3D const &, array3D const &, array3D const &, array3D &);
+void edgeOfTriangle( int, array3D const &, array3D const &, array3D const &, array3D &, array3D &);
 
-void vertexOfBox( int const &, array3D const &, array3D const &, array3D &);
-void edgeOfBox( int const &, array3D const &, array3D const &, array3D &, array3D &);
-void faceOfBox( int const &, array3D const &, array3D const &, array3D &, array3D &, array3D &, array3D & );
+void vertexOfBox( int, array3D const &, array3D const &, array3D &);
+void edgeOfBox( int, array3D const &, array3D const &, array3D &, array3D &);
+void faceOfBox( int, array3D const &, array3D const &, array3D &, array3D &, array3D &, array3D & );
 
 int polygonEdgesCount(std::vector<array3D> const &);
 int polygonEdgesCount(std::size_t, array3D const *);
 int polygonSubtriangleCount(std::vector<array3D> const &);
 int polygonSubtriangleCount(std::size_t, array3D const *);
-void edgeOfPolygon( int const &, std::vector<array3D> const &, array3D &, array3D &);
-void edgeOfPolygon( int const &, std::size_t, array3D const *, array3D &, array3D &);
-void subtriangleOfPolygon( int const &, std::vector<array3D> const &, array3D &, array3D &, array3D &);
-void subtriangleOfPolygon( int const &, std::size_t, array3D const *, array3D &, array3D &, array3D &);
+void edgeOfPolygon( int, std::vector<array3D> const &, array3D &, array3D &);
+void edgeOfPolygon( int, std::size_t, array3D const *, array3D &, array3D &);
+void subtriangleOfPolygon( int, std::vector<array3D> const &, array3D &, array3D &, array3D &);
+void subtriangleOfPolygon( int, std::size_t, array3D const *, array3D &, array3D &, array3D &);
 
 }
 

--- a/src/CG/CG_elem.cpp
+++ b/src/CG/CG_elem.cpp
@@ -798,7 +798,7 @@ void computeGeneralizedBarycentric( array3D const &p, std::size_t nVertices, arr
 {
     lambda.resize(nVertices);
 
-    return computeGeneralizedBarycentric( p, nVertices, vertex, lambda.data());
+    computeGeneralizedBarycentric( p, nVertices, vertex, lambda.data());
 }
 
 /*!

--- a/src/CG/CG_elem.cpp
+++ b/src/CG/CG_elem.cpp
@@ -1281,7 +1281,7 @@ array3D projectPointPolygon( array3D const &P, std::size_t nV, array3D const *V,
  * \param[in] alpha cone half angle
  * \return projection point
  */
-array3D projectPointCone( array3D const &point, array3D const &apex, array3D const &axis, double const &alpha)
+array3D projectPointCone( array3D const &point, array3D const &apex, array3D const &axis, double alpha)
 {
 
 
@@ -1406,7 +1406,7 @@ double distancePointTriangle( array3D const &P, array3D const &Q0, array3D const
  * \param[in] alpha cone half angle
  * \return distance
  */
-double distancePointCone( array3D const &point, array3D const &apex, array3D const &axis, double const &alpha)
+double distancePointCone( array3D const &point, array3D const &apex, array3D const &axis, double alpha)
 {
     array3D xP = projectPointCone( point, apex, axis, alpha);
     return norm2(point-xP);
@@ -2651,7 +2651,7 @@ void subtractionAABB(array3D const &A0, array3D const &A1, array3D const &B0, ar
  * \param[in] V1 second vertex of segment
  * \param[out] P vertex
  */
-void vertexOfSegment(int const &i, array3D const &V0, array3D const &V1, array3D &P)
+void vertexOfSegment(int i, array3D const &V0, array3D const &V1, array3D &P)
 {
     switch(i){
 
@@ -2679,7 +2679,7 @@ void vertexOfSegment(int const &i, array3D const &V0, array3D const &V1, array3D
  * \param[in] V2 third vertex of triangle
  * \param[out] P vertex
  */
-void vertexOfTriangle(int const &i, array3D const &V0, array3D const &V1, array3D const &V2, array3D &P)
+void vertexOfTriangle(int i, array3D const &V0, array3D const &V1, array3D const &V2, array3D &P)
 {
     switch(i){
 
@@ -2712,7 +2712,7 @@ void vertexOfTriangle(int const &i, array3D const &V0, array3D const &V1, array3
  * \param[out] P0 first vertex of edge
  * \param[out] P1 first vertex of edge
  */
-void edgeOfTriangle(int const &i, array3D const &V0, array3D const &V1, array3D const &V2, array3D &P0, array3D &P1)
+void edgeOfTriangle(int i, array3D const &V0, array3D const &V1, array3D const &V2, array3D &P0, array3D &P1)
 {
     switch(i){
 
@@ -2749,7 +2749,7 @@ void edgeOfTriangle(int const &i, array3D const &V0, array3D const &V1, array3D 
  * \param[out] P2 first vertex of face
  * \param[out] P3 first vertex of face
  */
-void faceOfBox(int const &i, array3D const &A0, array3D const &A1, array3D &P0, array3D &P1, array3D &P2, array3D &P3)
+void faceOfBox(int i, array3D const &A0, array3D const &A1, array3D &P0, array3D &P1, array3D &P2, array3D &P3)
 {
 
     assert(i<6);
@@ -2775,7 +2775,7 @@ void faceOfBox(int const &i, array3D const &A0, array3D const &A1, array3D &P0, 
  * \param[out] P0 first vertex of edge
  * \param[out] P1 first vertex of edge
  */
-void edgeOfBox(int const &i, array3D const &A0, array3D const &A1, array3D &P0, array3D &P1)
+void edgeOfBox(int i, array3D const &A0, array3D const &A1, array3D &P0, array3D &P1)
 {
     assert(i<12);
 
@@ -2795,7 +2795,7 @@ void edgeOfBox(int const &i, array3D const &A0, array3D const &A1, array3D &P0, 
  * \param[in] A1 max point of bounding box
  * \param[out] P vertex coordinates
  */
-void vertexOfBox(int  const &i, array3D const &A0, array3D const &A1, array3D &P)
+void vertexOfBox(int i, array3D const &A0, array3D const &A1, array3D &P)
 {
 
     switch(i){
@@ -2939,7 +2939,7 @@ int polygonSubtriangleCount( std::size_t nV, array3D const *V)
  * \param[in] V0 first vertice coordinates of edge
  * \param[in] V1 second vertice coordinates of edge
  */
-void edgeOfPolygon( int const &edge, std::vector<array3D> const &V, array3D &V0, array3D &V1)
+void edgeOfPolygon( int edge, std::vector<array3D> const &V, array3D &V0, array3D &V1)
 {
     edgeOfPolygon( edge, V.size(), V.data(), V0, V1);
 }
@@ -2952,7 +2952,7 @@ void edgeOfPolygon( int const &edge, std::vector<array3D> const &V, array3D &V0,
  * \param[in] V0 first vertice coordinates of edge
  * \param[in] V1 second vertice coordinates of edge
  */
-void edgeOfPolygon( int const &edge, std::size_t nV, array3D const *V, array3D &V0, array3D &V1)
+void edgeOfPolygon( int edge, std::size_t nV, array3D const *V, array3D &V0, array3D &V1)
 {
     assert(edge<polygonEdgesCount(nV, V));
 
@@ -2969,7 +2969,7 @@ void edgeOfPolygon( int const &edge, std::size_t nV, array3D const *V, array3D &
  * \param[in] V1 second vertice coordinates of triangle
  * \param[in] V2 third vertice coordinates of triangle
  */
-void subtriangleOfPolygon( int const &triangle, std::vector<array3D> const &V, array3D &V0, array3D &V1, array3D &V2)
+void subtriangleOfPolygon( int triangle, std::vector<array3D> const &V, array3D &V0, array3D &V1, array3D &V2)
 {
     subtriangleOfPolygon( triangle, V.size(), V.data(), V0, V1, V2);
 }
@@ -2983,7 +2983,7 @@ void subtriangleOfPolygon( int const &triangle, std::vector<array3D> const &V, a
  * \param[in] V1 second vertice coordinates of triangle
  * \param[in] V2 third vertice coordinates of triangle
  */
-void subtriangleOfPolygon( int const &triangle, std::size_t nV, array3D const *V, array3D &V0, array3D &V1, array3D &V2)
+void subtriangleOfPolygon( int triangle, std::size_t nV, array3D const *V, array3D &V0, array3D &V1, array3D &V2)
 {
     BITPIT_UNUSED(nV);
     assert(triangle<polygonSubtriangleCount(nV, V));

--- a/src/IO/DGF.cpp
+++ b/src/IO/DGF.cpp
@@ -107,7 +107,7 @@ return; }
     \param[in] filename dgf file name
 */
 DGFObj::DGFObj(
-    std::string                          filename
+    const std::string                   &filename
 ) {
 
 // ========================================================================== //
@@ -125,7 +125,8 @@ DGFObj::DGFObj(
 // ========================================================================== //
 
 // General info
-dgf_name = utils::string::trim(filename);
+dgf_name = filename;
+dgf_name = utils::string::trim(dgf_name);
 
 // Error flags
 err = 0;
@@ -148,7 +149,7 @@ return; }
     \param[in] mode opening mode ("in": input, "out": output, "app": append mode)
 */
 void DGFObj::open(
-    std::string                          mode
+    const std::string                    &mode
 ) {
 
 // ========================================================================== //
@@ -211,7 +212,7 @@ return; };
     "app": append mode)
 */
 void DGFObj::close(
-    std::string                          mode
+    const std::string                    &mode
 ) {
 
 // ========================================================================== //
@@ -624,7 +625,7 @@ void DGFObj::load(
     std::vector<std::array<double,3> >  &V,
     std::vector<std::vector<int> >      &S,
     std::vector<int>                    &PID,
-    std::string                         pidName
+    const std::string                   &pidName
 ) {
 
 // ========================================================================== //

--- a/src/IO/DGF.hpp
+++ b/src/IO/DGF.hpp
@@ -97,7 +97,7 @@ class DGFObj {
         void                                                                  // (input) none
     );
     DGFObj(                                                                  // Custom constructor #1 for DGF object
-        std::string                                                           // (input) dgf file name
+        const std::string                       &                            // (input) dgf file name
     );
 
     // Destructor =========================================================== //
@@ -109,10 +109,10 @@ class DGFObj {
     // Public methods ------------------------------------------------------- //
     public:
     void open(                                                                // Open input/output stream to dgf file
-        std::string                                                           // (input) stream mode
+        const std::string                       &                             // (input) stream mode
     );
     void close(                                                               // Close input/output stream to dgf file
-        std::string                              a = "inout"                  // (input) stream mode
+        const std::string                       &a = "inout"                  // (input) stream mode
     );
     void clear(                                                               // Reser members to default value
         void                                                                  // (input) none
@@ -144,7 +144,7 @@ class DGFObj {
         std::vector<std::array<double,3> >      &,                            // (input/output) vertex coordinate list
         std::vector<std::vector<int> >          &,                            // (input/output) simplex-vertex connectivity
         std::vector<int>                        &,                            // (input/output) pid list
-        std::string pidName = "PID"                                           // name of simplexdata to be used as PID
+        const std::string                       &pidName = "PID"              // name of simplexdata to be used as PID
     );
     void save(                                                                // Save mesh data into a .dgf file
         int                                     &,                            // (input) number of mesh vertices
@@ -161,28 +161,28 @@ class DGFObj {
 
     template< typename T, typename ... T2 >
     void loadVData(                                                          // Load vertex data sets from dgf file
-        std::string                              data_name,                   // (input) dataset name
+        const std::string                       &data_name,                  // (input) dataset name
         int                                     &n,                           // (input/output) number of data in the dataset
         std::vector< T >                        &data,                        // (input/output) loaded dataset
         T2                                      &... others                   // (input/optional) others datasets to be loaded
     );
     template< typename T, typename ... T2 >
     void loadSData(                                                          // Load simplex data sets from dgf file
-        std::string                              data_name,                   // (input) dataset name
+        const std::string                       &data_name,                   // (input) dataset name
         int                                     &n,                           // (input/output) number of data in the dataset
         std::vector< T >                        &data,                        // (input/output) loaded dataset
         T2                                      &... others                   // (input/optional) others datasets to be loaded
     );
     template < typename T, typename ... T2 >
     void appendVData(                                                        // Append vertex data set to dgf file
-        std::string                              data_name,                   // (input) dataset name
+        const std::string                       &data_name,                   // (input) dataset name
         int                                     &n,                           // (input) number of data in the dataset
         std::vector< T >                        &data,                        // (input) dataset to be exported
         T2                                      &... others                   // (input/optional) others datasets to be exported
     );
     template < typename T, typename ... T2 >
     void appendSData(                                                        // Append simplex data set to dgf file
-        std::string                              data_name,                   // (input) dataset name
+        const std::string                       &data_name,                   // (input) dataset name
         int                                     &n,                           // (input) number of data in the dataset
         std::vector< T >                        &data,                        // (input) dataset to be exported
         T2                                      &... others                   // (input/optional) others datasets to be exported
@@ -262,14 +262,14 @@ unsigned int readVertexData(                                             // Load
     std::ifstream                               &file_handle,                 // (input) input stream to dgf file
     int                                         &n,                           // (input/output) number of loaded data
     std::vector< T >                            &data,                        // (input/output) loaded data
-    std::string                                 data_name = ""                // (input/optional) dataset name
+    const std::string                           &data_name = ""               // (input/optional) dataset name
 );
 template< typename T >
 unsigned int readSimplexData(                                            // Load dgf simplex data
     std::ifstream                               &file_handle,                 // (input) input stream to dgf file
     int                                         &n,                           // (input/output) number of loaded data
     std::vector< T >                            &data,                        // (input/output) loaded data
-    std::string                                 data_name = ""                // (input/optional) dataset name
+    const std::string                           &data_name = ""               // (input/optional) dataset name
 );
 
 // Output routines ---------------------------------------------------------- //
@@ -299,14 +299,14 @@ unsigned int writeVertexData(                                            // Expo
     std::ofstream                               &file_handle,                 // (input) output stream to dgf file
     int                                         &N,                           // (input) number of data in the dataset
     std::vector< T >                            &Data,                        // (input) vertex data set
-    std::string                                 Data_name = ""                // (input/optional) data set name
+    const std::string                           &Data_name = ""               // (input/optional) data set name
 );
 template < typename T >
 unsigned int writeSimplexData(                                           // Export simplex data to dgf file
     std::ofstream                               &file_handle,                 // (input) output stream to dgf file
     int                                         &N,                           // (input) number of data in the dataset
     std::vector< T >                            &Data,                        // (input) simplex data set
-    std::string                                 Data_name = ""                // (input/optional) data set name
+    const std::string                           &Data_name = ""               // (input/optional) data set name
 );
 
 }

--- a/src/IO/DGF.tpp
+++ b/src/IO/DGF.tpp
@@ -56,7 +56,7 @@
 */ 
 template< typename T, typename ... T2 >
 void DGFObj::loadVData(
-    std::string                  data_name,
+    const std::string           &data_name,
     int                         &n,
     std::vector< T >            &data,
     T2                          &... others
@@ -103,7 +103,7 @@ return; };
 */
 template< typename T, typename ... T2 >
 void DGFObj::loadSData(
-    std::string                  data_name,
+    const std::string           &data_name,
     int                         &n,
     std::vector< T >            &data,
     T2                          &... others
@@ -147,7 +147,7 @@ return; };
 */ 
 template< typename T, typename ... T2 >
 void DGFObj::appendVData(
-    std::string                  data_name,
+    const std::string           &data_name,
     int                         &n,
     std::vector< T >            &data,
     T2                          &... others
@@ -191,7 +191,7 @@ return; }
 */ 
 template< typename T, typename ... T2 >
 void DGFObj::appendSData(
-    std::string                  data_name,
+    const std::string           &data_name,
     int                         &n,
     std::vector< T >            &data,
     T2                          &... others
@@ -342,7 +342,7 @@ unsigned int readVertexData(
     std::ifstream               &file_handle,
     int                         &n,
     std::vector< T >            &data,
-    std::string                  data_name
+    const std::string           &data_name
 ) {
 
 // ========================================================================== //
@@ -437,7 +437,7 @@ unsigned int readSimplexData(
     std::ifstream               &file_handle,
     int                         &n,
     std::vector< T >            &data,
-    std::string                  data_name
+    const std::string           &data_name
 ) {
 
 // ========================================================================== //
@@ -575,7 +575,7 @@ unsigned int writeVertexData(
     std::ofstream               &file_handle,
     int                         &N,
     std::vector< T >            &Data,
-    std::string                 Data_name
+    const std::string           &Data_name
 ) {
 
 // ========================================================================== //
@@ -585,6 +585,7 @@ unsigned int writeVertexData(
 // Local variables
 unsigned int        err = 0;
 std::stringstream        sheader;
+std::string              dataset;
 std::string              header;
 
 // Counters
@@ -600,8 +601,9 @@ if (!file_handle.good()) { return(1); }
 // ========================================================================== //
 
 // Data header -------------------------------------------------------------- //
-Data_name = utils::string::trim(Data_name);
-sheader << "VERTEXDATA " << Data_name << std::endl;
+dataset = Data_name;
+dataset = utils::string::trim(dataset);
+sheader << "VERTEXDATA " << dataset << std::endl;
 header = sheader.str();
 header = utils::string::trim(header);
 file_handle << header << std::endl;
@@ -629,7 +631,7 @@ unsigned int writeSimplexData(
     std::ofstream               &file_handle,
     int                         &N,
     std::vector< T >            &Data,
-    std::string                  Data_name
+    const std::string           &Data_name
 ) {
 
 // ========================================================================== //
@@ -639,6 +641,7 @@ unsigned int writeSimplexData(
 // Local variables
 unsigned int        err = 0;
 std::stringstream        sheader;
+std::string              dataset;
 std::string              header;
 
 // Counters
@@ -654,8 +657,9 @@ if (!file_handle.good()) { return(1); }
 // ========================================================================== //
 
 // Data header -------------------------------------------------------------- //
-Data_name = utils::string::trim(Data_name);
-sheader << "SIMPLEXDATA " << Data_name << std::endl;
+dataset = Data_name;
+dataset = utils::string::trim(dataset);
+sheader << "SIMPLEXDATA " << dataset << std::endl;
 header = sheader.str();
 header = utils::string::trim(header);
 file_handle << header << std::endl;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -495,8 +495,8 @@ class VTKRectilinearGrid : public VTK{
         template<class T>
         void                    setGeomData( VTKRectilinearField, VTKBaseStreamer* = nullptr ) ;
 
-        void                    setGlobalIndex( std::vector<extension3D_t> ) ;
-        void                    setGlobalIndex( std::vector<extension2D_t> ) ;
+        void                    setGlobalIndex( const std::vector<extension3D_t> & ) ;
+        void                    setGlobalIndex( const std::vector<extension2D_t> & ) ;
 
         uint64_t                calcFieldSize( const VTKField &) override ;
         uint64_t                calcFieldEntries( const VTKField &) override ;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -155,7 +155,7 @@ class VTKTypes{
         static std::unordered_map<std::type_index, VTKDataType> m_types;  /**< map conatining registered data types */
 
     public:
-        static uint8_t          sizeOfType( const VTKDataType & type );
+        static uint8_t          sizeOfType( VTKDataType type );
 
         template<typename T>
         static VTKDataType      registerType();
@@ -508,16 +508,16 @@ class VTKRectilinearGrid : public VTK{
  * @brief Utility fuctions for VTK
  */
 namespace vtk{
-    uint8_t                     getElementNodeCount( const VTKElementType & ) ;
+    uint8_t                     getElementNodeCount( VTKElementType ) ;
 
     std::string                 convertDataArrayToString( const VTKField & ) ;
     std::string                 convertPDataArrayToString( const VTKField & ) ;
 
     bool                        convertStringToDataArray( const std::string &, VTKField &) ;
 
-    std::string                 convertEnumToString( const VTKLocation & ) ;
-    std::string                 convertEnumToString( const VTKFormat & ) ;
-    std::string                 convertEnumToString( const VTKDataType & ) ;
+    std::string                 convertEnumToString( VTKLocation ) ;
+    std::string                 convertEnumToString( VTKFormat ) ;
+    std::string                 convertEnumToString( VTKDataType ) ;
 
     bool                        convertStringToEnum( const std::string &, VTKLocation & ) ;
     bool                        convertStringToEnum( const std::string &, VTKFormat & ) ;

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -460,7 +460,7 @@ void VTKRectilinearGrid::setGlobalDimensions( int I, int J ){
  *  Needs to be called only by rank 0.
  *  @param[in] loc min I-index, max I-index, min J-index, max J-index, min K-index, max K-index for each process
  */
-void VTKRectilinearGrid::setGlobalIndex( std::vector<extension3D_t> loc ){
+void VTKRectilinearGrid::setGlobalIndex( const std::vector<extension3D_t> &loc ){
 
     if( loc.size() != m_procs ) 
         log::cout() << "Size of loc_ in VTKRectilinearGrid::setParallelIndex does not fit m_procs " << std::endl ;
@@ -474,7 +474,7 @@ void VTKRectilinearGrid::setGlobalIndex( std::vector<extension3D_t> loc ){
  *  Needs to be called only by rank 0.
  *  @param[in]  loc min I-index, max I-index, min J-index, max J-index for each process
  */
-void VTKRectilinearGrid::setGlobalIndex( std::vector<extension2D_t> loc ){
+void VTKRectilinearGrid::setGlobalIndex( const std::vector<extension2D_t> &loc ){
 
     if( loc.size() !=m_procs ) log::cout() << "Size of loc_ in VTKRectilinearGrid::setParallelIndex does not fit m_procs " << std::endl ;
 

--- a/src/IO/VTKTypes.cpp
+++ b/src/IO/VTKTypes.cpp
@@ -64,7 +64,7 @@ static VTKDataType VTKTypeIndex_VTKElement = VTKTypes::registerType<VTKElementTy
  * @param[in]  type    type of data [ VTKDataType::[[U]Int[8/16/32/64] / Float[32/64] ] ]
  * @return      size of basic type
  */
-uint8_t VTKTypes::sizeOfType( const VTKDataType & type ){
+uint8_t VTKTypes::sizeOfType( VTKDataType type ){
 
     switch( type){
         case VTKDataType::Int8 : case VTKDataType::UInt8:

--- a/src/IO/VTKUtils.cpp
+++ b/src/IO/VTKUtils.cpp
@@ -32,7 +32,7 @@ namespace bitpit{
  *  @param[in] type element type
  *  @return number of vertices of element type
  */
-uint8_t vtk::getElementNodeCount( const VTKElementType &type){
+uint8_t vtk::getElementNodeCount( VTKElementType type){
 
     switch (type){
 
@@ -192,7 +192,7 @@ std::string  vtk::convertPDataArrayToString( const VTKField &field ){
  * @param[in] loc VTKLocation to be converted
  * @return string to be used in DataArray
  */
-std::string vtk::convertEnumToString( const VTKLocation &loc ){
+std::string vtk::convertEnumToString( VTKLocation loc ){
    
     switch(loc){
         case VTKLocation::CELL :
@@ -211,7 +211,7 @@ std::string vtk::convertEnumToString( const VTKLocation &loc ){
  * @param[in]  cod VTKFormat to be converted
  * @return string to be used in DataArray
  */
-std::string vtk::convertEnumToString( const VTKFormat &cod ){
+std::string vtk::convertEnumToString( VTKFormat cod ){
     
     switch(cod){
         case VTKFormat::ASCII :
@@ -230,7 +230,7 @@ std::string vtk::convertEnumToString( const VTKFormat &cod ){
  * @param[in] type VTKDataType to be converted
  * @return string to be used in DataArray
  */
-std::string vtk::convertEnumToString( const VTKDataType &type ){
+std::string vtk::convertEnumToString( VTKDataType type ){
     
     switch(type){
         case VTKDataType::Int8 :

--- a/src/IO/logger.cpp
+++ b/src/IO/logger.cpp
@@ -1369,7 +1369,7 @@ namespace log {
         \param name is the name of the logger
         \result An instance of the specified logger.
     */
-    Logger & cout(std::string name)
+    Logger & cout(const std::string &name)
     {
         return manager().cout(name);
     }

--- a/src/IO/logger.hpp
+++ b/src/IO/logger.hpp
@@ -270,7 +270,7 @@ namespace log {
     // Generic global functions
     LoggerManager & manager();
     Logger & cout();
-    Logger & cout(std::string name);
+    Logger & cout(const std::string &name);
 
     // Manipulators global functions
 

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -85,7 +85,7 @@ void SystemSolver::addInitOptions(const std::vector<std::string> &options)
         throw std::runtime_error("Initialization opions can be set only before initializing the solver.");
     }
 
-    for (std::string option : options) {
+    for (const std::string &option : options) {
         m_options.push_back(option);
     }
 }

--- a/src/PABLO/Map.cpp
+++ b/src/PABLO/Map.cpp
@@ -100,7 +100,7 @@ darray3 Map::mapCoordinates(u32array3 const & X) const {
  * \param[in] X Coordinate X from logical domain.
  * \return Coordinate X in physical domain.
  */
-double Map::mapX(uint32_t const & X) const {
+double Map::mapX(uint32_t X) const {
 	return m_maxLength_1 * double(X);
 };
 
@@ -108,7 +108,7 @@ double Map::mapX(uint32_t const & X) const {
  * \param[in] Y Coordinate Y from logical domain.
  * \return Coordinate Y in physical domain.
  */
-double Map::mapY(uint32_t const & Y) const {
+double Map::mapY(uint32_t Y) const {
 	return m_maxLength_1 * double(Y);
 };
 
@@ -116,7 +116,7 @@ double Map::mapY(uint32_t const & Y) const {
  * \param[in] Z Coordinate Z from logical domain.
  * \return Coordinate Z in physical domain.
  */
-double Map::mapZ(uint32_t const & Z) const {
+double Map::mapZ(uint32_t Z) const {
 	return m_maxLength_1 * double(Z);
 };
 
@@ -136,7 +136,7 @@ u32array3 Map::mapCoordinates(darray3 const & X) const {
  * \param[in] X Coordinate X from physical domain.
  * \return Coordinate X in logical domain.
  */
-uint32_t Map::mapX(double const & X) const {
+uint32_t Map::mapX(double X) const {
 	return (uint32_t)(double(m_maxLength) * X);
 };
 
@@ -144,7 +144,7 @@ uint32_t Map::mapX(double const & X) const {
  * \param[in] Y Coordinate Y from physical domain.
  * \return Coordinate Y in logical domain.
  */
-uint32_t Map::mapY(double const & Y) const {
+uint32_t Map::mapY(double Y) const {
 	return (uint32_t)(double(m_maxLength) * Y);
 };
 
@@ -152,7 +152,7 @@ uint32_t Map::mapY(double const & Y) const {
  * \param[in] Z Coordinate Z from physical domain.
  * \return Coordinate Z in logical domain.
  */
-uint32_t Map::mapZ(double const & Z) const {
+uint32_t Map::mapZ(double Z) const {
 	return (uint32_t)(double(m_maxLength) * Z);
 };
 
@@ -160,7 +160,7 @@ uint32_t Map::mapZ(double const & Z) const {
  * \param[in] size Size of octant from logical domain.
  * \return Size of octant in physical domain.
  */
-double Map::mapSize(uint32_t const & size) const {
+double Map::mapSize(uint32_t size) const {
 	return m_maxLength_1 *double(size);
 };
 
@@ -168,7 +168,7 @@ double Map::mapSize(uint32_t const & size) const {
  * \param[in] area Area of octant from logical domain.
  * \return Area of octant in physical domain.
  */
-double Map::mapArea(uint64_t const & area) const {
+double Map::mapArea(uint64_t area) const {
 	return m_maxArea_1*double(area);
 };
 
@@ -176,7 +176,7 @@ double Map::mapArea(uint64_t const & area) const {
  * \param[in] volume Volume of octant from logical domain.
  * \return Coordinate Volume of octant in physical domain.
  */
-double Map::mapVolume(uint64_t const & volume) const {
+double Map::mapVolume(uint64_t volume) const {
 	return m_maxVolume_1*double(volume);
 };
 

--- a/src/PABLO/Map.hpp
+++ b/src/PABLO/Map.hpp
@@ -107,16 +107,16 @@ private:
 	void initialize(uint8_t dim);
 
 	darray3 mapCoordinates(u32array3 const & X) const;
-	double mapX(uint32_t const & X) const;
-	double mapY(uint32_t const & Y) const;
-	double mapZ(uint32_t const & Z) const;
+	double mapX(uint32_t X) const;
+	double mapY(uint32_t Y) const;
+	double mapZ(uint32_t Z) const;
 	u32array3 mapCoordinates(darray3 const & X) const;
-	uint32_t mapX(double const & X) const;
-	uint32_t mapY(double const & Y) const;
-	uint32_t mapZ(double const & Z) const;
-	double mapSize(uint32_t const & size) const;
-	double mapArea(uint64_t const & area) const;
-	double mapVolume(uint64_t const & volume) const;
+	uint32_t mapX(double X) const;
+	uint32_t mapY(double Y) const;
+	uint32_t mapZ(double Z) const;
+	double mapSize(uint32_t size) const;
+	double mapArea(uint64_t area) const;
+	double mapVolume(uint64_t volume) const;
 	void mapCenter(double* & center, darray3 & mapcenter) const;
 	void mapCenter(darray3 & center, darray3 & mapcenter) const;
 	void mapNodes(uint32_t (*nodes)[3], darr3vector & mapnodes) const;

--- a/src/PABLO/PabloUniform.cpp
+++ b/src/PABLO/PabloUniform.cpp
@@ -50,9 +50,9 @@ namespace bitpit {
     /*!
      * \param[in] comm The MPI communicator used by the parallel octree. MPI_COMM_WORLD is the default value.
      */
-    PabloUniform::PabloUniform(std::string logfile, MPI_Comm comm):ParaTree(logfile,comm){
+    PabloUniform::PabloUniform(const std::string &logfile, MPI_Comm comm):ParaTree(logfile,comm){
 #else
-    PabloUniform::PabloUniform(std::string logfile):ParaTree(logfile){
+    PabloUniform::PabloUniform(const std::string &logfile):ParaTree(logfile){
 #endif
         __reset();
     }
@@ -66,9 +66,9 @@ namespace bitpit {
     /*!
      * \param[in] comm The MPI communicator used by the parallel octree. MPI_COMM_WORLD is the default value.
      */
-    PabloUniform::PabloUniform(uint8_t dim, std::string logfile, MPI_Comm comm):ParaTree(dim,logfile,comm){
+    PabloUniform::PabloUniform(uint8_t dim, const std::string &logfile, MPI_Comm comm):ParaTree(dim,logfile,comm){
 #else
-    PabloUniform::PabloUniform(uint8_t dim, std::string logfile):ParaTree(dim,logfile){
+    PabloUniform::PabloUniform(uint8_t dim, const std::string &logfile):ParaTree(dim,logfile){
 #endif
         __reset();
     };
@@ -86,9 +86,9 @@ namespace bitpit {
     /*!
      * \param[in] comm The MPI communicator used by the parallel octree. MPI_COMM_WORLD is the default value.
      */
-    PabloUniform::PabloUniform(double X, double Y, double Z, double L, uint8_t dim, std::string logfile, MPI_Comm comm):ParaTree(dim,logfile,comm){
+    PabloUniform::PabloUniform(double X, double Y, double Z, double L, uint8_t dim, const std::string &logfile, MPI_Comm comm):ParaTree(dim,logfile,comm){
 #else
-    PabloUniform::PabloUniform(double X, double Y, double Z, double L, uint8_t dim, std::string logfile):ParaTree(dim,logfile){
+    PabloUniform::PabloUniform(double X, double Y, double Z, double L, uint8_t dim, const std::string &logfile):ParaTree(dim,logfile){
 #endif
         __reset();
 
@@ -221,7 +221,7 @@ namespace bitpit {
      * \param[in] origin Origin of the octree.
      */
     void
-    PabloUniform::setOrigin(darray3 origin){
+    PabloUniform::setOrigin(const darray3 &origin){
         m_origin = origin;
     };
 
@@ -871,7 +871,7 @@ namespace bitpit {
      * \param[in] filename Name of output file (PABLO will add the total number of processes p000# and the current rank s000#).
      */
     void
-    PabloUniform::write(string filename) {
+    PabloUniform::write(const std::string &filename) {
 
         if (getConnectivity().size() == 0) {
             computeConnectivity();
@@ -1025,7 +1025,7 @@ namespace bitpit {
      * \param[in] data Vector of double with user data.
      */
     void
-    PabloUniform::writeTest(string filename, vector<double> data) {
+    PabloUniform::writeTest(const std::string &filename, vector<double> data) {
 
         if (getConnectivity().size() == 0) {
             computeConnectivity();

--- a/src/PABLO/PabloUniform.hpp
+++ b/src/PABLO/PabloUniform.hpp
@@ -79,13 +79,13 @@ namespace bitpit {
         void	__reset();
     public:
 #if BITPIT_ENABLE_MPI==1
-        PabloUniform(std::string logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
-        PabloUniform(uint8_t dim, std::string logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
-        PabloUniform(double X, double Y, double Z, double L, uint8_t dim = 2, std::string logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
+        PabloUniform(const std::string &logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
+        PabloUniform(uint8_t dim, const std::string &logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
+        PabloUniform(double X, double Y, double Z, double L, uint8_t dim = 2, const std::string &logfile = DEFAULT_LOG_FILE, MPI_Comm comm = MPI_COMM_WORLD);
 #else
-        PabloUniform(std::string logfile = DEFAULT_LOG_FILE);
-        PabloUniform(uint8_t dim, std::string logfile = DEFAULT_LOG_FILE);
-        PabloUniform(double X, double Y, double Z, double L, uint8_t dim = 2, std::string logfile = DEFAULT_LOG_FILE);
+        PabloUniform(const std::string &logfile = DEFAULT_LOG_FILE);
+        PabloUniform(uint8_t dim, const std::string &logfile = DEFAULT_LOG_FILE);
+        PabloUniform(double X, double Y, double Z, double L, uint8_t dim = 2, const std::string &logfile = DEFAULT_LOG_FILE);
 #endif
 
         // =================================================================================== //
@@ -106,7 +106,7 @@ namespace bitpit {
         double		getZ0() const;
         double		getL() const;
         void		setL(double L);
-        void		setOrigin(darray3 origin);
+        void		setOrigin(const darray3 &origin);
         double		levelToSize( uint8_t& level);
 
         // =================================================================================== //
@@ -184,8 +184,8 @@ namespace bitpit {
         // =================================================================================== //
         // TESTING OUTPUT METHODS													    	   //
         // =================================================================================== //
-        void        write(std::string filename);
-        void        writeTest(std::string filename, dvector data);
+        void        write(const std::string &filename);
+        void        writeTest(const std::string &filename, dvector data);
     };
 
 }

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -3857,7 +3857,7 @@ namespace bitpit {
      * \return Rank of the process owning the element
      */
     int
-    ParaTree::findOwner(const uint64_t & morton) const {
+    ParaTree::findOwner(uint64_t morton) const {
         // Early return if the requested morton is on first partition
         if (morton <= m_partitionLastDesc[0]) {
             return 0;
@@ -3903,7 +3903,7 @@ namespace bitpit {
      * \return Rank of the process owning the element
      */
     int
-    ParaTree::getOwnerRank(const uint64_t & globalIndex) const {
+    ParaTree::getOwnerRank(uint64_t globalIndex) const {
         // Get the iterator point to the onwer rank
         std::vector<uint64_t>::const_iterator rankItr = std::lower_bound (m_partitionRangeGlobalIdx.begin(), m_partitionRangeGlobalIdx.end(), globalIndex);
 

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -478,8 +478,8 @@ namespace bitpit {
         // OTHER PARATREE BASED METHODS												    	   //
         // =================================================================================== //
         uint8_t		getMaxDepth() const;
-        int 		findOwner(const uint64_t & morton) const;
-        int 		getOwnerRank(const uint64_t & globalIdx) const;
+        int 		findOwner(uint64_t morton) const;
+        int 		getOwnerRank(uint64_t globalIdx) const;
         void        settleMarkers();
         void        preadapt();
         bool        checkToAdapt();

--- a/src/POD/pod.cpp
+++ b/src/POD/pod.cpp
@@ -1857,7 +1857,7 @@ void POD::_evalModes()
  * \param[in] snap Snapshot filename
  * \param[out] fieldr Resulting POD field
  */
-void POD::readSnapshot(pod::SnapshotFile snap, pod::PODField & fieldr)
+void POD::readSnapshot(const pod::SnapshotFile & snap, pod::PODField & fieldr)
 {
 
     int dumpBlock = (m_nProcs > 1) ? m_rank : -1;

--- a/src/POD/pod.cpp
+++ b/src/POD/pod.cpp
@@ -746,10 +746,10 @@ std::vector<std::array<std::string,3>> POD::getVectorNames()
 std::vector<std::string> POD::getFieldsNames()
 {
     std::vector<std::string> names;
-    for (std::string ss : m_nameScalarFields)
+    for (const std::string &ss : m_nameScalarFields)
         names.push_back(ss);
-    for (std::array<std::string,3> ssa : m_nameVectorFields){
-        for (std::string ss : ssa)
+    for (const std::array<std::string,3> &ssa : m_nameVectorFields){
+        for (const std::string &ss : ssa)
             names.push_back(ss);
     }
 
@@ -1271,7 +1271,7 @@ void POD::evalErrorBoundingBox()
     
     // Find scalar target fields
     std::size_t count=0;
-    for (std::string val : m_nameScalarFields) {
+    for (const std::string &val : m_nameScalarFields) {
         std::map<std::string, std::size_t>::iterator found = targetErrorFields.find(val);
         if (found != targetErrorFields.end()) {
             scalarIds.push_back(count);
@@ -1281,10 +1281,10 @@ void POD::evalErrorBoundingBox()
     }
 
     // Find vector target fields
-    for (std::array<std::string,3> valv : m_nameVectorFields) {
+    for (const std::array<std::string,3> &valv : m_nameVectorFields) {
         std::size_t ic = 0;
         std::array<std::string,3> toerase;
-        for (std::string val : valv) {
+        for (const std::string &val : valv) {
             std::map<std::string, std::size_t>::iterator found = targetErrorFields.find(val);
             if (found != targetErrorFields.end()) {
                 toerase[ic] = val;
@@ -2701,7 +2701,7 @@ void POD::reconstructFields(PiercedStorage<double> &fields, VolumeKernel *mesh,
 
     // Find scalar target fields
     std::size_t count = 0;
-    for (std::string val : m_nameScalarFields) {
+    for (const std::string &val : m_nameScalarFields) {
         std::map<std::string, std::size_t>::iterator found = targetFields.find(val);
         if (found != targetFields.end()) {
             std::size_t ind = found->second;
@@ -2714,11 +2714,11 @@ void POD::reconstructFields(PiercedStorage<double> &fields, VolumeKernel *mesh,
 
     // Find vector target fields
     count = 0;
-    for (std::array<std::string,3> valv : m_nameVectorFields) {
+    for (const std::array<std::string,3> &valv : m_nameVectorFields) {
         std::size_t ic = 0;
         std::array<std::size_t,3> vectorarr;
         std::array<std::string,3> toerase;
-        for (std::string val : valv) {
+        for (const std::string &val : valv) {
             std::map<std::string, std::size_t>::iterator found = targetFields.find(val);
             if (found != targetFields.end()) {
                 std::size_t ind = found->second;

--- a/src/POD/pod.hpp
+++ b/src/POD/pod.hpp
@@ -270,7 +270,7 @@ private:
 
     void dumpMode(std::size_t ir);
 
-    void readSnapshot(pod::SnapshotFile snap, pod::PODField &fieldr);
+    void readSnapshot(const pod::SnapshotFile &snap, pod::PODField &fieldr);
     void readMode(std::size_t ir);
 
     double getCellVolume(long id);

--- a/src/POD/pod_voloctree.cpp
+++ b/src/POD/pod_voloctree.cpp
@@ -1211,7 +1211,7 @@ std::unordered_set<long> PODVolOctree::mapCellsToPOD(const std::unordered_set<lo
         //build send buffers
         DataCommunicator dataCommunicator(m_communicator);
         std::size_t bytes = sizeof(long);
-        for (std::pair<int, std::unordered_set<long> > val : sendPODcells){
+        for (const auto &val : sendPODcells){
             std::size_t ncells = val.second.size();
             int rank = val.first;
             //set size
@@ -1219,7 +1219,7 @@ std::unordered_set<long> PODVolOctree::mapCellsToPOD(const std::unordered_set<lo
             dataCommunicator.setSend(rank,buffSize);
             //fill buffer with octants
             SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-            for (const long & ID : val.second){
+            for (long ID : val.second){
                 sendBuffer << ID;
             }
         }
@@ -1309,14 +1309,14 @@ void PODVolOctree::communicatePODField(const pod::PODField & field, std::map<int
         //build send buffers
         DataCommunicator dataCommunicator(m_communicator);
         std::size_t bytes = sizeof(bool) + (nsf+(3*nvf)+1)*sizeof(double);
-        for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+        for (const auto &val : rankIDsend){
             int rank = val.first;
             //set size
             std::size_t buffSize = val.second.size() * bytes;
             dataCommunicator.setSend(rank,buffSize);
             //fill buffer with octants
             SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-            for (long & ID : val.second){
+            for (long ID : val.second){
                 bool mask = field.mask->at(ID);
                 sendBuffer << mask;
                 for (std::size_t i=0; i<nsf; i++)
@@ -1334,11 +1334,11 @@ void PODVolOctree::communicatePODField(const pod::PODField & field, std::map<int
         dataCommunicator.startAllRecvs();
         dataCommunicator.startAllSends();
 
-        for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+        for (const auto &val : rankIDrec){
             int rank = val.first;
             dataCommunicator.waitRecv(rank);
             RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-            for (long & ID : val.second){
+            for (long ID : val.second){
                 recvBuffer >> dataBrec[rank][ID];
                 for (std::size_t i=0; i<nsf; i++){
                     double data;
@@ -1374,14 +1374,14 @@ void PODVolOctree::communicatePODFieldFromPOD(const pod::PODField & field, std::
         //build send buffers
         DataCommunicator dataCommunicator(m_communicator);
         std::size_t bytes = sizeof(long) + sizeof(bool) + (nsf+3*nvf+1)*sizeof(double);
-        for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+        for (const auto &val : rankIDsend){
             int rank = val.first;
             //set size
             std::size_t buffSize = val.second.size() * bytes;
             dataCommunicator.setSend(rank,buffSize);
             //fill buffer with octants
             SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-            for (long & ID : val.second){
+            for (long ID : val.second){
                 sendBuffer << ID;
                 bool mask = field.mask->at(ID);
                 sendBuffer << mask;
@@ -1442,14 +1442,14 @@ void PODVolOctree::communicateBoolField(const PiercedStorage<bool> & field, std:
     //build send buffers
     DataCommunicator dataCommunicator(m_communicator);
     std::size_t bytes = sizeof(bool);
-    for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+    for (const auto &val : rankIDsend){
         int rank = val.first;
         //set size
         std::size_t buffSize = val.second.size() * bytes;
         dataCommunicator.setSend(rank,buffSize);
         //fill buffer with octants
         SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-        for (long & ID : val.second){
+        for (long ID : val.second){
             sendBuffer << field.at(ID);
         }
     }
@@ -1458,11 +1458,11 @@ void PODVolOctree::communicateBoolField(const PiercedStorage<bool> & field, std:
     dataCommunicator.startAllRecvs();
     dataCommunicator.startAllSends();
 
-    for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+    for (const auto &val : rankIDrec){
         int rank = val.first;
         dataCommunicator.waitRecv(rank);
         RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-        for (long & ID : val.second){
+        for (long ID : val.second){
             recvBuffer >> dataBrec[rank][ID];
         }
     }
@@ -1482,14 +1482,14 @@ void PODVolOctree::communicateField(const PiercedStorage<double> & field, const 
     //build send buffers
     DataCommunicator dataCommunicator(m_communicator);
     std::size_t bytes = (nf+1)*sizeof(double);
-    for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+    for (const auto &val : rankIDsend){
         int rank = val.first;
         //set size
         std::size_t buffSize = val.second.size() * bytes;
         dataCommunicator.setSend(rank,buffSize);
         //fill buffer with octants
         SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-        for (long & ID : val.second){
+        for (long ID : val.second){
             for (std::size_t ifield=0; ifield<nf; ifield++)
                 sendBuffer << field.at(ID, ifield);
             sendBuffer << mesh->evalCellVolume(ID);
@@ -1500,11 +1500,11 @@ void PODVolOctree::communicateField(const PiercedStorage<double> & field, const 
     dataCommunicator.startAllRecvs();
     dataCommunicator.startAllSends();
 
-    for (std::pair<const int, std::vector<long int> > val : rankIDrec){
+    for (const auto &val : rankIDrec){
         int rank = val.first;
         dataCommunicator.waitRecv(rank);
         RecvBuffer & recvBuffer = dataCommunicator.getRecvBuffer(rank);
-        for (long & ID : val.second){
+        for (long ID : val.second){
             datarec[rank][ID].resize(nf);
             for (std::size_t ifield=0; ifield<nf; ifield++)
                 recvBuffer >> datarec[rank][ID][ifield];
@@ -1526,14 +1526,14 @@ void PODVolOctree::communicateFieldFromPOD(const PiercedStorage<double> & field,
     //build send buffers
     DataCommunicator dataCommunicator(m_communicator);
     std::size_t bytes = (nf+1)*sizeof(double)+sizeof(long);
-    for (std::pair<const int, std::vector<long int> > val : rankIDsend){
+    for (const auto &val : rankIDsend){
         int rank = val.first;
         //set size
         std::size_t buffSize = val.second.size() * bytes;
         dataCommunicator.setSend(rank,buffSize);
         //fill buffer with octants
         SendBuffer &sendBuffer = dataCommunicator.getSendBuffer(rank);
-        for (long & ID : val.second){
+        for (long ID : val.second){
             sendBuffer << ID;
             for (std::size_t ifield=0; ifield<nf; ifield++)
                 sendBuffer << field.at(ID, ifield);

--- a/src/RBF/rbf.cpp
+++ b/src/RBF/rbf.cpp
@@ -119,7 +119,7 @@ void RBFKernel::swap(RBFKernel &x) noexcept
  * Sets the rbf function to be used. Supported in both modes.
  * @param[in] bfunc basis function to be used
  */
-void RBFKernel::setFunction( const RBFBasisFunction &bfunc )
+void RBFKernel::setFunction( RBFBasisFunction bfunc )
 {
     switch(bfunc){
 

--- a/src/RBF/rbf.hpp
+++ b/src/RBF/rbf.hpp
@@ -85,7 +85,7 @@ public:
     RBFKernel();
     RBFKernel(const RBFKernel & other);
 
-    void                    setFunction(const RBFBasisFunction &);
+    void                    setFunction(RBFBasisFunction);
     void                    setFunction(double (&funct)(double ));
 
     RBFBasisFunction        getFunctionType();

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -405,7 +405,7 @@ private:
     template<typename T = value_t, typename std::enable_if<PiercedStorage<T, id_t>::has_restore()>::type * = nullptr>
     void restoreField(std::istream &stream, T &object);
 
-    void dumpField(std::ostream &stream, const std::vector<bool>::const_reference &value) const;
+    void dumpField(std::ostream &stream, std::vector<bool>::const_reference value) const;
 
     template<typename T = value_t, typename std::enable_if<!PiercedStorage<T, id_t>::has_dump()>::type * = nullptr>
     void dumpField(std::ostream &stream, const T &value) const;

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -1436,7 +1436,7 @@ void PiercedStorage<value_t, id_t>::dump(std::ostream &stream) const
 * \param value is the value that will be dumped
 */
 template<typename value_t, typename id_t>
-void PiercedStorage<value_t, id_t>::dumpField(std::ostream &stream, const std::vector<bool>::const_reference &value) const
+void PiercedStorage<value_t, id_t>::dumpField(std::ostream &stream, std::vector<bool>::const_reference value) const
 {
     bool bool_value = value;
     utils::binary::write(stream, bool_value);

--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -243,7 +243,7 @@ int LevelSet::addObject( SurfaceKernel *segmentation, double angle, int id ) {
  * @param[in] id id to be assigned to object. In case default value is passed the insertion order will be used as identifier
  * @return identifier of new object
  */
-int LevelSet::addObject( const LevelSetBooleanOperation &operation, int id1, int id2, int id ) {
+int LevelSet::addObject( LevelSetBooleanOperation operation, int id1, int id2, int id ) {
 
     if (id == levelSetDefaults::OBJECT) {
         id = m_objects.size();
@@ -262,7 +262,7 @@ int LevelSet::addObject( const LevelSetBooleanOperation &operation, int id1, int
  * @param[in] id id to be assigned to object. In case default value is passed the insertion order will be used as identifier
  * @return identifier of new object
  */
-int LevelSet::addObject( const LevelSetBooleanOperation &operation, const std::vector<int> &ids, int id ) {
+int LevelSet::addObject( LevelSetBooleanOperation operation, const std::vector<int> &ids, int id ) {
 
     if (id == levelSetDefaults::OBJECT) {
         id = m_objects.size();

--- a/src/levelset/levelSet.hpp
+++ b/src/levelset/levelSet.hpp
@@ -78,8 +78,8 @@ class LevelSet{
     int                     addObject( SurfaceKernel *, double, int id = levelSetDefaults::OBJECT ) ;
     int                     addObject( std::unique_ptr<SurfUnstructured> &&, double, int id = levelSetDefaults::OBJECT ) ;
     int                     addObject( SurfUnstructured *, double, int id = levelSetDefaults::OBJECT ) ;
-    int                     addObject( const LevelSetBooleanOperation &, int, int, int id=levelSetDefaults::OBJECT ) ;
-    int                     addObject( const LevelSetBooleanOperation &, const std::vector<int> &, int id=levelSetDefaults::OBJECT ) ;
+    int                     addObject( LevelSetBooleanOperation, int, int, int id=levelSetDefaults::OBJECT ) ;
+    int                     addObject( LevelSetBooleanOperation, const std::vector<int> &, int id=levelSetDefaults::OBJECT ) ;
     int                     addObject( const std::unordered_set<long> &, int id=levelSetDefaults::OBJECT ) ;
     int                     addObject( const std::vector<long> &, long, bool, int id=levelSetDefaults::OBJECT ) ;
     int                     addObject( std::unique_ptr<LevelSetObject> && ) ;

--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -255,7 +255,7 @@ void LevelSetCachedObject::propagateSign() {
         size_t dataSize = sizeof(sign);
 
         // Set the receives
-        for (const auto entry : mesh.getGhostExchangeTargets()) {
+        for (const auto &entry : mesh.getGhostExchangeTargets()) {
             const int rank = entry.first;
             const auto &list = entry.second;
 
@@ -279,9 +279,9 @@ void LevelSetCachedObject::propagateSign() {
             }
 
             // Start the sends
-            for (const auto entry : mesh.getGhostExchangeSources()) {
+            for (const auto &entry : mesh.getGhostExchangeSources()) {
                 const int rank = entry.first;
-                auto &sendIds = entry.second;
+                const auto &sendIds = entry.second;
                 SendBuffer &buffer = dataCommunicator.getSendBuffer(rank);
 
                 for (long cellId : sendIds) {

--- a/src/levelset/levelSetKernel.cpp
+++ b/src/levelset/levelSetKernel.cpp
@@ -227,7 +227,7 @@ bool LevelSetKernel::isPointInCell(long id, const std::array<double,3> &pointCoo
  * @result True if the specified cell is inside the given bounding box, false
  * otherwise.
  */
-double LevelSetKernel::isCellInsideBoundingBox( long id, std::array<double, 3> minPoint, std::array<double, 3> maxPoint ){
+double LevelSetKernel::isCellInsideBoundingBox( long id, const std::array<double, 3> &minPoint, const std::array<double, 3> &maxPoint ){
 
     const Cell &cell = m_mesh->getCell(id);
     double tolerance = m_mesh->getTol();

--- a/src/levelset/levelSetKernel.hpp
+++ b/src/levelset/levelSetKernel.hpp
@@ -71,7 +71,7 @@ class LevelSetKernel{
     void                                        updateGeometryCache(const std::vector<adaption::Info> &);
 
     const std::array<double,3> &                computeCellCentroid(long);
-    double                                      isCellInsideBoundingBox(long, std::array<double,3> , std::array<double,3> );
+    double                                      isCellInsideBoundingBox(long, const std::array<double,3> &, const std::array<double,3> & );
 
     const std::array<double,3> &                getVertexCoords(long);
 

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -603,7 +603,7 @@ void LevelSetObject::communicate( const std::unordered_map<int,std::vector<long>
 
     // Fill the send buffer with the  content from the LevelSetObject base
     // class and the specific derived class.
-    for (const auto entry : sendList) {
+    for (const auto &entry : sendList) {
         // Create an empty send
         int rank = entry.first;
         dataCommunicator.setSend(rank, 0);

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -315,7 +315,7 @@ LevelSetSegmentation::SurfaceInfo::SurfaceInfo( ) : support(levelSetDefaults::SU
 /*!
  * Constructor
  */
-LevelSetSegmentation::SurfaceInfo::SurfaceInfo( long index, std::array<double,3> vec ) : support(index), normal(vec)
+LevelSetSegmentation::SurfaceInfo::SurfaceInfo( long index, const std::array<double,3> &vec ) : support(index), normal(vec)
 {
 }
 

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -104,7 +104,7 @@ class LevelSetSegmentation : public LevelSetCachedObject {
         std::array<double,3> normal;
 
         SurfaceInfo();
-        SurfaceInfo(long, std::array<double,3>);
+        SurfaceInfo(long, const std::array<double,3> &);
     };
 
     std::shared_ptr<const SegmentationKernel> m_segmentation;

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -186,7 +186,7 @@ void PatchNumberingInfo::_extract()
 		dataCommunicator = std::unique_ptr<DataCommunicator>(new DataCommunicator(m_patch->getCommunicator()));
 
 		// Set and start the receives
-		for (const auto entry : m_patch->getGhostExchangeTargets()) {
+		for (const auto &entry : m_patch->getGhostExchangeTargets()) {
 			const int rank = entry.first;
 			const auto &list = entry.second;
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -4206,7 +4206,7 @@ void PatchKernel::evalCellBoundingBox(long id, std::array<double,3> *minPoint, s
 {
 	const Cell &cell = getCell(id);
 
-	return evalElementBoundingBox(cell, minPoint, maxPoint);
+	evalElementBoundingBox(cell, minPoint, maxPoint);
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2106,7 +2106,7 @@ PatchKernel::CellIterator PatchKernel::restoreCell(ElementType type, std::unique
 	\param connectStorage is the storage the contains or will contain
 	the connectivity of the element
 */
-void PatchKernel::_restoreInternal(CellIterator iterator, ElementType type,
+void PatchKernel::_restoreInternal(const CellIterator &iterator, ElementType type,
 								   std::unique_ptr<long[]> &&connectStorage)
 {
 	Cell &cell = *iterator;
@@ -5166,7 +5166,7 @@ std::unordered_map<long, std::vector<long>> PatchKernel::binGroupVertices(const 
 
 	\param[in] translation is the translation vector
 */
-void PatchKernel::translate(std::array<double, 3> translation)
+void PatchKernel::translate(const std::array<double, 3> &translation)
 {
 	// Translate the patch
 	for (auto &vertex : m_vertices) {
@@ -5199,7 +5199,7 @@ void PatchKernel::translate(double sx, double sy, double sz)
 
 	\param[in] scaling is the scaling factor vector
 */
-void PatchKernel::scale(std::array<double, 3> scaling)
+void PatchKernel::scale(const std::array<double, 3> &scaling)
 {
 	// Scale the patch
 	for (auto &vertex : m_vertices) {

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -4249,7 +4249,7 @@ void PatchKernel::evalInterfaceBoundingBox(long id, std::array<double,3> *minPoi
 {
 	const Interface &interface = getInterface(id);
 
-	return evalElementBoundingBox(interface, minPoint, maxPoint);
+	evalElementBoundingBox(interface, minPoint, maxPoint);
 }
 
 

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -503,9 +503,9 @@ public:
 	bool isBoundingBoxDirty(bool global = false) const;
 	void updateBoundingBox(bool forcedUpdated = false);
 
-	virtual void translate(std::array<double, 3> translation);
+	virtual void translate(const std::array<double, 3> &translation);
 	void translate(double sx, double sy, double sz);
-	virtual void scale(std::array<double, 3> scaling);
+	virtual void scale(const std::array<double, 3> &scaling);
 	void scale(double scaling);
 	void scale(double sx, double sy, double sz);
 
@@ -784,9 +784,9 @@ private:
 	CellIterator _addGhost(ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank, long id);
 #endif
 
-	void _restoreInternal(CellIterator iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage);
+	void _restoreInternal(const CellIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage);
 #if BITPIT_ENABLE_MPI==1
-	void _restoreGhost(CellIterator iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank);
+	void _restoreGhost(const CellIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank);
 #endif
 
 	void _deleteInternal(long id, bool delayed);

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -1398,7 +1398,7 @@ std::unordered_map<long, int> PatchKernel::_partitioningAlter_evalGhostOwnership
     size_t notificationDataSize = sizeof(patchRank);
 
     // Set and start the receives
-    for (const auto entry : getGhostExchangeTargets()) {
+    for (const auto &entry : getGhostExchangeTargets()) {
         const int rank = entry.first;
         const auto &targetCells = entry.second;
 

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -541,7 +541,7 @@ PatchKernel::CellIterator PatchKernel::restoreCell(ElementType type, std::unique
 	the connectivity of the element
 	\param rank is the rank that owns the cell that will be restored
 */
-void PatchKernel::_restoreGhost(CellIterator iterator, ElementType type,
+void PatchKernel::_restoreGhost(const CellIterator &iterator, ElementType type,
 								std::unique_ptr<long[]> &&connectStorage, int rank)
 {
 	// Restore cell

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -1256,7 +1256,7 @@ long VolCartesian::getCellLinearId(const std::array<int, 3> &ijk) const
 	\param[in] idx is the linear index of the cell
 	\result Returns the set of cartesian indices of the cell.
 */
-std::array<int, 3> VolCartesian::getCellCartesianId(long const &idx) const
+std::array<int, 3> VolCartesian::getCellCartesianId(long idx) const
 {
 	int offset_ij = m_nCells1D[0] * m_nCells1D[1];
 
@@ -1319,7 +1319,7 @@ long VolCartesian::getVertexLinearId(const std::array<int, 3> &ijk) const
 	\param[in] idx is the linear index of the vertex
 	\result Returns the set of cartesian indices of the vertex.
 */
-std::array<int, 3> VolCartesian::getVertexCartesianId(long const &idx) const
+std::array<int, 3> VolCartesian::getVertexCartesianId(long idx) const
 {
 	int offset_ij = m_nVertices1D[0] * m_nVertices1D[1];
 
@@ -1344,7 +1344,7 @@ std::array<int, 3> VolCartesian::getVertexCartesianId(long const &idx) const
 	\param[in] vertex is the local vertex
 	\result Returns the set of cartesian indices of the vertex.
 */
-std::array<int, 3> VolCartesian::getVertexCartesianId(long const &cellIdx, int const &vertex) const
+std::array<int, 3> VolCartesian::getVertexCartesianId(long cellIdx, int vertex) const
 {
 	return getVertexCartesianId(getCellCartesianId(cellIdx), vertex);
 }
@@ -1358,7 +1358,7 @@ std::array<int, 3> VolCartesian::getVertexCartesianId(long const &cellIdx, int c
 	\param[in] vertex is the local vertex
 	\result Returns the set of cartesian indices of the vertex.
 */
-std::array<int, 3> VolCartesian::getVertexCartesianId(const std::array<int, 3> &cellIjk, int const &vertex) const
+std::array<int, 3> VolCartesian::getVertexCartesianId(const std::array<int, 3> &cellIjk, int vertex) const
 {
 	std::bitset<3> vertexBitset(vertex);
 	std::array<int, 3> vertexIjk(cellIjk);
@@ -1524,7 +1524,7 @@ std::vector<long> VolCartesian::extractCellSubSet(std::array<int, 3> const &ijkM
 	\param[in] idxMax is the linear index of the upper bound
 	\result The linear indices of the cell subset.
 */
-std::vector<long> VolCartesian::extractCellSubSet(int const &idxMin, int const &idxMax)
+std::vector<long> VolCartesian::extractCellSubSet(int idxMin, int idxMax)
 {
 	return extractCellSubSet(getCellCartesianId(idxMin), getCellCartesianId(idxMax));
 }
@@ -1577,7 +1577,7 @@ std::vector<long> VolCartesian::extractVertexSubSet(std::array<int, 3> const &ij
 	\param[in] idxMax is the linear index of the upper bound
 	\result The linear indices of the vertex subset.
 */
-std::vector<long> VolCartesian::extractVertexSubSet(int const &idxMin, int const &idxMax)
+std::vector<long> VolCartesian::extractVertexSubSet(int idxMin, int idxMax)
 {
 	return extractVertexSubSet(getVertexCartesianId(idxMin), getVertexCartesianId(idxMax));
 }

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -1625,7 +1625,7 @@ void VolCartesian::setOrigin(const std::array<double, 3> &origin)
 
 	\param[in] translation is the translation vector
  */
-void VolCartesian::translate(std::array<double, 3> translation)
+void VolCartesian::translate(const std::array<double, 3> &translation)
 {
 	for (int n = 0; n < 3; ++n) {
 		m_minCoords[n] += translation[n];
@@ -1685,7 +1685,7 @@ void VolCartesian::setLengths(const std::array<double, 3> &lengths)
 
 	\param[in] scaling is the scaling factor vector
  */
-void VolCartesian::scale(std::array<double, 3> scaling)
+void VolCartesian::scale(const std::array<double, 3> &scaling)
 {
 	for (int n = 0; n < 3; ++n) {
 		m_maxCoords[n] = m_minCoords[n] + scaling[n] * (m_maxCoords[n] - m_minCoords[n]);

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -105,10 +105,10 @@ public:
 	std::array<int, 3> locateClosestCellCartesian(std::array<double,3> const &point) const;
 
 	std::vector<long> extractCellSubSet(std::array<int, 3> const &ijkMin, std::array<int, 3> const &ijkMax);
-	std::vector<long> extractCellSubSet(int const &idxMin, int const &idxMax);
+	std::vector<long> extractCellSubSet(int idxMin, int idxMax);
 	std::vector<long> extractCellSubSet(std::array<double, 3> const &pointMin, std::array<double, 3> const &pointMax);
 	std::vector<long> extractVertexSubSet(std::array<int, 3> const &ijkMin, std::array<int, 3> const &ijkMax);
-	std::vector<long> extractVertexSubSet(int const &idxMin, int const &idxMax);
+	std::vector<long> extractVertexSubSet(int idxMin, int idxMax);
 	std::vector<long> extractVertexSubSet(std::array<double, 3> const &pointMin, std::array<double, 3> const &pointMax);
 
 	std::array<double, 3> getOrigin() const;
@@ -128,13 +128,13 @@ public:
 
 	long getCellLinearId(int i, int j, int k) const;
 	long getCellLinearId(const std::array<int, 3> &ijk) const;
-	std::array<int, 3> getCellCartesianId(long const &idx) const;
+	std::array<int, 3> getCellCartesianId(long idx) const;
 	bool isCellCartesianIdValid(const std::array<int, 3> &ijk) const;
 	long getVertexLinearId(int i, int j, int k) const;
 	long getVertexLinearId(const std::array<int, 3> &ijk) const;
-	std::array<int, 3> getVertexCartesianId(long const &idx) const;
-	std::array<int, 3> getVertexCartesianId(long const &cellIdx, int const &vertex) const;
-	std::array<int, 3> getVertexCartesianId(const std::array<int, 3> &cellIjk, int const &vertex) const;
+	std::array<int, 3> getVertexCartesianId(long idx) const;
+	std::array<int, 3> getVertexCartesianId(long cellIdx, int vertex) const;
+	std::array<int, 3> getVertexCartesianId(const std::array<int, 3> &cellIjk, int vertex) const;
 	bool isVertexCartesianIdValid(const std::array<int, 3> &ijk) const;
 
 protected:

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -113,10 +113,10 @@ public:
 
 	std::array<double, 3> getOrigin() const;
 	void setOrigin(const std::array<double, 3> &origin);
-	void translate(std::array<double, 3> translation) override;
+	void translate(const std::array<double, 3> &translation) override;
 	std::array<double, 3> getLengths() const;
 	void setLengths(const std::array<double, 3> &lengths);
-	void scale(std::array<double, 3> scaling) override;
+	void scale(const std::array<double, 3> &scaling) override;
 
 	std::vector<double> convertToVertexData(const std::vector<double> &cellData) const;
 	std::vector<double> convertToCellData(const std::vector<double> &nodeData) const;

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -87,7 +87,7 @@ VolOctree::VolOctree()
 	\param length is the length of the domain
 	\param dh is the maximum allowed cell size of the initial refinement
 */
-VolOctree::VolOctree(int dimension, std::array<double, 3> origin, double length, double dh)
+VolOctree::VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh)
 	: VolOctree(PatchManager::AUTOMATIC_ID, dimension, origin, length, dh)
 {
 }
@@ -101,7 +101,7 @@ VolOctree::VolOctree(int dimension, std::array<double, 3> origin, double length,
 	\param length is the length of the domain
 	\param dh is the maximum allowed cell size of the initial refinement
 */
-VolOctree::VolOctree(int id, int dimension, std::array<double, 3> origin, double length, double dh)
+VolOctree::VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh)
 	: VolumeKernel(id, dimension, false)
 {
 	// Create the tree

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2240,7 +2240,7 @@ void VolOctree::setOrigin(const std::array<double, 3> &origin)
 
 	\param[in] translation is the translation vector
  */
-void VolOctree::translate(std::array<double, 3> translation)
+void VolOctree::translate(const std::array<double, 3> &translation)
 {
 	m_tree->setOrigin(m_tree->getOrigin() + translation);
 
@@ -2304,7 +2304,7 @@ void VolOctree::setLength(double length)
 
 	\param[in] scaling is the scaling factor vector
  */
-void VolOctree::scale(std::array<double, 3> scaling)
+void VolOctree::scale(const std::array<double, 3> &scaling)
 {
 	bool uniformScaling = true;
 	uniformScaling &= (std::abs(scaling[0] - scaling[1]) > 1e-14);

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -110,10 +110,10 @@ public:
 
 	std::array<double, 3> getOrigin() const;
 	void setOrigin(const std::array<double, 3> &origin);
-	void translate(std::array<double, 3> translation) override;
+	void translate(const std::array<double, 3> &translation) override;
 	double getLength() const;
 	void setLength(double length);
-	void scale(std::array<double, 3> scaling) override;
+	void scale(const std::array<double, 3> &scaling) override;
 
 	void updateAdjacencies(const std::vector<long> &cellIds) override;
 

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -66,8 +66,8 @@ public:
 	};
 
 	VolOctree();
-	VolOctree(int dimension, std::array<double, 3> origin, double length, double dh);
-	VolOctree(int id, int dimension, std::array<double, 3> origin, double length, double dh);
+	VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh);
+	VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh);
 	VolOctree(std::unique_ptr<PabloUniform> &&tree, std::unique_ptr<PabloUniform> *adopter = nullptr);
 	VolOctree(int id, std::unique_ptr<PabloUniform> &&tree, std::unique_ptr<PabloUniform> *adopter = nullptr);
 	VolOctree(std::istream &stream);

--- a/src/voloctree/voloctree_mapper.hpp
+++ b/src/voloctree/voloctree_mapper.hpp
@@ -88,7 +88,7 @@ private:
          * \param[in] _globalId Global octant id
          * \param[in] _rank Octant rank
          */
-        OctantIR(Octant _octant, long _id, long _globalId = -1, int _rank = -1)
+        OctantIR(const Octant &_octant, long _id, long _globalId = -1, int _rank = -1)
         {
             octant = _octant;
             id = _id;

--- a/test/RBF/test_RBF_00002.cpp
+++ b/test/RBF/test_RBF_00002.cpp
@@ -61,7 +61,7 @@ std::array<double,3> modulation( std::array<double,3> P, std::array<double,3> am
  * @param[in] tras amplitude in three space directions
  * @return displacement vector
  */
-std::array<double,3> traslation( std::array<double,3> P, std::array<double,3> tras){
+std::array<double,3> traslation( const std::array<double,3> &P, const std::array<double,3> &tras){
 	BITPIT_UNUSED(P);
     return tras;
 }
@@ -73,7 +73,7 @@ std::array<double,3> traslation( std::array<double,3> P, std::array<double,3> tr
  * @param[in] rot rotation vector
  * @return displacement vector
  */
-std::array<double,3> rotation( std::array<double,3> P, std::array<double,3> origin, std::array<double,3> rot ){
+std::array<double,3> rotation( const std::array<double,3> &P, const std::array<double,3> &origin, const std::array<double,3> &rot ){
 
     return crossProduct( rot, P - origin ) ;
 


### PR DESCRIPTION
Fixes the following type of misusages of references:
 - small and trivially-copyable types passed by reference;
 - large types passed by value;
 - usage of copies in for-range loops.