### PR TITLE
LA: fix clearing system solver data structures

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -336,7 +336,7 @@ void SystemSolver::clear()
         m_setUp = false;
     }
 
-    if (!isAssembled()) {
+    if (isAssembled()) {
         MatDestroy(&m_A);
         VecDestroy(&m_rhs);
         VecDestroy(&m_solution);


### PR DESCRIPTION
The condition to detect if system data structures need to be cleared was inverted.