### PR TITLE
 LA: properly mark system set up as done at the end of "SystemSolver::setUp"

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1333,6 +1333,9 @@ void SystemSolver::setUp()
 
     // Perform actions after KSP set up
     postKSPSetupActions();
+
+    // Set up is now complete
+    m_setUp = true;
 }
 
 /*!


### PR DESCRIPTION
Since the setUp was not properly marked as done, it was executed every time the function "solve" was called.