### PR TITLE
communications: do not use MPI_REQUEST_NULL as sentinel value

### DIFF
--- a/src/communications/communications.cpp
+++ b/src/communications/communications.cpp
@@ -292,7 +292,8 @@ void DataCommunicator::discoverSends()
     }
 
     // Receive the data sizes and set the sends
-    MPI_Request exchangeCompletedRequest = MPI_REQUEST_NULL;
+    int localDiscoverSendsCompleted = 0;
+    MPI_Request exchangeCompletedRequest;
     while (true) {
         // If there are messagea available receive them and set the sends
         int messageAvailable = 1;
@@ -307,10 +308,9 @@ void DataCommunicator::discoverSends()
         }
 
         // If all the sends are complete notify it
-        if (exchangeCompletedRequest == MPI_REQUEST_NULL) {
-            int discoverSendsCompleted;
-            MPI_Testall(discoverRequests.size(), discoverRequests.data(), &discoverSendsCompleted, MPI_STATUSES_IGNORE);
-            if (discoverSendsCompleted) {
+        if (!localDiscoverSendsCompleted) {
+            MPI_Testall(discoverRequests.size(), discoverRequests.data(), &localDiscoverSendsCompleted, MPI_STATUSES_IGNORE);
+            if (localDiscoverSendsCompleted) {
                 MPI_Ibarrier(m_communicator, &exchangeCompletedRequest);
             }
         }
@@ -320,7 +320,7 @@ void DataCommunicator::discoverSends()
         // be makred as completed only when the corresponding receive has
         // completed. When all processes have completed the send/recevies
         // all sizes have been exchanged.
-        if (exchangeCompletedRequest != MPI_REQUEST_NULL) {
+        if (localDiscoverSendsCompleted) {
             int exchangeCompleted = 0;
             MPI_Test(&exchangeCompletedRequest, &exchangeCompleted, MPI_STATUS_IGNORE);
             if (exchangeCompleted) {
@@ -364,7 +364,8 @@ void DataCommunicator::discoverRecvs()
     }
 
     // Receive the data sizes and set the receives
-    MPI_Request exchangeCompletedRequest = MPI_REQUEST_NULL;
+    int localDiscoverSendsCompleted = 0;
+    MPI_Request exchangeCompletedRequest;
     while (true) {
         // If there are messagea available receive them and set the receives
         int messageAvailable = 1;
@@ -379,10 +380,9 @@ void DataCommunicator::discoverRecvs()
         }
 
         // If all the sends are complete notify it
-        if (exchangeCompletedRequest == MPI_REQUEST_NULL) {
-            int discoverSendsCompleted;
-            MPI_Testall(discoverRequests.size(), discoverRequests.data(), &discoverSendsCompleted, MPI_STATUSES_IGNORE);
-            if (discoverSendsCompleted) {
+        if (!localDiscoverSendsCompleted) {
+            MPI_Testall(discoverRequests.size(), discoverRequests.data(), &localDiscoverSendsCompleted, MPI_STATUSES_IGNORE);
+            if (localDiscoverSendsCompleted) {
                 MPI_Ibarrier(m_communicator, &exchangeCompletedRequest);
             }
         }
@@ -392,7 +392,7 @@ void DataCommunicator::discoverRecvs()
         // be makred as completed only when the corresponding receive has
         // completed. When all processes have completed the send/recevies
         // all sizes have been exchanged.
-        if (exchangeCompletedRequest != MPI_REQUEST_NULL) {
+        if (localDiscoverSendsCompleted) {
             int exchangeCompleted = 0;
             MPI_Test(&exchangeCompletedRequest, &exchangeCompleted, MPI_STATUS_IGNORE);
             if (exchangeCompleted) {

--- a/src/communications/communications.cpp
+++ b/src/communications/communications.cpp
@@ -273,6 +273,13 @@ bool DataCommunicator::areRecvsContinuous()
 
 /*!
     Discover the sends inspecting the receives that the user has already set.
+
+    This function implements the "Nonblocking Consensus" algorithm proposed
+    in "Scalable Communication Protocols for Dynamic Sparse Data Exchange",
+    Torsten Hoefler, Christian Siebert and Andrew Lumsdaine, Proceedings of
+    the 2010 ACM SIGPLAN Symposium on Principles and Practice of Parallel
+    Programming (PPoPP'10), presented in Bangalore, India, pages 159--168,
+    ACM, ISBN: 978-1-60558-708-0, Jan. 2010.
 */
 void DataCommunicator::discoverSends()
 {
@@ -345,6 +352,13 @@ void DataCommunicator::discoverSends()
 
 /*!
     Discover the receives inspecting the sends that the user has already set.
+
+    This function implements the "Nonblocking Consensus" algorithm proposed
+    in "Scalable Communication Protocols for Dynamic Sparse Data Exchange",
+    Torsten Hoefler, Christian Siebert and Andrew Lumsdaine, Proceedings of
+    the 2010 ACM SIGPLAN Symposium on Principles and Practice of Parallel
+    Programming (PPoPP'10), presented in Bangalore, India, pages 159--168,
+    ACM, ISBN: 978-1-60558-708-0, Jan. 2010.
 */
 void DataCommunicator::discoverRecvs()
 {


### PR DESCRIPTION
On some MPI implementaiotns (i.e., MPICH), the function MPI_Ibarrier can return a MPI_REQUEST_NULL if the communicator size is 1. Thus, it is not possible to use MPI_REQUEST_NULL as a sentinel value.

A separate boolean is introduced to track if the local exchange has completed.