### PR TITLE
discretization: fix stencil initialization

### DIFF
--- a/src/containers/flatVector2D.hpp
+++ b/src/containers/flatVector2D.hpp
@@ -70,6 +70,7 @@ public:
     FlatVector2D(bool initialize = true);
     FlatVector2D(const std::vector<std::size_t> &sizes, const T &value = T());
     FlatVector2D(std::size_t nVectors, std::size_t size, const T &value = T());
+    FlatVector2D(std::size_t nVectors, const std::size_t *sizes, const T &value);
     FlatVector2D(std::size_t nVectors, const std::size_t *sizes, const T *values);
     FlatVector2D(const std::vector<std::vector<T> > &vector2D);
     FlatVector2D(const FlatVector2D &other) = default;
@@ -93,6 +94,7 @@ public:
 
     void initialize(const std::vector<std::size_t> &sizes, const T &value = T());
     void initialize(std::size_t nVectors, std::size_t size, const T &value = T());
+    void initialize(std::size_t nVectors, const std::size_t *sizes, const T &value);
     void initialize(std::size_t nVectors, const std::size_t *sizes, const T *values);
     void initialize(const std::vector<std::vector<T> > &vector2D);
     void initialize(const FlatVector2D<T> &other);

--- a/src/containers/flatVector2D.tpp
+++ b/src/containers/flatVector2D.tpp
@@ -114,6 +114,20 @@ FlatVector2D<T>::FlatVector2D(std::size_t nVectors, std::size_t size, const T &v
 
     \param nVectors is the number of vectors
     \param sizes are the sizes of the vectors
+    \param value is the value that will be use to initialize the
+    items of the vectors
+*/
+template <class T>
+FlatVector2D<T>::FlatVector2D(std::size_t nVectors, const std::size_t *sizes, const T &value)
+{
+    initialize(nVectors, sizes, 1, &value, 0);
+}
+
+/*!
+    Creates a new container.
+
+    \param nVectors is the number of vectors
+    \param sizes are the sizes of the vectors
     \param values are the values of the vectors
 */
 template <class T>
@@ -160,6 +174,21 @@ void FlatVector2D<T>::initialize(std::size_t nVectors, std::size_t size, const T
 {
     initialize(nVectors, &size, 0, &value, 0);
 }
+
+/*!
+    Initializes the container.
+
+    \param nVectors is the number of vectors
+    \param sizes are the sizes of the vectors
+    \param value is the value that will be use to initialize the
+    items of the vectors
+*/
+template <class T>
+void FlatVector2D<T>::initialize(std::size_t nVectors, const std::size_t *sizes, const T &value)
+{
+    initialize(nVectors, sizes, 1, &value, 0);
+}
+
 
 /*!
     Initializes the container.

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -224,8 +224,8 @@ template<typename weight_t>
 void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *bucketSizes, const weight_t &zero)
 {
     m_zero = zero;
-    m_pattern.initialize(nBuckets, bucketSizes, &NULL_ID);
-    m_weights.initialize(nBuckets, bucketSizes, &zero);
+    m_pattern.initialize(nBuckets, bucketSizes, NULL_ID);
+    m_weights.initialize(nBuckets, bucketSizes, zero);
     m_constant = m_zero;
 }
 
@@ -242,7 +242,7 @@ void DiscreteStencil<weight_t>::initialize(int nBuckets, const std::size_t *buck
 {
     m_zero = zero;
     m_pattern.initialize(nBuckets, bucketSizes, pattern);
-    m_weights.initialize(nBuckets, bucketSizes, &zero);
+    m_weights.initialize(nBuckets, bucketSizes, zero);
     m_constant = m_zero;
 }
 


### PR DESCRIPTION
When initializing an empty stencil, the function that handles the initialization of the pattern and the weights should receive in input references to the null id and to the zero value (as opposed to pointers).