### PR TITLE
patchkernel: allow to scale the patch with respect to an arbitrary point

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5194,15 +5194,27 @@ void PatchKernel::translate(double sx, double sy, double sz)
 */
 void PatchKernel::scale(const std::array<double, 3> &scaling)
 {
+	scale(scaling, m_boxMinPoint);
+}
+
+/*!
+	Scales the patch.
+
+	\param[in] scaling is the scaling factor vector
+	\param[in] center is the center of the scaling
+*/
+void PatchKernel::scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center)
+{
 	// Scale the patch
 	for (auto &vertex : m_vertices) {
-		vertex.scale(scaling, m_boxMinPoint);
+		vertex.scale(scaling, center);
 	}
 
 	// Update the bounding box
 	if (!isBoundingBoxFrozen() || isBoundingBoxDirty()) {
 		for (int k = 0; k < 3; ++k) {
-			m_boxMaxPoint[k] = m_boxMinPoint[k] + scaling[k] * (m_boxMaxPoint[k] - m_boxMinPoint[k]);
+			m_boxMinPoint[k] = center[k] + scaling[k] * (m_boxMinPoint[k] - center[k]);
+			m_boxMaxPoint[k] = center[k] + scaling[k] * (m_boxMaxPoint[k] - center[k]);
 		}
 	}
 }
@@ -5216,7 +5228,18 @@ void PatchKernel::scale(const std::array<double, 3> &scaling)
 */
 void PatchKernel::scale(double scaling)
 {
-	scale({{scaling, scaling, scaling}});
+	scale({{scaling, scaling, scaling}}, m_boxMinPoint);
+}
+
+/*!
+	Scales the patch.
+
+	\param[in] scaling is the scaling factor
+	\param[in] center is the center of the scaling
+*/
+void PatchKernel::scale(double scaling, const std::array<double, 3> &center)
+{
+	scale({{scaling, scaling, scaling}}, center);
 }
 
 /*!
@@ -5228,7 +5251,22 @@ void PatchKernel::scale(double scaling)
 */
 void PatchKernel::scale(double sx, double sy, double sz)
 {
-	scale({{sx, sy, sz}});
+	scale({{sx, sy, sz}}, m_boxMinPoint);
+}
+
+/*!
+	Scales the patch.
+
+	The patch is scaled about the lower-left point of the bounding box.
+
+	\param[in] sx scaling factor along x direction
+	\param[in] sy scaling factor along y direction
+	\param[in] sz scaling factor along z direction
+	\param[in] center is the center of the scaling
+*/
+void PatchKernel::scale(double sx, double sy, double sz, const std::array<double, 3> &center)
+{
+	scale({{sx, sy, sz}}, center);
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -505,9 +505,12 @@ public:
 
 	virtual void translate(const std::array<double, 3> &translation);
 	void translate(double sx, double sy, double sz);
-	virtual void scale(const std::array<double, 3> &scaling);
+	void scale(const std::array<double, 3> &scaling);
+	virtual void scale(const std::array<double, 3> &scaling, const std::array<double, 3> &origin);
 	void scale(double scaling);
+	void scale(double scaling, const std::array<double, 3> &origin);
 	void scale(double sx, double sy, double sz);
+	void scale(double sx, double sy, double sz, const std::array<double, 3> &origin);
 
 	void setTol(double tolerance);
 	double getTol() const;

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -1681,17 +1681,17 @@ void VolCartesian::setLengths(const std::array<double, 3> &lengths)
 /*!
 	Scales the patch.
 
-	The patch is scaled about the lower-left point of the bounding box.
-
 	\param[in] scaling is the scaling factor vector
+	\param[in] center is the center of the scaling
  */
-void VolCartesian::scale(const std::array<double, 3> &scaling)
+void VolCartesian::scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center)
 {
 	for (int n = 0; n < 3; ++n) {
-		m_maxCoords[n] = m_minCoords[n] + scaling[n] * (m_maxCoords[n] - m_minCoords[n]);
+		m_minCoords[n] = center[n] + scaling[n] * (m_minCoords[n] - center[n]);
+		m_maxCoords[n] = center[n] + scaling[n] * (m_maxCoords[n] - center[n]);
 		for (int i = 1; i < m_nVertices1D[n]; ++i) {
-			m_vertexCoords[n][i] = m_minCoords[n] + scaling[n] * (m_vertexCoords[n][i] - m_minCoords[n]);
-			m_cellCenters[n][i]  = m_minCoords[n] + scaling[n] * (m_cellCenters[n][i] - m_minCoords[n]);
+			m_vertexCoords[n][i] = center[n] + scaling[n] * (m_vertexCoords[n][i] - center[n]);
+			m_cellCenters[n][i]  = center[n] + scaling[n] * (m_cellCenters[n][i] - center[n]);
 		}
 
 		m_cellSpacings[n] *= scaling[n];
@@ -1703,7 +1703,7 @@ void VolCartesian::scale(const std::array<double, 3> &scaling)
 
 	setBoundingBox(m_minCoords, m_maxCoords);
 
-	VolumeKernel::scale(scaling);
+	VolumeKernel::scale(scaling, center);
 }
 
 /*!

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -116,7 +116,7 @@ public:
 	void translate(const std::array<double, 3> &translation) override;
 	std::array<double, 3> getLengths() const;
 	void setLengths(const std::array<double, 3> &lengths);
-	void scale(const std::array<double, 3> &scaling) override;
+	void scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center) override;
 
 	std::vector<double> convertToVertexData(const std::vector<double> &cellData) const;
 	std::vector<double> convertToCellData(const std::vector<double> &nodeData) const;

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2303,8 +2303,9 @@ void VolOctree::setLength(double length)
 	Scales the patch.
 
 	\param[in] scaling is the scaling factor vector
+	\param[in] center is the center of the scaling
  */
-void VolOctree::scale(const std::array<double, 3> &scaling)
+void VolOctree::scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center)
 {
 	bool uniformScaling = true;
 	uniformScaling &= (std::abs(scaling[0] - scaling[1]) > 1e-14);
@@ -2315,9 +2316,15 @@ void VolOctree::scale(const std::array<double, 3> &scaling)
 		return;
 	}
 
+	std::array<double, 3> origin = m_tree->getOrigin();
+	for (int n = 0; n < 3; ++n) {
+		origin[n] = center[n] + scaling[n] * (origin[n] - center[n]);
+	}
+	m_tree->setOrigin(origin);
+
 	m_tree->setL(m_tree->getL() * scaling[0]);
 
-	VolumeKernel::scale(scaling);
+	VolumeKernel::scale(scaling, center);
 
 	// The bounding box is frozen, it is not updated automatically
 	setBoundingBox();

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -113,7 +113,7 @@ public:
 	void translate(const std::array<double, 3> &translation) override;
 	double getLength() const;
 	void setLength(double length);
-	void scale(const std::array<double, 3> &scaling) override;
+	void scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center) override;
 
 	void updateAdjacencies(const std::vector<long> &cellIds) override;
 


### PR DESCRIPTION
It is now possible scale the patch with respect to an arbitrary point.

@marcocisternino @edoardolombardi Can you double check that PABLO tree is properly scaled in VolOctree?