### PR TITLE
discretization: fix evaluation of stencil grantient weights

### DIFF
--- a/src/containers/piercedKernelIterator.hpp
+++ b/src/containers/piercedKernelIterator.hpp
@@ -130,8 +130,7 @@ public:
     /**
     * Two-way comparison.
     */
-    template<typename other_id_t>
-    bool operator==(const PiercedKernelIterator<other_id_t>& rhs) const
+    bool operator==(const PiercedKernelIterator &rhs) const
     {
         return (m_kernel == rhs.m_kernel) && (m_pos == rhs.m_pos);
     }
@@ -139,8 +138,7 @@ public:
     /**
     * Two-way comparison.
     */
-    template<typename other_id_t>
-    bool operator!=(const PiercedKernelIterator<other_id_t>& rhs) const
+    bool operator!=(const PiercedKernelIterator &rhs) const
     {
         return (m_kernel != rhs.m_kernel) || (m_pos != rhs.m_pos);
     }

--- a/src/containers/piercedStorageIterator.hpp
+++ b/src/containers/piercedStorageIterator.hpp
@@ -160,9 +160,7 @@ public:
     /**
     * Two-way comparison.
     */
-    template<typename other_value_t, typename other_id_t = long,
-         typename other_value_no_cv_t = typename std::remove_cv<other_value_t>::type>
-    bool operator==(const PiercedStorageIterator<other_value_t, other_id_t, other_value_no_cv_t>& rhs) const
+    bool operator==(const PiercedStorageIterator &rhs) const
     {
         return (PiercedKernelIterator<id_t>::operator==(rhs) && m_storage == rhs.m_storage);
     }
@@ -170,9 +168,7 @@ public:
     /**
     * Two-way comparison.
     */
-    template<typename other_value_t, typename other_id_t = long,
-         typename other_value_no_cv_t = typename std::remove_cv<other_value_t>::type>
-    bool operator!=(const PiercedStorageIterator<other_value_t, other_id_t, other_value_no_cv_t>& rhs) const
+    bool operator!=(const PiercedStorageIterator &rhs) const
     {
         return (PiercedKernelIterator<id_t>::operator!=(rhs) || m_storage != rhs.m_storage);
     }

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2694,6 +2694,15 @@ void ReconstructionKernel::computeGradientLimitedWeights(uint8_t degree, const s
 
         direction[d] = 0.;
     }
+
+    // Explicitly zero unused components
+    if (dimensions != ReconstructionPolynomial::MAX_DIMENSIONS) {
+        for (int i = 0; i < nEquations; ++i) {
+            for (int d = dimensions; d < ReconstructionPolynomial::MAX_DIMENSIONS; ++d) {
+                gradientWeights[i][d] = 0.;
+            }
+        }
+    }
 }
 
 /*!


### PR DESCRIPTION
When evaluating the gradient stencil weight, the unused components (es. the third component of a two-dimensional reconstruction) is now explicitly set to zero. I prefer setting the unused components to zero inside bitpit, rather than in the external application using bitpit. 

