### PR TITLE
discretization: add a stencil to handle variable-length weights

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -123,12 +123,12 @@ long SystemSparseMatrixAssembler::getColGlobalOffset() const
 /*!
  * Get the number of non-zero elements in the specified row.
  *
- * \param row is the row of the matrix
+ * \param rowIndex is the index of the row in the assembler
  * \result The number of non-zero elements in the specified row.
  */
-long SystemSparseMatrixAssembler::getRowNZCount(long row) const
+long SystemSparseMatrixAssembler::getRowNZCount(long rowIndex) const
 {
-    return m_matrix->getRowNZCount(row);
+    return m_matrix->getRowNZCount(rowIndex);
 }
 
 /**
@@ -144,23 +144,23 @@ long SystemSparseMatrixAssembler::getMaxRowNZCount() const
 /*!
  * Get the values of the specified row.
  *
- * \param row is the row of the matrix
+ * \param rowIndex is the index of the row in the assembler
  * \param pattern on output will contain the values of the specified row
  */
-void SystemSparseMatrixAssembler::getRowPattern(long row, ConstProxyVector<long> *pattern) const
+void SystemSparseMatrixAssembler::getRowPattern(long rowIndex, ConstProxyVector<long> *pattern) const
 {
-    m_matrix->getRowPattern(row, pattern);
+    m_matrix->getRowPattern(rowIndex, pattern);
 }
 
 /*!
  * Get the values of the specified row.
  *
- * \param row is the row of the matrix
+ * \param rowIndex is the index of the row in the assembler
  * \param pattern on output will contain the values of the specified row
  */
