### PR TITLE
LA: fix set up of debug options

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -330,7 +330,11 @@ SystemSolver::~SystemSolver()
 
     // Finalize petsc
     if (m_nInstances == 0) {
-        PetscFinalize();
+        PetscBool isPetscFinalized;
+        PetscFinalized(&isPetscFinalized);
+        if (!isPetscFinalized) {
+            PetscFinalize();
+        }
     }
 }
 

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -267,9 +267,6 @@ SystemSolver::SystemSolver(const std::string &prefix, bool debug)
     // Add debug options
     if (debug) {
         addInitOption("-log_view");
-        addInitOption("-ksp_monitor_true_residual");
-        addInitOption("-ksp_converged_reason");
-        addInitOption("-ksp_monitor_singular_value");
     }
 
     // Initialize Petsc
@@ -298,6 +295,19 @@ SystemSolver::SystemSolver(const std::string &prefix, bool debug)
         }
 
         delete[] argv;
+    }
+
+    // Set KSP debug options
+    if (debug) {
+#if (PETSC_VERSION_MAJOR >= 3 && PETSC_VERSION_MINOR >= 7)
+            PetscOptionsSetValue(nullptr, ("-" + m_prefix + "ksp_monitor_true_residual").c_str(), "");
+            PetscOptionsSetValue(nullptr, ("-" + m_prefix + "ksp_converged_reason").c_str(), "");
+            PetscOptionsSetValue(nullptr, ("-" + m_prefix + "ksp_monitor_singular_value").c_str(), "");
+#else
+            PetscOptionsSetValue(("-" + m_prefix + "ksp_monitor_true_residual").c_str(), "");
+            PetscOptionsSetValue(("-" + m_prefix + "ksp_converged_reason").c_str(), "");
+            PetscOptionsSetValue(("-" + m_prefix + "ksp_monitor_singular_value").c_str(), "");
+#endif
     }
 
     // Increase the number of instances

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -130,6 +130,8 @@ public:
     static void addInitOptions(const std::vector<std::string> &options);
     static void clearInitOptions();
 
+    static void enableLogView();
+
     SystemSolver(bool debug = false);
     SystemSolver(const std::string &prefix, bool debug = false);
 
@@ -220,7 +222,10 @@ protected:
 private:
     static int m_nInstances;
     static bool m_optionsEditable;
+    static bool m_logViewEnabled;
     static std::vector<std::string> m_options;
+
+    static PetscErrorCode displayLogView();
 
     std::string m_prefix;
 


### PR DESCRIPTION
PETSc option prefix is properly taken into account when setting debug options. Also, log view is now enabled using PETSc functions instead of PETSc options, this allows to enable the log view also if PetscInitialize function is called outside bitpit.