### PR TITLE
discretization: optimize assembly of stencil solver

### DIFF
--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -718,12 +718,26 @@ void SparseMatrix::getRowPattern(long row, ConstProxyVector<long> *pattern) cons
 */
 ConstProxyVector<double> SparseMatrix::getRowValues(long row) const
 {
+    ConstProxyVector<double> values;
+    getRowValues(row, &values);
+
+    return values;
+}
+
+/**
+* Get the values of the specified row.
+*
+* \param row is the row
+* \param values on output will contain the values of the specified row
+*/
+void SparseMatrix::getRowValues(long row, ConstProxyVector<double> *values) const
+{
     const std::size_t *rowExtent = m_pattern.indices(row);
 
     const double *rowValues = m_values.data() + rowExtent[0];
     const std::size_t nRowValues = rowExtent[1] - rowExtent[0];
 
-    return ConstProxyVector<double>(rowValues, nRowValues);
+    values->set(rowValues, nRowValues);
 }
 
 }

--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -688,12 +688,26 @@ void SparseMatrix::addRow(long nRowNZ, const long *rowPattern, const double *row
 */
 ConstProxyVector<long> SparseMatrix::getRowPattern(long row) const
 {
+    ConstProxyVector<long> pattern;
+    getRowPattern(row, &pattern);
+
+    return pattern;
+}
+
+/**
+* Get the pattern of the specified row.
+*
+* \param row is the row
+* \param pattern on output will contain the pattern of the specified row
+*/
+void SparseMatrix::getRowPattern(long row, ConstProxyVector<long> *pattern) const
+{
     const std::size_t *rowExtent = m_pattern.indices(row);
 
     const long *rowPattern = m_pattern.data() + rowExtent[0];
     const std::size_t rowPatternSize = rowExtent[1] - rowExtent[0];
 
-    return ConstProxyVector<long>(rowPattern, rowPatternSize);
+    pattern->set(rowPattern, rowPatternSize);
 }
 
 /**

--- a/src/LA/system_matrix.hpp
+++ b/src/LA/system_matrix.hpp
@@ -93,6 +93,7 @@ public:
 
     ConstProxyVector<double> getRowValues(long row) const;
     ConstProxyVector<long> getRowPattern(long row) const;
+    void getRowPattern(long row, ConstProxyVector<long> *pattern) const;
 
 protected:
     long m_nRows;

--- a/src/LA/system_matrix.hpp
+++ b/src/LA/system_matrix.hpp
@@ -92,6 +92,8 @@ public:
     void addRow(long nRowNZ, const long *rowPattern, const double *rowValues);
 
     ConstProxyVector<double> getRowValues(long row) const;
+    void getRowValues(long row, ConstProxyVector<double> *values) const;
+
     ConstProxyVector<long> getRowPattern(long row) const;
     void getRowPattern(long row, ConstProxyVector<long> *pattern) const;
 

--- a/src/LA/system_matrix.hpp
+++ b/src/LA/system_matrix.hpp
@@ -91,11 +91,11 @@ public:
     void addRow(const std::vector<long> &rowPattern, const std::vector<double> &rowValues);
     void addRow(long nRowNZ, const long *rowPattern, const double *rowValues);
 
-    ConstProxyVector<double> getRowValues(long row) const;
-    void getRowValues(long row, ConstProxyVector<double> *values) const;
-
     ConstProxyVector<long> getRowPattern(long row) const;
     void getRowPattern(long row, ConstProxyVector<long> *pattern) const;
+
+    ConstProxyVector<double> getRowValues(long row) const;
+    void getRowValues(long row, ConstProxyVector<double> *values) const;
 
 protected:
     long m_nRows;

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -304,7 +304,7 @@ void SystemSolver::assembly(const SparseMatrix &matrix)
     matrixFill(matrix);
 
     // Initialize RHS and solution vectors
-    vectorsInit();
+    vectorsCreate();
 
     // The system is now assembled
     m_assembled = true;
@@ -768,9 +768,9 @@ void SystemSolver::matrixUpdate(const std::vector<long> &rows, const SparseMatri
 }
 
 /*!
- * Initialize rhs and solution vectors.
+ * Create rhs and solution vectors.
  */
-void SystemSolver::vectorsInit()
+void SystemSolver::vectorsCreate()
 {
     PetscInt nRows;
     PetscInt nColumns;

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -316,10 +316,11 @@ void SystemSolver::assembly(const SparseMatrix &matrix)
  * Only the values of the system matrix can be updated, once the system is
  * assembled its pattern cannot be modified.
  *
+ * \param nRows is the number of rows that will be updated
  * \param rows are the global indices of the rows that will be updated
  * \param elements are the elements that will be used to update the rows
  */
-void SystemSolver::update(const std::vector<long> &rows, const SparseMatrix &elements)
+void SystemSolver::update(std::size_t nRows, const long *rows, const SparseMatrix &elements)
 {
     // Check if the element storage is assembled
     if (!elements.isAssembled()) {
@@ -332,7 +333,7 @@ void SystemSolver::update(const std::vector<long> &rows, const SparseMatrix &ele
     }
 
     // Update matrix
-    matrixUpdate(rows, elements);
+    matrixUpdate(nRows, rows, elements);
 }
 
 /**
@@ -684,10 +685,11 @@ void SystemSolver::matrixFill(const SparseMatrix &matrix)
  * The contents of the specified rows will be replaced by the specified
  * elements.
  *
+ * \param nRows is the number of rows that will be updated
  * \param rows are the global indices of the rows that will be updated
  * \param elements are the elements that will be used to update the rows
  */
-void SystemSolver::matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements)
+void SystemSolver::matrixUpdate(std::size_t nRows, const long *rows, const SparseMatrix &elements)
 {
     const long maxRowElements = std::max(elements.getMaxRowNZCount(), 0L);
 
@@ -701,7 +703,7 @@ void SystemSolver::matrixUpdate(const std::vector<long> &rows, const SparseMatri
     rowGlobalOffset = 0;
 #endif
 
-    for (std::size_t n = 0; n < rows.size(); ++n) {
+    for (std::size_t n = 0; n < nRows; ++n) {
         ConstProxyVector<long> rowPattern = elements.getRowPattern(n);
         const int nRowElements = rowPattern.size();
         if (nRowElements == 0) {
@@ -739,7 +741,7 @@ void SystemSolver::matrixUpdate(const std::vector<long> &rows, const SparseMatri
     std::vector<PetscInt> rawRowPattern(maxRowElements);
     std::vector<PetscScalar> rawRowValues(maxRowElements);
 
-    for (std::size_t n = 0; n < rows.size(); ++n) {
+    for (std::size_t n = 0; n < nRows; ++n) {
         ConstProxyVector<double> rowValues = elements.getRowValues(n);
         const int nRowElements = rowValues.size();
         if (nRowElements == 0) {

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -300,7 +300,7 @@ void SystemSolver::assembly(const SparseMatrix &matrix)
 #endif
 
     // Initialize matrix
-    matrixInit(matrix);
+    matrixCreate(matrix);
     matrixFill(matrix);
 
     // Initialize RHS and solution vectors
@@ -507,11 +507,11 @@ void SystemSolver::postKSPSolveActions()
 }
 
 /*!
- * Initializes the matrix.
+ * Create the matrix.
  *
  * \param matrix is the matrix
  */
-void SystemSolver::matrixInit(const SparseMatrix &matrix)
+void SystemSolver::matrixCreate(const SparseMatrix &matrix)
 {
     long nRows = matrix.getRowCount();
     long nCols = matrix.getColCount();

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -90,7 +90,7 @@ public:
     void assembly(const SparseMatrix &matrix);
     bool isAssembled() const;
 
-    void update(const std::vector<long> &rows, const SparseMatrix &elements);
+    void update(std::size_t nRows, const long *rows, const SparseMatrix &elements);
 
     void setUp();
     bool isSetUp() const;
@@ -141,7 +141,7 @@ protected:
 
     void matrixCreate(const SparseMatrix &matrix);
     void matrixFill(const SparseMatrix &matrix);
-    void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
+    void matrixUpdate(std::size_t nRows, const long *rows, const SparseMatrix &elements);
 
     void vectorsCreate();
     void vectorsPermute(bool invert);

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -143,7 +143,7 @@ protected:
     void matrixFill(const SparseMatrix &matrix);
     void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
 
-    void vectorsInit();
+    void vectorsCreate();
     void vectorsPermute(bool invert);
     void vectorsFill(const std::vector<double> &rhs, std::vector<double> *solution);
     void vectorsExport(std::vector<double> *solution);

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -143,11 +143,7 @@ protected:
     void matrixFill(const SparseMatrix &matrix);
     void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
 
-#if BITPIT_ENABLE_MPI == 1
-    void vectorsInit(const std::vector<long> &ghosts);
-#else
     void vectorsInit();
-#endif
     void vectorsPermute(bool invert);
     void vectorsFill(const std::vector<double> &rhs, std::vector<double> *solution);
     void vectorsExport(std::vector<double> *solution);

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -139,7 +139,7 @@ protected:
     KSPOptions m_KSPOptions;
     KSPStatus m_KSPStatus;
 
-    void matrixInit(const SparseMatrix &matrix);
+    void matrixCreate(const SparseMatrix &matrix);
     void matrixFill(const SparseMatrix &matrix);
     void matrixUpdate(const std::vector<long> &rows, const SparseMatrix &elements);
 

--- a/src/discretization/stencil_solver.cpp
+++ b/src/discretization/stencil_solver.cpp
@@ -162,7 +162,7 @@ void StencilScalarSolver::update(const std::vector<long> &rows, const std::vecto
 
     elements.assembly();
 
-    SystemSolver::update(rows, elements);
+    SystemSolver::update(rows.size(), rows.data(), elements);
 }
 
 /*!

--- a/src/discretization/stencil_solver.cpp
+++ b/src/discretization/stencil_solver.cpp
@@ -85,6 +85,7 @@ void StencilScalarSolver::assembly(const std::vector<StencilScalar> &stencils)
 {
     assembly(MPI_COMM_SELF, false, stencils);
 }
+
 /*!
 * Initialize the stencil solver.
 *

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -36,6 +36,47 @@
 
 namespace bitpit {
 
+class StencilSolverAssembler : public SystemMatrixAssembler {
+
+public:
+    StencilSolverAssembler(const std::vector<StencilScalar> *stencils);
+#if BITPIT_ENABLE_MPI==1
+    StencilSolverAssembler(MPI_Comm communicator, bool partitioned, const std::vector<StencilScalar> *stencils);
+#endif
+
+    long getRowCount() const override;
+    long getColCount() const override;
+
+#if BITPIT_ENABLE_MPI==1
+    long getRowGlobalCount() const override;
+    long getColGlobalCount() const override;
+
+    long getRowGlobalOffset() const override;
+    long getColGlobalOffset() const override;
+#endif
+
+    long getRowNZCount(long row) const override;
+    long getMaxRowNZCount() const override;
+
+    void getRowPattern(long row, ConstProxyVector<long> *pattern) const override;
+    void getRowValues(long row, ConstProxyVector<double> *values) const override;
+
+    double getRowConstant(long row) const;
+
+protected:
+    const std::vector<StencilScalar> *m_stencils;
+
+    long m_nDOFs;
+    long m_maxRowNZ;
+
+#if BITPIT_ENABLE_MPI==1
+    long m_nGlobalDOFs;
+    long m_globalDOFOffset;
+#endif
+
+
+};
+
 class StencilScalarSolver : public SystemSolver {
 
 public:


### PR DESCRIPTION
The class "StencilSolverAssembler" makes it possible to assemble the stencil solver without first assembly a temporary matrix. This reduce both the computational time and the memory requirements of the stencil solver. 

The class "StencilSolverAssembler" is used by the solver internally, thus the API has not changed.