-void SystemSparseMatrixAssembler::getRowValues(long row, ConstProxyVector<double> *values) const
+void SystemSparseMatrixAssembler::getRowValues(long rowIndex, ConstProxyVector<double> *values) const
 {
-    m_matrix->getRowValues(row, values);
+    m_matrix->getRowValues(rowIndex, values);
 }
 
 /*!

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -80,9 +80,9 @@ long SystemSparseMatrixAssembler::getColCount() const
 
 #if BITPIT_ENABLE_MPI==1
 /*!
- * Get the number of global rows of the matrix.
+ * Get the global number of rows of the matrix.
  *
- * \result The number of global rows of the matrix.
+ * \result The global number of rows of the matrix.
  */
 long SystemSparseMatrixAssembler::getRowGlobalCount() const
 {
@@ -90,9 +90,9 @@ long SystemSparseMatrixAssembler::getRowGlobalCount() const
 }
 
 /*!
- * Get the number of global columns of the matrix.
+ * Get the global number of columns of the matrix.
  *
- * \result The number of global columns of the matrix.
+ * \result The global number of columns of the matrix.
  */
 long SystemSparseMatrixAssembler::getColGlobalCount() const
 {
@@ -156,7 +156,7 @@ void SystemSparseMatrixAssembler::getRowPattern(long rowIndex, ConstProxyVector<
  * Get the values of the specified row.
  *
  * \param rowIndex is the index of the row in the assembler
- * \param pattern on output will contain the values of the specified row
+ * \param values on output will contain the values of the specified row
  */
 void SystemSparseMatrixAssembler::getRowValues(long rowIndex, ConstProxyVector<double> *values) const
 {

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -552,7 +552,7 @@ void SystemSolver::update(const SparseMatrix &elements)
  * \param rows are the indices of the rows that will be updated
  * \param elements are the elements that will be used to update the rows
  */
-void SystemSolver::update(std::size_t nRows, const long *rows, const SparseMatrix &elements)
+void SystemSolver::update(long nRows, const long *rows, const SparseMatrix &elements)
 {
     // Check if the element storage is assembled
     if (!elements.isAssembled()) {
@@ -587,7 +587,7 @@ void SystemSolver::update(const SystemMatrixAssembler &assembler)
  * \param rows are the indices of the rows that will be updated
  * \param assembler is the matrix assembler for the rows that will be updated
  */
-void SystemSolver::update(std::size_t nRows, const long *rows, const SystemMatrixAssembler &assembler)
+void SystemSolver::update(long nRows, const long *rows, const SystemMatrixAssembler &assembler)
 {
     // Check if the system is assembled
     if (!isAssembled()) {
@@ -947,7 +947,7 @@ void SystemSolver::matrixFill(const SystemMatrixAssembler &assembler)
  * from 0 to (nRows - 1).
  * \param assembler is the matrix assembler for the rows that will be updated
  */
-void SystemSolver::matrixUpdate(std::size_t nRows, const long *rows, const SystemMatrixAssembler &assembler)
+void SystemSolver::matrixUpdate(long nRows, const long *rows, const SystemMatrixAssembler &assembler)
 {
     // Update element values
     long rowGlobalOffset;
@@ -964,7 +964,7 @@ void SystemSolver::matrixUpdate(std::size_t nRows, const long *rows, const Syste
 
     ConstProxyVector<long> rowPattern;
     ConstProxyVector<double> rowValues;
-    for (std::size_t n = 0; n < nRows; ++n) {
+    for (long n = 0; n < nRows; ++n) {
         assembler.getRowValues(n, &rowValues);
         const int nRowElements = rowValues.size();
         if (nRowElements == 0) {

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -149,9 +149,9 @@ public:
     bool isAssembled() const;
 
     void update(const SparseMatrix &elements);
-    void update(std::size_t nRows, const long *rows, const SparseMatrix &elements);
+    void update(long nRows, const long *rows, const SparseMatrix &elements);
     void update(const SystemMatrixAssembler &assembler);
-    void update(std::size_t nRows, const long *rows, const SystemMatrixAssembler &assembler);
+    void update(long nRows, const long *rows, const SystemMatrixAssembler &assembler);
 
     void setUp();
     bool isSetUp() const;
@@ -202,7 +202,7 @@ protected:
 
     void matrixCreate(const SystemMatrixAssembler &assembler);
     void matrixFill(const SystemMatrixAssembler &assembler);
-    void matrixUpdate(std::size_t nRows, const long *rows, const SystemMatrixAssembler &assembler);
+    void matrixUpdate(long nRows, const long *rows, const SystemMatrixAssembler &assembler);
 
     void vectorsCreate();
     void vectorsPermute(bool invert);

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -79,11 +79,11 @@ public:
     virtual long getColGlobalOffset() const = 0;
 #endif
 
-    virtual long getRowNZCount(long row) const = 0;
+    virtual long getRowNZCount(long rowIndex) const = 0;
     virtual long getMaxRowNZCount() const = 0;
 
-    virtual void getRowPattern(long row, ConstProxyVector<long> *pattern) const = 0;
-    virtual void getRowValues(long row, ConstProxyVector<double> *values) const = 0;
+    virtual void getRowPattern(long rowIndex, ConstProxyVector<long> *pattern) const = 0;
+    virtual void getRowValues(long rowIndex, ConstProxyVector<double> *values) const = 0;
 
 protected:
     SystemMatrixAssembler() = default;
@@ -106,11 +106,11 @@ public:
     long getColGlobalOffset() const override;
 #endif
 
-    long getRowNZCount(long row) const override;
+    long getRowNZCount(long rowIndex) const override;
     long getMaxRowNZCount() const override;
 
-    void getRowPattern(long row, ConstProxyVector<long> *pattern) const override;
-    void getRowValues(long row, ConstProxyVector<double> *values) const override;
+    void getRowPattern(long rowIndex, ConstProxyVector<long> *pattern) const override;
+    void getRowValues(long rowIndex, ConstProxyVector<double> *values) const override;
 
 protected:
     const SparseMatrix *m_matrix;

--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -84,4 +84,12 @@ do {                  \
 #   define BITPIT_DEPRECATED(func) func
 #endif
 
+
+/*!
+ * \ingroup common_macro
+ *
+ * Comma.
+ */
+#define BITPIT_COMMA ,
+
 #endif

--- a/src/containers/flatVector2D.hpp
+++ b/src/containers/flatVector2D.hpp
@@ -122,7 +122,9 @@ public:
     void pushBack(const std::vector<T> &subArray);
     void pushBack(std::size_t subArraySize, const T *subArray);
     void pushBackItem(const T& value);
+    void pushBackItem(T &&value);
     void pushBackItem(std::size_t i, const T& value);
+    void pushBackItem(std::size_t i, T &&value);
 
     void popBack();
     void popBackItem();
@@ -132,12 +134,14 @@ public:
     void eraseItem(std::size_t i, std::size_t j);
 
     void setItem(std::size_t i, std::size_t j, const T &value);
+    void setItem(std::size_t i, std::size_t j, T &&value);
     T & getItem(std::size_t i, std::size_t j);
     const T & getItem(std::size_t i, std::size_t j) const;
     const T * get(std::size_t i) const;
     T * get(std::size_t i);
 
     void rawSetItem(std::size_t k, const T &value);
+    void rawSetItem(std::size_t k, T &&value);
     T & rawGetItem(std::size_t k);
     const T & rawGetItem(std::size_t k) const;
 

--- a/src/containers/flatVector2D.tpp
+++ b/src/containers/flatVector2D.tpp
@@ -670,6 +670,23 @@ void FlatVector2D<T>::pushBackItem(const T& value)
 }
 
 /*!
+    Adds an item to the last vector.
+
+    Adds an item at the end of to the last vector.
+
+    \param value is the value that will be added
+*/
+template <class T>
+void FlatVector2D<T>::pushBackItem(T &&value)
+{
+    m_index.back()++;
+
+    m_v.emplace_back();
+    T &storedValue = m_v.back();
+    storedValue = std::move(value);
+}
+
+/*!
     Adds an item to the specified vector.
 
     Adds an item at the end of to the specified last vector.
@@ -683,6 +700,28 @@ void FlatVector2D<T>::pushBackItem(std::size_t i, const T &value)
     assert(isIndexValid(i));
 
     m_v.insert(m_v.begin() + m_index[i+1], value);
+
+    std::size_t nIndexes = m_index.size();
+    for (std::size_t k = i + 1; k < nIndexes; ++k) {
+        m_index[k]++;
+    }
+}
+
+
+/*!
+    Adds an item to the specified vector.
+
+    Adds an item at the end of to the specified last vector.
+
+    \param i is the index of the vector
+    \param value is the value that will be added
+*/
+template <class T>
+void FlatVector2D<T>::pushBackItem(std::size_t i, T &&value)
+{
+    assert(isIndexValid(i));
+
+    m_v.insert(m_v.begin() + m_index[i+1], std::move(value));
 
     std::size_t nIndexes = m_index.size();
     for (std::size_t k = i + 1; k < nIndexes; ++k) {
@@ -798,6 +837,20 @@ void FlatVector2D<T>::setItem(std::size_t i, std::size_t j, const T &value)
 }
 
 /*!
+    Sets the value of the specified item in a vector.
+
+    \param i is the index of the vector
+    \param j is the index of the item that will be removed
+    \param value is the value that will be set
+*/
+template <class T>
+void FlatVector2D<T>::setItem(std::size_t i, std::size_t j, T &&value)
+{
+    assert(isIndexValid(i, j));
+    (*this)[i][j] = std::move(value);
+}
+
+/*!
     Gets a reference of the specified item in a vector.
 
     \param i is the index of the vector
@@ -863,6 +916,18 @@ template <class T>
 void FlatVector2D<T>::rawSetItem(std::size_t k, const T &value)
 {
     m_v[k] = value;
+}
+
+/*!
+    Sets the value of the specified item in a vector.
+
+    \param k is the raw index
+    \param value is the value that will be set
+*/
+template <class T>
+void FlatVector2D<T>::rawSetItem(std::size_t k, T &&value)
+{
+    m_v[k] = std::move(value);
 }
 
 /*!

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -201,7 +201,7 @@ public:
 
     void set(T *data, std::size_t size);
     template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    void set(std::vector<T_no_cv> &&storage);
+    T_no_cv * set(std::vector<T_no_cv> &&storage);
 
     void clear();
     void swap(ProxyVector &other);

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -202,6 +202,8 @@ public:
     void set(T *data, std::size_t size);
     template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
     T_no_cv * set(std::vector<T_no_cv> &&storage);
+    template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
+    T_no_cv * set(std::size_t size);
 
     void clear();
     void swap(ProxyVector &other);

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -262,11 +262,13 @@ void ProxyVector<T>::set(T *data, std::size_t size)
 */
 template<typename T>
 template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
-void ProxyVector<T>::set(std::vector<T_no_cv> &&storage)
+typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::vector<T_no_cv> &&storage)
 {
     m_storage = std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(std::move(storage)));
     m_data    = m_storage->data();
     m_size    = m_storage->size();
+
+    return m_storage->data();
 }
 
 /*!

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -272,6 +272,27 @@ typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::vector<T_no_cv> &&st
 }
 
 /*!
+    Sets the content of the container.
+
+    \param size is the number of elements the storage should be able to
+    contain
+*/
+template<typename T>
+template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
+typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::size_t size)
+{
+    if (!m_storage) {
+        m_storage = std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(size));
+    } else {
+        m_storage->resize(size);
+    }
+    m_data = m_storage->data();
+    m_size = m_storage->size();
+
+    return m_storage->data();
+}
+
+/*!
     Clear content.
 */
 template<typename T>

--- a/src/discretization/stencil.cpp
+++ b/src/discretization/stencil.cpp
@@ -35,6 +35,7 @@ namespace bitpit {
 
 template class DiscreteStencil<double>;
 template class DiscreteStencil<std::array<double, 3>>;
+template class DiscreteStencil<std::vector<double>>;
 
 }
 

--- a/src/discretization/stencil.cpp
+++ b/src/discretization/stencil.cpp
@@ -146,6 +146,5 @@ void project(const bitpit::StencilVector &stencil, const std::array<double, 3> &
         weight = ::dotProduct(weight, direction) * direction;
     }
 
-    bitpit::StencilVector::weight_type &constant = stencil_projection->getConstant();
-    constant = ::dotProduct(constant, direction) * direction;
+    stencil_projection->setConstant(::dotProduct(stencil_projection->getConstant(), direction) * direction);
 }

--- a/src/discretization/stencil.cpp
+++ b/src/discretization/stencil.cpp
@@ -65,6 +65,60 @@ void DiscreteStencil<std::vector<double>>::rawCopyValue(const std::vector<double
     }
 }
 
+/*!
+* Optimize the specified weight.
+*
+* \param bucket is the bucket of the weight to check
+* \param pos is the position of the weight to check
+* \param tolerance is the tolerance that will be used for the check
+* \result Returns true if the whole weight is neglibile
+*/
+template<>
+bool DiscreteStencil<std::array<double, 3>>::optimizeWeight(int bucket, std::size_t pos, double tolerance)
+{
+    std::array<double, 3> &weight = m_weights.getItem(bucket, pos);
+    int nItems = weight.size();
+
+    int nNegligibleItems = 0;
+    for (int k = 0; k < nItems; ++k) {
+        if (std::abs(weight[k] - m_zero[k]) > tolerance) {
+            continue;
+        }
+
+        weight[k] = m_zero[k];
+        ++nNegligibleItems;
+    }
+
+    return (nNegligibleItems == nItems);
+}
+
+/*!
+* Optimize the specified weight.
+*
+* \param bucket is the bucket of the weight to check
+* \param pos is the position of the weight to check
+* \param tolerance is the tolerance that will be used for the check
+* \result Returns true if the whole weight is neglibile
+*/
+template<>
+bool DiscreteStencil<std::vector<double>>::optimizeWeight(int bucket, std::size_t pos, double tolerance)
+{
+    std::vector<double> &weight = m_weights.getItem(bucket, pos);
+    int nItems = weight.size();
+
+    int nNegligibleItems = 0;
+    for (int k = 0; k < nItems; ++k) {
+        if (std::abs(weight[k] - m_zero[k]) > tolerance) {
+            continue;
+        }
+
+        weight[k] = m_zero[k];
+        ++nNegligibleItems;
+    }
+
+    return (nNegligibleItems == nItems);
+}
+
 }
 
 /*!

--- a/src/discretization/stencil.cpp
+++ b/src/discretization/stencil.cpp
@@ -37,6 +37,34 @@ template class DiscreteStencil<double>;
 template class DiscreteStencil<std::array<double, 3>>;
 template class DiscreteStencil<std::vector<double>>;
 
+/**
+ * Set the source value into the target.
+ *
+ * \param source is the value that will be set
+ * \param[out] target on output will contain the source value
+ */
+template<>
+void DiscreteStencil<std::array<double, 3>>::rawCopyValue(const std::array<double, 3> &source, std::array<double, 3> *target)
+{
+    std::copy_n(source.data(), source.size(), target->data());
+}
+
+/**
+ * Set the source value into the target.
+ *
+ * \param source is the value that will be set
+ * \param[out] target on output will contain the source value
+ */
+template<>
+void DiscreteStencil<std::vector<double>>::rawCopyValue(const std::vector<double> &source, std::vector<double> *target)
+{
+    if (source.size() == target->size()) {
+        std::copy_n(source.data(), source.size(), target->data());
+    } else {
+        target->assign(source.begin(), source.end());
+    }
+}
+
 }
 
 /*!

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -207,6 +207,7 @@ namespace bitpit {
 
 typedef DiscreteStencil<double> StencilScalar;
 typedef DiscreteStencil<std::array<double, 3>> StencilVector;
+typedef DiscreteStencil<std::vector<double>> StencilBlock;
 
 }
 
@@ -216,6 +217,7 @@ namespace bitpit {
 
 extern template class DiscreteStencil<double>;
 extern template class DiscreteStencil<std::array<double, 3>>;
+extern template class DiscreteStencil<std::vector<double>>;
 
 }
 #endif

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -126,7 +126,9 @@ public:
     const weight_t * weightData() const;
     const FlatVector2D<weight_t> & getWeights() const;
     void setWeight(std::size_t pos, const weight_t &weight);
+    void setWeight(std::size_t pos, weight_t &&weight);
     void setWeight(int bucket, std::size_t pos, const weight_t &weight);
+    void setWeight(int bucket, std::size_t pos, weight_t &&weight);
     void sumWeight(std::size_t pos, const weight_t &value);
     void sumWeight(int bucket, std::size_t pos, const weight_t &value);
     void zeroWeight(std::size_t pos);
@@ -137,15 +139,20 @@ public:
     void rawSetWeight(std::size_t pos, const weight_t &weight);
 
     void setItem(std::size_t pos, long id, const weight_t &weight);
+    void setItem(std::size_t pos, long id, weight_t &&weight);
     void setItem(int bucket, std::size_t pos, long id, const weight_t &weight);
+    void setItem(int bucket, std::size_t pos, long id, weight_t &&weight);
     void sumItem(long id, const weight_t &value);
     void sumItem(int bucket, long id, const weight_t &value);
     void appendItem(long id, const weight_t &weight);
+    void appendItem(long id, weight_t &&weight);
     void appendItem(int bucket, long id, const weight_t &weight);
+    void appendItem(int bucket, long id, weight_t &&weight);
 
     weight_t & getConstant();
     const weight_t & getConstant() const;
     void setConstant(const weight_t &value);
+    void setConstant(weight_t &&value);
     void sumConstant(const weight_t &value);
     void zeroConstant();
 
@@ -166,6 +173,7 @@ public:
 
 private:
     static void rawCopyValue(const weight_t &source, weight_t *destination);
+    static void rawMoveValue(weight_t &&source, weight_t *destination);
 
     weight_t m_zero;
     FlatVector2D<long> m_pattern;

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -129,6 +129,8 @@ public:
     void setWeight(int bucket, std::size_t pos, const weight_t &weight);
     void sumWeight(std::size_t pos, const weight_t &value);
     void sumWeight(int bucket, std::size_t pos, const weight_t &value);
+    void zeroWeight(std::size_t pos);
+    void zeroWeight(int bucket, std::size_t pos);
 
     weight_t & rawGetWeight(std::size_t pos);
     const weight_t & rawGetWeight(std::size_t pos) const;

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -145,6 +145,7 @@ public:
     const weight_t & getConstant() const;
     void setConstant(const weight_t &value);
     void sumConstant(const weight_t &value);
+    void zeroConstant();
 
     void flatten();
     void optimize(double tolerance = 1.e-12);

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -165,6 +165,8 @@ public:
     DiscreteStencil<weight_t> & operator-=(const DiscreteStencil<weight_t> &other);
 
 private:
+    static void rawCopyValue(const weight_t &source, weight_t *destination);
+
     weight_t m_zero;
     FlatVector2D<long> m_pattern;
     FlatVector2D<weight_t> m_weights;
@@ -180,6 +182,13 @@ private:
     bool isWeightNeglibile(int bucket, std::size_t pos, double tolerance = 1.e-12);
 
 };
+
+// Methods for the spcializations
+template<>
+void DiscreteStencil<std::array<double, 3>>::rawCopyValue(const std::array<double, 3> &source, std::array<double, 3> *target);
+
+template<>
+void DiscreteStencil<std::vector<double>>::rawCopyValue(const std::vector<double> &source, std::vector<double> *target);
 
 }
 

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -183,11 +183,7 @@ private:
     weight_t * findWeight(int bucket, long id);
     const weight_t * findWeight(int bucket, long id) const;
 
-    template<typename U = weight_t, typename std::enable_if<std::is_fundamental<U>::value>::type * = nullptr>
-    bool isWeightNeglibile(int bucket, std::size_t pos, double tolerance = 1.e-12);
-
-    template<typename U = weight_t, typename std::enable_if<!std::is_fundamental<U>::value>::type * = nullptr>
-    bool isWeightNeglibile(int bucket, std::size_t pos, double tolerance = 1.e-12);
+    bool optimizeWeight(int bucket, std::size_t pos, double tolerance = 1.e-12);
 
 };
 
@@ -197,6 +193,12 @@ void DiscreteStencil<std::array<double, 3>>::rawCopyValue(const std::array<doubl
 
 template<>
 void DiscreteStencil<std::vector<double>>::rawCopyValue(const std::vector<double> &source, std::vector<double> *target);
+
+template<>
+bool DiscreteStencil<std::array<double, 3>>::optimizeWeight(int bucket, std::size_t pos, double tolerance);
+
+template<>
+bool DiscreteStencil<std::vector<double>>::optimizeWeight(int bucket, std::size_t pos, double tolerance);
 
 }
 

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -230,7 +230,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 }
 
 /*!
-* Initialize the stencil
+* Initialize the stencil.
 *
 * \param nBuckets is the number of buckets in the stencil
 * \param bucketSizes are the sizes of the buckets in the stencil
@@ -247,7 +247,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 }
 
 /*!
-* Initialize the stencil
+* Initialize the stencil.
 *
 * \param nBuckets is the number of buckets in the stencil
 * \param bucketSizes are the sizes of the buckets in the stencil
@@ -265,11 +265,10 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 }
 
 /*!
-* Initialize the stencil
+* Initialize the stencil.
 *
 * \param other is another stencil of the same time, whose items will be used
 * to initialize this stencil
-* \param zero is the value to be used as zero
 */
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(const DiscreteStencil<weight_t> &other)
@@ -848,6 +847,9 @@ void DiscreteStencil<weight_t>::sumItem(int bucket, long id, const weight_t &val
 * If the stencil has more than one bucket, the item will be appended to the
 * first bucket.
 *
+* The item will be appended to the stencil also if the stencil already
+* contains an item with the same id.
+*
 * \param id is the index that will be set
 * \param weight is the weight that will be set
 */
@@ -863,6 +865,9 @@ void DiscreteStencil<weight_t>::appendItem(long id, const weight_t &weight)
 * If the stencil has more than one bucket, the item will be appended to the
 * first bucket.
 *
+* The item will be appended to the stencil also if the stencil already
+* contains an item with the same id.
+*
 * \param id is the index that will be set
 * \param weight is the weight that will be set
 */
@@ -874,6 +879,9 @@ void DiscreteStencil<weight_t>::appendItem(long id, weight_t &&weight)
 
 /*!
 * Append an item the stencil.
+*
+* The item will be appended to the stencil also if the stencil already
+* contains an item with the same id.
 *
 * \param bucket is the bucket that will updated
 * \param id is the index that will be set
@@ -888,6 +896,9 @@ void DiscreteStencil<weight_t>::appendItem(int bucket, long id, const weight_t &
 
 /*!
 * Append an item the stencil.
+*
+* The item will be appended to the stencil also if the stencil already
+* contains an item with the same id.
 *
 * \param bucket is the bucket that will updated
 * \param id is the index that will be set

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -197,7 +197,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, int nBucketItems, const
     m_zero = zero;
     m_pattern.initialize(nBuckets, nBucketItems, NULL_ID);
     m_weights.initialize(nBuckets, nBucketItems, zero);
-    m_constant = m_zero;
+    zeroConstant();
 }
 
 /*!
@@ -226,7 +226,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
     m_zero = zero;
     m_pattern.initialize(nBuckets, bucketSizes, NULL_ID);
     m_weights.initialize(nBuckets, bucketSizes, zero);
-    m_constant = m_zero;
+    zeroConstant();
 }
 
 /*!
@@ -243,7 +243,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
     m_zero = zero;
     m_pattern.initialize(nBuckets, bucketSizes, pattern);
     m_weights.initialize(nBuckets, bucketSizes, zero);
-    m_constant = m_zero;
+    zeroConstant();
 }
 
 /*!
@@ -261,7 +261,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
     m_zero = zero;
     m_pattern.initialize(nBuckets, bucketSizes, pattern);
     m_weights.initialize(nBuckets, bucketSizes, weights);
-    m_constant = m_zero;
+    zeroConstant();
 }
 
 /*!
@@ -834,6 +834,15 @@ void DiscreteStencil<weight_t>::sumConstant(const weight_t &value)
 }
 
 /*!
+* Zero the constant associated to the stencil.
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::zeroConstant()
+{
+    m_constant = m_zero;
+}
+
+/*!
 * Clears the items of the stencil.
 *
 * Removes all items from the stencil (which are destroyed), leaving each
@@ -849,7 +858,7 @@ void DiscreteStencil<weight_t>::clear(bool release)
     m_pattern.clearItems(release);
     m_weights.clearItems(release);
 
-    m_constant = m_zero;
+    zeroConstant();
 }
 
 /*!

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -608,6 +608,20 @@ void DiscreteStencil<weight_t>::setWeight(std::size_t pos, const weight_t &weigh
 /*!
 * Set the value of the specified weight of the stencil.
 *
+* If the stencil has more than one bucket, the first bucket will be considered.
+*
+* \param pos is the position of the weight
+* \param weight is the value that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::setWeight(std::size_t pos, weight_t &&weight)
+{
+    setWeight(0, pos, std::move(weight));
+}
+
+/*!
+* Set the value of the specified weight of the stencil.
+*
 * \param bucket is the bucket that will updated
 * \param pos is the position of the weight
 * \param weight is the value that will be set
@@ -616,6 +630,19 @@ template<typename weight_t>
 void DiscreteStencil<weight_t>::setWeight(int bucket, std::size_t pos, const weight_t &weight)
 {
     m_weights.setItem(bucket, pos, weight);
+}
+
+/*!
+* Set the value of the specified weight of the stencil.
+*
+* \param bucket is the bucket that will updated
+* \param pos is the position of the weight
+* \param weight is the value that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::setWeight(int bucket, std::size_t pos, weight_t &&weight)
+{
+    m_weights.setItem(bucket, pos, std::move(weight));
 }
 
 /*!
@@ -730,6 +757,21 @@ void DiscreteStencil<weight_t>::setItem(std::size_t pos, long id, const weight_t
 /*!
 * Set the specified item of the stencil.
 *
+* If the stencil has more than one bucket, the first bucket will be considered.
+*
+* \param pos is the position of the weight
+* \param id is the index that will be set
+* \param weight is the weight that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::setItem(std::size_t pos, long id, weight_t &&weight)
+{
+    setItem(0, pos, id, std::move(weight));
+}
+
+/*!
+* Set the specified item of the stencil.
+*
 * \param bucket is the bucket that will updated
 * \param pos is the position of the weight
 * \param id is the index that will be set
@@ -740,6 +782,21 @@ void DiscreteStencil<weight_t>::setItem(int bucket, std::size_t pos, long id, co
 {
     setPattern(bucket, pos, id);
     setWeight(bucket, pos, weight);
+}
+
+/*!
+* Set the specified item of the stencil.
+*
+* \param bucket is the bucket that will updated
+* \param pos is the position of the weight
+* \param id is the index that will be set
+* \param weight is the weight that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::setItem(int bucket, std::size_t pos, long id, weight_t &&weight)
+{
+    setPattern(bucket, pos, id);
+    setWeight(bucket, pos, std::move(weight));
 }
 
 /*!
@@ -803,6 +860,21 @@ void DiscreteStencil<weight_t>::appendItem(long id, const weight_t &weight)
 /*!
 * Append an item the stencil.
 *
+* If the stencil has more than one bucket, the item will be appended to the
+* first bucket.
+*
+* \param id is the index that will be set
+* \param weight is the weight that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::appendItem(long id, weight_t &&weight)
+{
+    appendItem(0, id, std::move(weight));
+}
+
+/*!
+* Append an item the stencil.
+*
 * \param bucket is the bucket that will updated
 * \param id is the index that will be set
 * \param weight is the weight that will be set
@@ -812,6 +884,20 @@ void DiscreteStencil<weight_t>::appendItem(int bucket, long id, const weight_t &
 {
     m_pattern.pushBackItem(bucket, id);
     m_weights.pushBackItem(bucket, weight);
+}
+
+/*!
+* Append an item the stencil.
+*
+* \param bucket is the bucket that will updated
+* \param id is the index that will be set
+* \param weight is the weight that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::appendItem(int bucket, long id, weight_t &&weight)
+{
+    m_pattern.pushBackItem(bucket, id);
+    m_weights.pushBackItem(bucket, std::move(weight));
 }
 
 /*!
@@ -845,6 +931,17 @@ template<typename weight_t>
 void DiscreteStencil<weight_t>::setConstant(const weight_t &value)
 {
     rawCopyValue(value, &m_constant);
+}
+
+/*!
+* Set the value of the constant associated to the stencil.
+*
+* \param value is the value that will be set
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::setConstant(weight_t &&value)
+{
+    rawMoveValue(std::move(value), &m_constant);
 }
 
 /*!
@@ -1052,6 +1149,18 @@ template<typename weight_t>
 void DiscreteStencil<weight_t>::rawCopyValue(const weight_t &source, weight_t *target)
 {
     *target = source;
+}
+
+/**
+ * Move the source value into the target.
+ *
+ * \param[in,out] source is the value that will be moved
+ * \param[out] target on output will contain the source value
+ */
+template<typename weight_t>
+void DiscreteStencil<weight_t>::rawMoveValue(weight_t &&source, weight_t *target)
+{
+    *target = std::move(source);
 }
 
 /*!

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -646,6 +646,31 @@ void DiscreteStencil<weight_t>::sumWeight(int bucket, std::size_t pos, const wei
     weight += value;
 }
 
+/*!
+* Zeros the weight at the specified position of the stencil.
+*
+* If the stencil has more than one bucket, the first bucket will be considered.
+*
+* \param pos is the position of the weight
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::zeroWeight(std::size_t pos)
+{
+    zeroWeight(0, pos);
+}
+
+/*!
+* Zero the weight at the specified position of the stencil.
+*
+* \param bucket is the bucket that will updated
+* \param pos is the position of the weight
+*/
+template<typename weight_t>
+void DiscreteStencil<weight_t>::zeroWeight(int bucket, std::size_t pos)
+{
+    weight_type &weight = m_weights.getItem(bucket, pos);
+    weight = m_zero;
+}
 
 /*!
 * Get a reference to the specified weight of the stencil.

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -194,7 +194,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const weight_t &zero)
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(int nBuckets, int nBucketItems, const weight_t &zero)
 {
-    m_zero = zero;
+    rawCopyValue(zero, &m_zero);
     m_pattern.initialize(nBuckets, nBucketItems, NULL_ID);
     m_weights.initialize(nBuckets, nBucketItems, zero);
     zeroConstant();
@@ -223,7 +223,7 @@ void DiscreteStencil<weight_t>::initialize(const std::vector<std::size_t> &bucke
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *bucketSizes, const weight_t &zero)
 {
-    m_zero = zero;
+    rawCopyValue(zero, &m_zero);
     m_pattern.initialize(nBuckets, bucketSizes, NULL_ID);
     m_weights.initialize(nBuckets, bucketSizes, zero);
     zeroConstant();
@@ -240,7 +240,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *bucketSizes, const long *pattern, const weight_t &zero)
 {
-    m_zero = zero;
+    rawCopyValue(zero, &m_zero);
     m_pattern.initialize(nBuckets, bucketSizes, pattern);
     m_weights.initialize(nBuckets, bucketSizes, zero);
     zeroConstant();
@@ -258,7 +258,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *bucketSizes, const long *pattern, const weight_t *weights, const weight_t &zero)
 {
-    m_zero = zero;
+    rawCopyValue(zero, &m_zero);
     m_pattern.initialize(nBuckets, bucketSizes, pattern);
     m_weights.initialize(nBuckets, bucketSizes, weights);
     zeroConstant();
@@ -274,10 +274,10 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(const DiscreteStencil<weight_t> &other)
 {
-    m_zero = other.m_zero;
+    rawCopyValue(other.m_zero, &m_zero);
     m_pattern.initialize(other.m_pattern);
     m_weights.initialize(other.m_weights);
-    m_constant = other.m_constant;
+    rawCopyValue(other.m_constant, &m_constant);
 }
 
 /*!
@@ -669,7 +669,7 @@ template<typename weight_t>
 void DiscreteStencil<weight_t>::zeroWeight(int bucket, std::size_t pos)
 {
     weight_type &weight = m_weights.getItem(bucket, pos);
-    weight = m_zero;
+    rawCopyValue(m_zero, &weight);
 }
 
 /*!
@@ -844,7 +844,7 @@ weight_t & DiscreteStencil<weight_t>::getConstant()
 template<typename weight_t>
 void DiscreteStencil<weight_t>::setConstant(const weight_t &value)
 {
-    m_constant = value;
+    rawCopyValue(value, &m_constant);
 }
 
 /*!
@@ -864,7 +864,7 @@ void DiscreteStencil<weight_t>::sumConstant(const weight_t &value)
 template<typename weight_t>
 void DiscreteStencil<weight_t>::zeroConstant()
 {
-    m_constant = m_zero;
+    rawCopyValue(m_zero, &m_constant);
 }
 
 /*!
@@ -963,7 +963,7 @@ void DiscreteStencil<weight_t>::zero()
     const std::size_t nItems = size();
     for (std::size_t n = 0; n < nItems; ++n) {
         weight_t &weight = m_weights.rawGetItem(n);
-        weight = m_zero;
+        rawCopyValue(m_zero, &weight);
     }
 
     setConstant(m_zero);
@@ -1040,6 +1040,18 @@ const weight_t * DiscreteStencil<weight_t>::findWeight(int bucket, long id) cons
     }
 
     return nullptr;
+}
+
+/**
+ * Copy the source value into the target.
+ *
+ * \param source is the value that will be copied
+ * \param[out] target on output will contain the source value
+ */
+template<typename weight_t>
+void DiscreteStencil<weight_t>::rawCopyValue(const weight_t &source, weight_t *target)
+{
+    *target = source;
 }
 
 /*!

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -1016,7 +1016,8 @@ void DiscreteStencil<weight_t>::optimize(double tolerance)
     for (int i = 0; i < nBuckets; ++i) {
         std::size_t nBucketItems = size(i);
         for (std::size_t j = 0; j < nBucketItems; ++j) {
-            if (isWeightNeglibile(i, j, tolerance)) {
+            bool isWeightNeglibile = optimizeWeight(i, j, tolerance);
+            if (isWeightNeglibile) {
                 m_pattern.eraseItem(i, j);
                 m_weights.eraseItem(i, j);
                 --j;
@@ -1077,31 +1078,17 @@ void DiscreteStencil<weight_t>::zero()
     setConstant(m_zero);
 }
 /*!
-* Check if the specified weight is neglibile accordingly the specified tolerance.
+* Optimize the specified weight.
 *
 * \param bucket is the bucket of the weight to check
 * \param pos is the position of the weight to check
 * \param tolerance is the tolerance that will be used for the check
+* \result Returns true if the whole weight is neglibile
 */
 template<typename weight_t>
-template<typename U, typename std::enable_if<std::is_fundamental<U>::value>::type *>
-bool DiscreteStencil<weight_t>::isWeightNeglibile(int bucket, std::size_t pos, double tolerance)
+bool DiscreteStencil<weight_t>::optimizeWeight(int bucket, std::size_t pos, double tolerance)
 {
-    return (std::abs(m_weights.getItem(bucket, pos)) <= tolerance);
-}
-
-/*!
-* Check if the specified weight is neglibile accordingly the specified tolerance.
-*
-* \param bucket is the bucket of the weight to check
-* \param pos is the position of the weight to check
-* \param tolerance is the tolerance that will be used for the check
-*/
-template<typename weight_t>
-template<typename U, typename std::enable_if<!std::is_fundamental<U>::value>::type *>
-bool DiscreteStencil<weight_t>::isWeightNeglibile(int bucket, std::size_t pos, double tolerance)
-{
-    return (norm2(m_weights.getItem(bucket, pos)) <= tolerance);
+    return (std::abs(m_weights.getItem(bucket, pos) - m_zero) <= tolerance);
 }
 
 /*!

--- a/src/discretization/stencil_solver.cpp
+++ b/src/discretization/stencil_solver.cpp
@@ -22,378 +22,45 @@
  *
 \*---------------------------------------------------------------------------*/
 
+#define __BITPIT_STENCIL_SOLVER_SRC__
+
 #include "stencil_solver.hpp"
 
 namespace bitpit {
 
+// Explicit instantization
+template class DiscretizationStencilSolverAssembler<StencilScalar>;
+
+template class DiscretizationStencilSolver<StencilScalar>;
+
+// Template specializations
+
 /*!
- * \class StencilSolverAssembler
- * \ingroup discretization
+ * Initialize block size.
  *
- * \brief The StencilSolverAssembler class defines an assembler for
- * building the stencil solver.
+ * Block size can only be initialized once.
  */
+template<>
+void DiscretizationStencilSolverAssembler<StencilScalar>::initializeBlockSize()
+{
+    assert(m_blockSize == -1);
 
-#if BITPIT_ENABLE_MPI==1
+    m_blockSize = 1;
+}
+
 /*!
- * Constructor.
+ * Get the raw value of the specified element.
  *
- * \param stencils are the stencils
+ * \param element is the stencil element
+ * \param item is the requested block item
+ * \result The values of the specified weight.
  */
-StencilSolverAssembler::StencilSolverAssembler(const std::vector<StencilScalar> *stencils)
-    : StencilSolverAssembler(MPI_COMM_SELF, false, stencils)
+template<>
+double DiscretizationStencilSolverAssembler<StencilScalar>::getRawValue(const StencilScalar::weight_type &element, int item) const
 {
-}
+    BITPIT_UNUSED(item);
 
-/*!
- * Constructor.
- *
- * \param communicator is the MPI communicator
- * \param partitioned controls if the matrix is partitioned
- * \param stencils are the stencils
- */
-StencilSolverAssembler::StencilSolverAssembler(MPI_Comm communicator, bool partitioned, const std::vector<StencilScalar> *stencils)
-#else
-/*!
- * Constructor.
- *
- * \param stencils are the stencils
- */
-StencilSolverAssembler::StencilSolverAssembler(const std::vector<StencilScalar> *stencils)
-#endif
-    : SystemMatrixAssembler(), m_stencils(stencils)
-{
-    // Count the DOFs
-    m_nDOFs = m_stencils->size();
-
-#if BITPIT_ENABLE_MPI==1
-    m_nGlobalDOFs = m_nDOFs;
-    if (partitioned) {
-        MPI_Allreduce(MPI_IN_PLACE, &m_nGlobalDOFs, 1, MPI_LONG, MPI_SUM, communicator);
-    }
-#endif
-
-    // Count maximum non-zero elements
-    m_maxRowNZ = 0;
-    for (const StencilScalar &stencil : *m_stencils) {
-        m_maxRowNZ = std::max(m_maxRowNZ, (long) stencil.size());
-    }
-
-#if BITPIT_ENABLE_MPI==1
-    // Get offsets
-    m_globalDOFOffset = 0;
-    if (partitioned) {
-        int nProcessors;
-        MPI_Comm_size(communicator, &nProcessors);
-
-        std::vector<long> nRankDOFs(nProcessors);
-        MPI_Allgather(&m_nDOFs, 1, MPI_LONG, nRankDOFs.data(), 1, MPI_LONG, communicator);
-
-        int rank;
-        MPI_Comm_rank(communicator, &rank);
-        for (int i = 0; i < rank; ++i) {
-            m_globalDOFOffset += nRankDOFs[i];
-        }
-    }
-#endif
-}
-
-/*!
- * Get the number of rows of the matrix.
- *
- * \result The number of rows of the matrix.
- */
-long StencilSolverAssembler::getRowCount() const
-{
-    return m_nDOFs;
-}
-
-/*!
- * Get the number of columns of the matrix.
- *
- * \result The number of columns of the matrix.
- */
-long StencilSolverAssembler::getColCount() const
-{
-    return m_nDOFs;
-}
-
-#if BITPIT_ENABLE_MPI==1
-/*!
- * Get the number of global rows of the matrix.
- *
- * \result The number of global rows of the matrix.
- */
-long StencilSolverAssembler::getRowGlobalCount() const
-{
-    return m_nGlobalDOFs;
-}
-
-/*!
- * Get the number of global columns of the matrix.
- *
- * \result The number of global columns of the matrix.
- */
-long StencilSolverAssembler::getColGlobalCount() const
-{
-    return m_nGlobalDOFs;
-}
-
-/*!
- * Get global row offset.
- *
- * \result The global row offset.
- */
-long StencilSolverAssembler::getRowGlobalOffset() const
-{
-    return m_globalDOFOffset;
-}
-
-/*!
- * Get global column offset.
- *
- * \result The global column offset.
- */
-long StencilSolverAssembler::getColGlobalOffset() const
-{
-    return m_globalDOFOffset;
-}
-#endif
-
-/*!
- * Get the number of non-zero elements in the specified row.
- *
- * \param row is the row of the matrix
- * \result The number of non-zero elements in the specified row.
- */
-long StencilSolverAssembler::getRowNZCount(long row) const
-{
-    return (*m_stencils)[row].size();
-}
-
-/**
- * Get the maximum number of non-zero elements per row.
- *
- * \result The maximum number of non-zero elements per row.
- */
-long StencilSolverAssembler::getMaxRowNZCount() const
-{
-    return m_maxRowNZ;
-}
-
-/*!
- * Get the values of the specified row.
- *
- * \param row is the row of the matrix
- * \param pattern on output will contain the values of the specified row
- */
-void StencilSolverAssembler::getRowPattern(long row, ConstProxyVector<long> *pattern) const
-{
-    const StencilScalar &stencil = (*m_stencils)[row];
-    pattern->set(stencil.patternData(), stencil.size());
-}
-
-/*!
- * Get the values of the specified row.
- *
- * \param row is the row of the matrix
- * \param pattern on output will contain the values of the specified row
- */
-void StencilSolverAssembler::getRowValues(long row, ConstProxyVector<double> *values) const
-{
-    const StencilScalar &stencil = (*m_stencils)[row];
-    values->set(stencil.weightData(), stencil.size());
-}
-
-/*!
- * Get the constant associated with the specified row.
- *
- * \param row is the row of the matrix
- * \result The constant associated with the specified row.
- */
-double StencilSolverAssembler::getRowConstant(long row) const
-{
-    const StencilScalar &stencil = (*m_stencils)[row];
-
-    return stencil.getConstant();
-}
-
-/*!
-* \ingroup discretization
-* \class StencilScalarSolver
-*
-* The StencilScalarSolver class handles the solution of linear systems assembled
-* from scalar discretization stencils.
-*/
-
-/*!
-* Constuctor
-*
-* \param debug if this parameter is set to true, debug informations will be
-* printed when solving the system
-*/
-StencilScalarSolver::StencilScalarSolver(bool debug)
-    : SystemSolver("", debug)
-{
-}
-
-/*!
-* Constuctor
-*
-* \param prefix is the prefix string to prepend to all option requests
-* \param debug if this parameter is set to true, debug informations will be
-* printed when solving the system
-*/
-StencilScalarSolver::StencilScalarSolver(const std::string &prefix, bool debug)
-    : SystemSolver(prefix, debug)
-{
-}
-
-/*!
-* Clear the stencil solver
-*
-* \param release if it's true the memory hold by the stencil solver will be
-* released, otherwise the stencil solver will be cleared but its memory will
-* not be relased
- */
-void StencilScalarSolver::clear(bool release)
-{
-    SystemSolver::clear();
-
-    if (release) {
-        std::vector<double>().swap(m_constants);
-    } else {
-        m_constants.clear();
-    }
-}
-
-#if BITPIT_ENABLE_MPI==1
-/*!
-* Assembly the stencil solver.
-*
-* \param stencils are the stencils
-*/
-void StencilScalarSolver::assembly(const std::vector<StencilScalar> &stencils)
-{
-    assembly(MPI_COMM_SELF, false, stencils);
-}
-
-/*!
-* Initialize the stencil solver.
-*
-* \param partitioned controls if the matrix is partitioned
-* \param communicator is the MPI communicator
-* \param stencils are the stencils
-*/
-void StencilScalarSolver::assembly(MPI_Comm communicator, bool partitioned, const std::vector<StencilScalar> &stencils)
-#else
-/*!
-* Initialize the stencil solver.
-*
-* \param stencils are the stencils
-*/
-void StencilScalarSolver::assembly(const std::vector<StencilScalar> &stencils)
-#endif
-{
-    // Assembly system
-#if BITPIT_ENABLE_MPI==1
-    StencilSolverAssembler assembler(communicator, partitioned, &stencils);
-    SystemSolver::assembly(communicator, partitioned, assembler);
-#else
-    StencilSolverAssembler assembler(&stencils);
-    SystemSolver::assembly(assembler);
-#endif
-
-    // Set constants
-    long nRows = assembler.getRowCount();
-    m_constants.resize(nRows);
-    for (long n = 0; n < nRows; ++n) {
-        m_constants[n] = assembler.getRowConstant(n);
-    }
-}
-
-/*!
- * Update all the stencil solver.
- *
- * Only the values of the system matrix and the values of the constants can be
- * updated, once the system is initialized its pattern cannot be modified.
- *
- * \param stencils are the stencils that will be used to update the rows
- */
-void StencilScalarSolver::update(const std::vector<StencilScalar> &stencils)
-{
-    update(getRowCount(), nullptr, stencils);
-}
-
-/*!
- * Update the stencil solver.
- *
- * Only the values of the system matrix and the values of the constants can be
- * updated, once the system is initialized its pattern cannot be modified.
- *
- * \param rows are the global indices of the rows that will be updated
- * \param stencils are the stencils that will be used to update the rows
- */
-void StencilScalarSolver::update(const std::vector<long> &rows, const std::vector<StencilScalar> &stencils)
-{
-    update(rows.size(), rows.data(), stencils);
-}
-
-/*!
- * Update the stencil solver.
- *
- * Only the values of the system matrix and the values of the constants can be
- * updated, once the system is initialized its pattern cannot be modified.
- *
- * \param nRows is the number of rows that will be updated
- * \param rows are the indices of the rows that will be updated,
- * if a null pointer is passed, the rows that will be updated are the
- * rows from 0 to (nRows - 1).
- * \param stencils are the stencils that will be used to update the rows
- */
-void StencilScalarSolver::update(std::size_t nRows, const long *rows, const std::vector<StencilScalar> &stencils)
-{
-    // Assembly system
-#if BITPIT_ENABLE_MPI==1
-    StencilSolverAssembler assembler(getCommunicator(), isPartitioned(), &stencils);
-#else
-    StencilSolverAssembler assembler(&stencils);
-#endif
-    SystemSolver::update(nRows, rows, assembler);
-
-    // Set constants
-    for (std::size_t n = 0; n < nRows; ++n) {
-        long row;
-        if (rows) {
-            row = rows[n];
-        } else {
-            row = n;
-        }
-
-        m_constants[row] = assembler.getRowConstant(n);
-    }
-}
-
-/*!
-* Solve the system.
-*/
-void StencilScalarSolver::solve()
-{
-    // Check if the stencil solver is assembled
-    if (!isAssembled()) {
-        throw std::runtime_error("Unable to solve the system. The stencil solver is not yet assembled.");
-    }
-
-    // Subtract constant terms to the RHS
-    long nUnknowns = getRowCount();
-    double *raw_rhs = getRHSRawPtr();
-    for (long i = 0; i < nUnknowns; ++i) {
-        raw_rhs[i] -= m_constants[i];
-    }
-    restoreRHSRawPtr(raw_rhs);
-
-    // Solve the system
-    SystemSolver::solve();
+    return element;
 }
 
 }

--- a/src/discretization/stencil_solver.cpp
+++ b/src/discretization/stencil_solver.cpp
@@ -30,8 +30,10 @@ namespace bitpit {
 
 // Explicit instantization
 template class DiscretizationStencilSolverAssembler<StencilScalar>;
+template class DiscretizationStencilSolverAssembler<StencilVector>;
 
 template class DiscretizationStencilSolver<StencilScalar>;
+template class DiscretizationStencilSolver<StencilVector>;
 
 // Template specializations
 
@@ -61,6 +63,32 @@ double DiscretizationStencilSolverAssembler<StencilScalar>::getRawValue(const St
     BITPIT_UNUSED(item);
 
     return element;
+}
+
+/*!
+ * Initialize block size.
+ *
+ * Block size can only be initialized once.
+ */
+template<>
+void DiscretizationStencilSolverAssembler<StencilVector>::initializeBlockSize()
+{
+    assert(m_blockSize == -1);
+
+    m_blockSize = sizeof(typename StencilVector::weight_type) / sizeof(typename StencilVector::weight_type::value_type);
+}
+
+/*!
+ * Get the raw value of the specified element.
+ *
+ * \param element is the stencil element
+ * \param item is the requested block item
+ * \result The values of the specified weight.
+ */
+template<>
+double DiscretizationStencilSolverAssembler<StencilVector>::getRawValue(const StencilVector::weight_type &element, int item) const
+{
+    return element[item];
 }
 
 }

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -117,8 +117,10 @@ public:
 
     void clear(bool release = false);
     void assembly(const std::vector<stencil_t> &stencils);
+    void assembly(const StencilSolverAssembler &assembler);
 #if BITPIT_ENABLE_MPI==1
     void assembly(MPI_Comm communicator, bool partitioned, const std::vector<stencil_t> &stencils);
+    void assembly(MPI_Comm communicator, bool partitioned, const StencilSolverAssembler &assembler);
 #endif
     void update(const std::vector<stencil_t> &stencils);
     void update(const std::vector<long> &rows, const std::vector<stencil_t> &stencils);

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -138,6 +138,12 @@ void DiscretizationStencilSolverAssembler<StencilVector>::initializeBlockSize();
 template<>
 double DiscretizationStencilSolverAssembler<StencilVector>::getRawValue(const StencilVector::weight_type &element, int item) const;
 
+template<>
+void DiscretizationStencilSolverAssembler<StencilBlock>::initializeBlockSize();
+
+template<>
+double DiscretizationStencilSolverAssembler<StencilBlock>::getRawValue(const StencilBlock::weight_type &element, int item) const;
+
 }
 
 // Template implementation
@@ -148,9 +154,11 @@ namespace bitpit {
 
 typedef DiscretizationStencilSolverAssembler<StencilScalar> StencilScalarSolverAssembler;
 typedef DiscretizationStencilSolverAssembler<StencilVector> StencilVectorSolverAssembler;
+typedef DiscretizationStencilSolverAssembler<StencilBlock> StencilBlockSolverAssembler;
 
 typedef DiscretizationStencilSolver<StencilScalar> StencilScalarSolver;
 typedef DiscretizationStencilSolver<StencilVector> StencilVectorSolver;
+typedef DiscretizationStencilSolver<StencilBlock> StencilBlockSolver;
 
 }
 
@@ -160,9 +168,11 @@ namespace bitpit {
 
 extern template class DiscretizationStencilSolverAssembler<StencilScalar>;
 extern template class DiscretizationStencilSolverAssembler<StencilVector>;
+extern template class DiscretizationStencilSolverAssembler<StencilBlock>;
 
 extern template class DiscretizationStencilSolver<StencilScalar>;
 extern template class DiscretizationStencilSolver<StencilVector>;
+extern template class DiscretizationStencilSolver<StencilBlock>;
 
 }
 #endif

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -132,6 +132,12 @@ void DiscretizationStencilSolverAssembler<StencilScalar>::initializeBlockSize();
 template<>
 double DiscretizationStencilSolverAssembler<StencilScalar>::getRawValue(const StencilScalar::weight_type &element, int item) const;
 
+template<>
+void DiscretizationStencilSolverAssembler<StencilVector>::initializeBlockSize();
+
+template<>
+double DiscretizationStencilSolverAssembler<StencilVector>::getRawValue(const StencilVector::weight_type &element, int item) const;
+
 }
 
 // Template implementation
@@ -141,8 +147,10 @@ double DiscretizationStencilSolverAssembler<StencilScalar>::getRawValue(const St
 namespace bitpit {
 
 typedef DiscretizationStencilSolverAssembler<StencilScalar> StencilScalarSolverAssembler;
+typedef DiscretizationStencilSolverAssembler<StencilVector> StencilVectorSolverAssembler;
 
 typedef DiscretizationStencilSolver<StencilScalar> StencilScalarSolver;
+typedef DiscretizationStencilSolver<StencilVector> StencilVectorSolver;
 
 }
 
@@ -151,8 +159,10 @@ typedef DiscretizationStencilSolver<StencilScalar> StencilScalarSolver;
 namespace bitpit {
 
 extern template class DiscretizationStencilSolverAssembler<StencilScalar>;
+extern template class DiscretizationStencilSolverAssembler<StencilVector>;
 
 extern template class DiscretizationStencilSolver<StencilScalar>;
+extern template class DiscretizationStencilSolver<StencilVector>;
 
 }
 #endif

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -37,8 +37,18 @@
 
 namespace bitpit {
 
+class StencilSolverAssembler : public SystemMatrixAssembler {
+
+public:
+    virtual double getRowConstant(long rowIndex) const = 0;
+
+protected:
+    using SystemMatrixAssembler::SystemMatrixAssembler;
+
+};
+
 template<typename stencil_t>
-class DiscretizationStencilSolverAssembler : public SystemMatrixAssembler {
+class DiscretizationStencilSolverAssembler : public StencilSolverAssembler {
 
 public:
     DiscretizationStencilSolverAssembler(const std::vector<stencil_t> *stencils);
@@ -64,7 +74,7 @@ public:
 
     void getRowPattern(long rowIndex, ConstProxyVector<long> *pattern) const override;
     void getRowValues(long rowIndex, ConstProxyVector<double> *values) const override;
-    double getRowConstant(long rowIndex) const;
+    double getRowConstant(long rowIndex) const override;
 
 protected:
     const std::vector<stencil_t> *m_stencils;

--- a/src/discretization/stencil_solver.tpp
+++ b/src/discretization/stencil_solver.tpp
@@ -64,7 +64,7 @@ DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAsse
 template<typename stencil_t>
 DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAssembler(const std::vector<stencil_t> *stencils)
 #endif
-    : SystemMatrixAssembler(), m_stencils(stencils),
+    : StencilSolverAssembler(), m_stencils(stencils),
       m_blockSize(-1)
 {
     // Initialize block size

--- a/src/discretization/stencil_solver.tpp
+++ b/src/discretization/stencil_solver.tpp
@@ -1,0 +1,541 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include "stencil_solver.hpp"
+
+namespace bitpit {
+
+/*!
+ * \class DiscretizationStencilSolverAssembler
+ * \ingroup discretization
+ *
+ * \brief The DiscretizationStencilSolverAssembler class defines an assembler
+ * for building the stencil solver.
+ */
+
+#if BITPIT_ENABLE_MPI==1
+/*!
+ * Constructor.
+ *
+ * \param stencils are the stencils
+ */
+template<typename stencil_t>
+DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAssembler(const std::vector<stencil_t> *stencils)
+    : DiscretizationStencilSolverAssembler(MPI_COMM_SELF, false, stencils)
+{
+}
+
+/*!
+ * Constructor.
+ *
+ * \param communicator is the MPI communicator
+ * \param partitioned controls if the matrix is partitioned
+ * \param stencils are the stencils
+ */
+template<typename stencil_t>
+DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAssembler(MPI_Comm communicator, bool partitioned, const std::vector<stencil_t> *stencils)
+#else
+/*!
+ * Constructor.
+ *
+ * \param stencils are the stencils
+ */
+template<typename stencil_t>
+DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAssembler(const std::vector<stencil_t> *stencils)
+#endif
+    : SystemMatrixAssembler(), m_stencils(stencils),
+      m_blockSize(-1)
+{
+    // Initialize block size
+    initializeBlockSize();
+
+    // Count the DOFs
+    m_nDOFs = stencils->size();
+
+#if BITPIT_ENABLE_MPI==1
+    m_nGlobalDOFs = m_nDOFs;
+    if (partitioned) {
+        MPI_Allreduce(MPI_IN_PLACE, &m_nGlobalDOFs, 1, MPI_LONG, MPI_SUM, communicator);
+    }
+#endif
+
+    // Count maximum non-zero elements
+    m_maxRowNZ = 0;
+    for (long n = 0; n < getRowCount(); ++n) {
+        m_maxRowNZ = std::max(getRowNZCount(n), m_maxRowNZ);
+    }
+
+#if BITPIT_ENABLE_MPI==1
+    // Get offsets
+    m_globalDOFOffset = 0;
+    if (partitioned) {
+        int nProcessors;
+        MPI_Comm_size(communicator, &nProcessors);
+
+        std::vector<long> nRankDOFs(nProcessors);
+        MPI_Allgather(&m_nDOFs, 1, MPI_LONG, nRankDOFs.data(), 1, MPI_LONG, communicator);
+
+        int rank;
+        MPI_Comm_rank(communicator, &rank);
+        for (int i = 0; i < rank; ++i) {
+            m_globalDOFOffset += nRankDOFs[i];
+        }
+    }
+#endif
+}
+
+/*!
+ * Get the stencil block size.
+ *
+ * \result The stencil block size.
+ */
+template<typename stencil_t>
+int DiscretizationStencilSolverAssembler<stencil_t>::getBlockSize() const
+{
+    return m_blockSize;
+}
+
+/*!
+ * Get the number of rows of the matrix.
+ *
+ * \result The number of rows of the matrix.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getRowCount() const
+{
+    return m_nDOFs;
+}
+
+/*!
+ * Get the number of columns of the matrix.
+ *
+ * \result The number of columns of the matrix.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getColCount() const
+{
+    return m_nDOFs;
+}
+
+#if BITPIT_ENABLE_MPI==1
+/*!
+ * Get the number of global rows of the matrix.
+ *
+ * \result The number of global rows of the matrix.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getRowGlobalCount() const
+{
+    return m_nGlobalDOFs;
+}
+
+/*!
+ * Get the number of global columns of the matrix.
+ *
+ * \result The number of global columns of the matrix.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getColGlobalCount() const
+{
+    return m_nGlobalDOFs;
+}
+
+/*!
+ * Get global row offset.
+ *
+ * \result The global row offset.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getRowGlobalOffset() const
+{
+    return m_globalDOFOffset;
+}
+
+/*!
+ * Get global column offset.
+ *
+ * \result The global column offset.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getColGlobalOffset() const
+{
+    return m_globalDOFOffset;
+}
+#endif
+
+/*!
+ * Get the number of non-zero elements in the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \result The number of non-zero elements in the specified row.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getRowNZCount(long rowIndex) const
+{
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+    std::size_t stencilSize = stencil.size();
+
+    return (m_blockSize * stencilSize);
+}
+
+/**
+ * Get the maximum number of non-zero elements per row.
+ *
+ * \result The maximum number of non-zero elements per row.
+ */
+template<typename stencil_t>
+long DiscretizationStencilSolverAssembler<stencil_t>::getMaxRowNZCount() const
+{
+    return m_maxRowNZ;
+}
+
+/*!
+ * Get the values of the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \param pattern on output will contain the values of the specified row
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolverAssembler<stencil_t>::getRowPattern(long rowIndex, ConstProxyVector<long> *pattern) const
+{
+    // Get stencil information
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+    std::size_t stencilSize = stencil.size();
+
+    // Get pattern
+    const long *patternData = stencil.patternData();
+    if (m_blockSize == 1) {
+        pattern->set(patternData, stencilSize);
+    } else {
+        std::size_t expandedPatternSize = m_blockSize * stencilSize;
+        long *expandedPatternStorage = pattern->set(expandedPatternSize);
+
+        std::size_t expandedPatternIdx = 0;
+        for (std::size_t k = 0; k < stencilSize; ++k) {
+            long patternBlockOffset = patternData[k] * m_blockSize;
+            for (int i = 0; i < m_blockSize; ++i) {
+                expandedPatternStorage[expandedPatternIdx++] = patternBlockOffset + i;
+            }
+        }
+    }
+}
+
+/*!
+ * Get the values of the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \param pattern on output will contain the values of the specified row
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolverAssembler<stencil_t>::getRowValues(long rowIndex, ConstProxyVector<double> *values) const
+{
+    _getRowValues(rowIndex, values);
+}
+
+/*!
+ * Get the values of the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \param pattern on output will contain the values of the specified row
+ */
+template<typename stencil_t>
+template<typename U, typename std::enable_if<std::is_fundamental<U>::value>::type *>
+void DiscretizationStencilSolverAssembler<stencil_t>::_getRowValues(long rowIndex, ConstProxyVector<double> *values) const
+{
+    // Get stencil information
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+
+    // Get values
+    values->set(stencil.weightData(), stencil.size());
+}
+
+/*!
+ * Get the values of the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \param pattern on output will contain the values of the specified row
+ */
+template<typename stencil_t>
+template<typename U, typename std::enable_if<!std::is_fundamental<U>::value>::type *>
+void DiscretizationStencilSolverAssembler<stencil_t>::_getRowValues(long rowIndex, ConstProxyVector<double> *values) const
+{
+    // Get stencil information
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+    std::size_t stencilSize = stencil.size();
+
+    // Get values
+    const typename stencil_t::weight_type *weightData = stencil.weightData();
+
+    std::size_t expandedValuesSize = m_blockSize * stencilSize;
+    double *expandedValuesStorage = values->set(expandedValuesSize);
+
+    std::size_t expandedValuesIdx = 0;
+    for (std::size_t k = 0; k < stencilSize; ++k) {
+        for (int i = 0; i < m_blockSize; ++i) {
+            expandedValuesStorage[expandedValuesIdx++] = getRawValue(weightData[k], i);
+        }
+    }
+}
+
+/*!
+ * Get the constant associated with the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \result The constant associated with the specified row.
+ */
+template<typename stencil_t>
+double DiscretizationStencilSolverAssembler<stencil_t>::getRowConstant(long rowIndex) const
+{
+    return _getRowConstant(rowIndex);
+}
+
+/*!
+ * Get the constant associated with the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \result The constant associated with the specified row.
+ */
+template<typename stencil_t>
+template<typename U, typename std::enable_if<std::is_fundamental<U>::value>::type *>
+double DiscretizationStencilSolverAssembler<stencil_t>::_getRowConstant(long rowIndex) const
+{
+    // Get stencil information
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+
+    // Get constant
+    return getRawValue(stencil.getConstant(), 0);
+}
+
+/*!
+ * Get the constant associated with the specified row.
+ *
+ * \param rowIndex is the index of the row in the assembler
+ * \result The constant associated with the specified row.
+ */
+template<typename stencil_t>
+template<typename U, typename std::enable_if<!std::is_fundamental<U>::value>::type *>
+double DiscretizationStencilSolverAssembler<stencil_t>::_getRowConstant(long rowIndex) const
+{
+    // Get stencil information
+    const stencil_t &stencil = (*m_stencils)[rowIndex];
+    const typename stencil_t::weight_type &stencilConstant = stencil.getConstant();
+
+    // Get constant
+    double constant = 0.;
+    for (int i = 0; i < m_blockSize; ++i) {
+        constant += getRawValue(stencilConstant, i);
+    }
+
+    return constant;
+}
+
+/*!
+* \ingroup discretization
+* \class DiscretizationStencilSolver
+*
+* The DiscretizationStencilSolver class handles the solution of linear systems
+* assembled from discretization stencils.
+*/
+
+/*!
+* Constuctor
+*
+* \param debug if this parameter is set to true, debug informations will be
+* printed when solving the system
+*/
+template<typename stencil_t>
+DiscretizationStencilSolver<stencil_t>::DiscretizationStencilSolver(bool debug)
+    : SystemSolver("", debug)
+{
+}
+
+/*!
+* Constuctor
+*
+* \param prefix is the prefix string to prepend to all option requests
+* \param debug if this parameter is set to true, debug informations will be
+* printed when solving the system
+*/
+template<typename stencil_t>
+DiscretizationStencilSolver<stencil_t>::DiscretizationStencilSolver(const std::string &prefix, bool debug)
+    : SystemSolver(prefix, debug)
+{
+}
+
+/*!
+* Clear the stencil solver
+*
+* \param release if it's true the memory hold by the stencil solver will be
+* released, otherwise the stencil solver will be cleared but its memory will
+* not be relased
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::clear(bool release)
+{
+    SystemSolver::clear();
+
+    if (release) {
+        std::vector<double>().swap(m_constants);
+    } else {
+        m_constants.clear();
+    }
+}
+
+#if BITPIT_ENABLE_MPI==1
+/*!
+* Assembly the stencil solver.
+*
+* \param stencils are the stencils
+*/
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::assembly(const std::vector<stencil_t> &stencils)
+{
+    assembly(MPI_COMM_SELF, false, stencils);
+}
+
+/*!
+* Initialize the stencil solver.
+*
+* \param partitioned controls if the matrix is partitioned
+* \param communicator is the MPI communicator
+* \param stencils are the stencils
+*/
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::assembly(MPI_Comm communicator, bool partitioned, const std::vector<stencil_t> &stencils)
+#else
+/*!
+* Initialize the stencil solver.
+*
+* \param stencils are the stencils
+*/
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::assembly(const std::vector<stencil_t> &stencils)
+#endif
+{
+    // Assembly system
+#if BITPIT_ENABLE_MPI==1
+    DiscretizationStencilSolverAssembler<stencil_t> assembler(communicator, partitioned, &stencils);
+    SystemSolver::assembly(communicator, partitioned, assembler);
+#else
+    DiscretizationStencilSolverAssembler<stencil_t> assembler(&stencils);
+    SystemSolver::assembly(assembler);
+#endif
+
+    // Set constants
+    long nRows = assembler.getRowCount();
+    m_constants.resize(nRows);
+    for (long n = 0; n < nRows; ++n) {
+        m_constants[n] = assembler.getRowConstant(n);
+    }
+}
+
+/*!
+ * Update all the stencil solver.
+ *
+ * Only the values of the system matrix and the values of the constants can be
+ * updated, once the system is initialized its pattern cannot be modified.
+ *
+ * \param stencils are the stencils that will be used to update the rows
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::update(const std::vector<stencil_t> &stencils)
+{
+    update(getRowCount(), nullptr, stencils);
+}
+
+/*!
+ * Update the stencil solver.
+ *
+ * Only the values of the system matrix and the values of the constants can be
+ * updated, once the system is initialized its pattern cannot be modified.
+ *
+ * \param rows are the global indices of the rows that will be updated
+ * \param stencils are the stencils that will be used to update the rows
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::update(const std::vector<long> &rows, const std::vector<stencil_t> &stencils)
+{
+    update(rows.size(), rows.data(), stencils);
+}
+
+/*!
+ * Update the stencil solver.
+ *
+ * Only the values of the system matrix and the values of the constants can be
+ * updated, once the system is initialized its pattern cannot be modified.
+ *
+ * \param nRows is the number of stencils that will be updated
+ * \param rows are the rows of the stencils that will be updated,
+ * if a null pointer is passed, the stencils that will be updated are the
+ * stencils from 0 to (nRows - 1).
+ * \param stencils are the stencils that will be used to update the rows
+ */
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::update(std::size_t nRows, const long *rows, const std::vector<stencil_t> &stencils)
+{
+    // Update the system
+#if BITPIT_ENABLE_MPI==1
+    DiscretizationStencilSolverAssembler<stencil_t> assembler(getCommunicator(), isPartitioned(), &stencils);
+#else
+    DiscretizationStencilSolverAssembler<stencil_t> assembler(&stencils);
+#endif
+    SystemSolver::update(nRows, rows, assembler);
+
+    // Update the constants
+    for (std::size_t n = 0; n < nRows; ++n) {
+        long row;
+        if (rows) {
+            row = rows[n];
+        } else {
+            row = n;
+        }
+
+        m_constants[row] = assembler.getRowConstant(n);
+    }
+}
+
+/*!
+* Solve the system.
+*/
+template<typename stencil_t>
+void DiscretizationStencilSolver<stencil_t>::solve()
+{
+    // Check if the stencil solver is assembled
+    if (!isAssembled()) {
+        throw std::runtime_error("Unable to solve the system. The stencil solver is not yet assembled.");
+    }
+
+    // Subtract constant terms to the RHS
+    long nUnknowns = getRowCount();
+    double *raw_rhs = getRHSRawPtr();
+    for (long i = 0; i < nUnknowns; ++i) {
+        raw_rhs[i] -= m_constants[i];
+    }
+    restoreRHSRawPtr(raw_rhs);
+
+    // Solve the system
+    SystemSolver::solve();
+}
+
+}


### PR DESCRIPTION
The StencilBlock class can store weights of variable length. Weights are stored using std::vector containers, which is not optimal in terms of performances and memory usage. More efficient storage strategies need some fundamental changes to the DiscretizationStencil class and, if needed, they will be introduced in the future. 