### PR TITLE
 patchkernel: add support for parallel surface skd-tree searches

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -780,13 +780,13 @@ void SkdNode::updateClosestCellInfo(const std::array<double, 3> &point,
 * Constructor.
 *
 * \param patch is the patch that will be use to build the tree
-* \param includeGhosts if set to true the ghost cells are included in the tree
+* \param interiorOnly if set to true, only interior cells will be considered
 */
-PatchSkdTree::PatchSkdTree(const PatchKernel *patch, bool includeGhosts)
+PatchSkdTree::PatchSkdTree(const PatchKernel *patch, bool interiorOnly)
     : m_patchInfo(patch, &m_cellRawIds),
-      m_cellRawIds(includeGhosts ? patch->getCellCount() : patch->getInternalCount()),
+      m_cellRawIds(interiorOnly ? patch->getInternalCount() : patch->getCellCount()),
       m_nLeafs(0), m_nMinLeafCells(0), m_nMaxLeafCells(0),
-      m_includeGhosts(includeGhosts)
+      m_interiorOnly(interiorOnly)
 {
 
 }
@@ -844,12 +844,12 @@ void PatchSkdTree::build(std::size_t leafThreshold, bool squeezeStorage)
     // Initialize list of cell raw ids
     std::size_t nCells;
     PatchKernel::CellConstRange cellRange;
-    if (m_includeGhosts) {
-        nCells = patch.getCellCount();
-        cellRange.initialize(patch.cellConstBegin(), patch.cellConstEnd());
-    } else {
+    if (m_interiorOnly) {
         nCells = patch.getInternalCount();
         cellRange.initialize(patch.internalConstBegin(), patch.internalConstEnd());
+    } else {
+        nCells = patch.getCellCount();
+        cellRange.initialize(patch.cellConstBegin(), patch.cellConstEnd());
     }
 
     if (m_cellRawIds.size() != nCells) {

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -357,9 +357,17 @@ SkdNode::SkdNode(const SkdPatchInfo *patchInfo, std::size_t cellRangeBegin, std:
 */
 void SkdNode::initializeBoundingBox()
 {
-    const std::vector<std::size_t> &cellRawIds = m_patchInfo->getCellRawIds();
+    // Early return if there are no cells
+    if (m_cellRangeBegin == m_cellRangeEnd){
+        m_boxMin.fill(  std::numeric_limits<double>::max());
+        m_boxMax.fill(- std::numeric_limits<double>::max());
+
+        return;
+    }
 
     // Evaluate the bounding box
+    const std::vector<std::size_t> &cellRawIds = m_patchInfo->getCellRawIds();
+
     m_boxMin = m_patchInfo->getCachedBoxMin(cellRawIds[m_cellRangeBegin]);
     m_boxMax = m_patchInfo->getCachedBoxMax(cellRawIds[m_cellRangeBegin]);
     for (std::size_t n = m_cellRangeBegin + 1; n < m_cellRangeEnd; n++) {
@@ -857,7 +865,8 @@ void PatchSkdTree::build(std::size_t leafThreshold, bool squeezeStorage)
     m_patchInfo.buildCache(cellRange);
 
     // Initialize node list
-    m_nodes.reserve(std::ceil(2. * nCells / leafThreshold - 1.));
+    std::size_t nodesCount = std::max(1, int(std::ceil(2. * nCells / leafThreshold - 1.)));
+    m_nodes.reserve(nodesCount);
 
     // Create the root
     m_nodes.emplace_back(&m_patchInfo, 0, nCells);

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -184,6 +184,137 @@ std::array<double, 3> SkdPatchInfo::evalCachedBoxMean(std::size_t rawId) const
 }
 
 /*!
+* \class SkdBox
+*
+* \brief The SkdBox class defines a box.
+*/
+
+/*!
+* Default constructor.
+*/
+SkdBox::SkdBox()
+    : m_boxMin{  std::numeric_limits<double>::max(),   std::numeric_limits<double>::max(),   std::numeric_limits<double>::max()},
+      m_boxMax{- std::numeric_limits<double>::max(), - std::numeric_limits<double>::max(), - std::numeric_limits<double>::max()}
+{
+}
+
+/*!
+* Constructor
+*
+* \param boxMin is the minimum coordinate of the box
+* \param boxMax is the maximum coordinate of the box
+*/
+SkdBox::SkdBox(const std::array<double,3> &boxMin, const std::array<double,3> &boxMax)
+    : m_boxMin(boxMin),
+      m_boxMax(boxMax)
+{
+}
+
+/*!
+* Get the minimum coordinate of the box.
+*
+* \result The minimum coordinate of the box.
+*/
+const std::array<double, 3> & SkdBox::getBoxMin() const
+{
+    return m_boxMin;
+}
+
+/*!
+* Get the maximum coordinate of the box.
+*
+* \result The maximum coordinate of the box.
+*/
+const std::array<double, 3> & SkdBox::getBoxMax() const
+{
+    return m_boxMax;
+}
+
+/*!
+* Evaluates the minimum distance among the specified point and the box
+*
+* \param point is the point
+* \result The minimum distance among the specified point and the box.
+*/
+double SkdBox::evalPointMinDistance(const std::array<double, 3> &point) const
+{
+    double distance = 0.;
+    for (int d = 0; d < 3; ++d) {
+        distance += std::pow(std::max({0., m_boxMin[d] - point[d], point[d] - m_boxMax[d]}), 2);
+    }
+    distance = std::sqrt(distance);
+
+    return distance;
+}
+
+/*!
+* Evaluates the maximum distance among the specified point and the box
+*
+* \param point is the point
+* \result The maximum distance among the specified point and the box
+*/
+double SkdBox::evalPointMaxDistance(const std::array<double, 3> &point) const
+{
+    double distance = 0.;
+    for (int d = 0; d < 3; ++d) {
+        distance += std::pow(std::max(point[d] - m_boxMin[d], m_boxMax[d] - point[d]), 2);
+    }
+    distance = std::sqrt(distance);
+
+    return distance;
+}
+
+/*!
+* Checks if the specified point is inside the box .
+*
+* The box size will be expanded by the specified offset value.
+*
+* \param point is the point
+* \param offset is the offset that will be used to expand the box
+* \result Returns true if the point is inside the inflated box, false otherwise.
+*/
+bool SkdBox::boxContainsPoint(const std::array<double, 3> &point, double offset) const
+{
+    for (int d = 0; d < 3; d++) {
+        if (point[d] < (m_boxMin[d] - offset)) {
+            return false;
+        }
+
+        if (point[d] > (m_boxMax[d] + offset)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*!
+* Checks if the box intersects the sphere with given center and radius.
+*
+* \param[in] center is the center of the sphere
+* \param[in] radius is the radius of the sphere
+* \result Returns true if the box intersects the sphere with given center
+* and radius, false otherwise.
+*/
+bool SkdBox::boxIntersectsSphere(const std::array<double, 3> &center, double radius) const
+{
+    // If the box contains the center it will also intersect the sphere
+    if (boxContainsPoint(center, 0.)) {
+        return true;
+    }
+
+    // Check if the distance between the center and its projection on
+    // the bounding box is smaller than the radius of the sphere.
+    std::array<double, 3> delta;
+    for (int d = 0; d < 3; d++) {
+        delta[d] = std::min(std::max(center[d], m_boxMin[d]), m_boxMax[d]) - center[d];
+    }
+    double distance = dotProduct(delta, delta);
+
+    return (distance < radius * radius);
+}
+
+/*!
 * \class SkdNode
 *
 * \brief The SkdPatchInfo class defines a node of the skd-tree.
@@ -200,7 +331,6 @@ const std::size_t SkdNode::NULL_ID = std::numeric_limits<std::size_t>::max();
 SkdNode::SkdNode()
     : m_patchInfo(nullptr),
       m_cellRangeBegin(0), m_cellRangeEnd(0),
-      m_boxMin({{0., 0., 0.}}), m_boxMax({{0., 0., 0.}}),
       m_children({{NULL_ID, NULL_ID}})
 {
 }
@@ -308,25 +438,11 @@ std::vector<long> SkdNode::getCells() const
 }
 
 /*!
-* Get the minimum coordinate of the bounding box associated to the node.
-*
-* \result The minimum coordinate of the bounding box associated to the
-* node.
+* Get the bounding box associated to the node.
 */
-const std::array<double, 3> & SkdNode::getBoxMin() const
+const SkdBox & SkdNode::getBoundingBox() const
 {
-    return m_boxMin;
-}
-
-/*!
-* Get the maximum coordinate of the bounding box associated to the node.
-*
-* \result The maximum coordinate of the bounding box associated to the
-* node.
-*/
-const std::array<double, 3> & SkdNode::getBoxMax() const
-{
-    return m_boxMax;
+    return *this;
 }
 
 /*!
@@ -387,44 +503,6 @@ bool SkdNode::hasChild(ChildLocation child) const
 std::size_t SkdNode::getChildId(ChildLocation child) const
 {
     return m_children[static_cast<std::size_t>(child)];
-}
-
-/*!
-* Evaluates the minimum distance among the specified point and the
-* cells contained the node.
-*
-* \param point is the point
-* \result The minimum distance among the specified point and the cells
-* contained the node.
-*/
-double SkdNode::evalPointMinDistance(const std::array<double, 3> &point) const
-{
-    double distance = 0.;
-    for (int d = 0; d < 3; ++d) {
-        distance += std::pow(std::max({0., m_boxMin[d] - point[d], point[d] - m_boxMax[d]}), 2);
-    }
-    distance = std::sqrt(distance);
-
-    return distance;
-}
-
-/*!
-* Evaluates the maximum distance among the specified point and the
-* cells contained in the bounding box associated to the node.
-*
-* \param point is the point
-* \result The maximum distance among the specified point and the cells
-* contained in the bounding box associated to the node.
-*/
-double SkdNode::evalPointMaxDistance(const std::array<double, 3> &point) const
-{
-    double distance = 0.;
-    for (int d = 0; d < 3; ++d) {
-        distance += std::pow(std::max(point[d] - m_boxMin[d], m_boxMax[d] - point[d]), 2);
-    }
-    distance = std::sqrt(distance);
-
-    return distance;
 }
 
 /*!
@@ -638,58 +716,6 @@ void SkdNode::updateClosestCellInfo(const std::array<double, 3> &point,
     }
 
     }
-}
-
-/*!
-* Checks if the specified point is inside the bounding box associated to the
-* node. The bounding box size will be expanded by the specified offset value.
-*
-* \param point is the point
-* \param offset is the offset that will be used to expand the bounding
-* box
-* \result Returns true if the point is inside the inflated bounding box,
-* false otherwise.
-*/
-bool SkdNode::boxContainsPoint(const std::array<double, 3> &point, double offset) const
-{
-    for (int d = 0; d < 3; d++) {
-        if (point[d] < (m_boxMin[d] - offset)) {
-            return false;
-        }
-
-        if (point[d] > (m_boxMax[d] + offset)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/*!
-* Checks if the bounding box associated to the node intersects the
-* sphere with given center and radius.
-*
-* \param[in] center is the center of the sphere
-* \param[in] radius is the radius of the sphere
-* \result Returns true if the bounding box associated to the node
-* intersects the sphere with given center and radius, false otherwise.
-*/
-bool SkdNode::boxIntersectsSphere(const std::array<double, 3> &center, double radius) const
-{
-    // If the box contains the center it will also intersect the sphere
-    if (boxContainsPoint(center, 0.)) {
-        return true;
-    }
-
-    // Check if the distance between the center and its projection on
-    // the bounding box is smaller than the radius of the sphere.
-    std::array<double, 3> delta;
-    for (int d = 0; d < 3; d++) {
-        delta[d] = std::min(std::max(center[d], m_boxMin[d]), m_boxMax[d]) - center[d];
-    }
-    double distance = dotProduct(delta, delta);
-
-    return (distance < radius * radius);
 }
 
 /*!

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -113,10 +113,10 @@ public:
     bool hasChild(ChildLocation child) const;
     std::size_t getChildId(ChildLocation child) const;
 
-    double evalPointDistance(const std::array<double, 3> &point) const;
+    double evalPointDistance(const std::array<double, 3> &point, bool ignoreGhosts) const;
 
-    void findPointClosestCell(const std::array<double, 3> &point, long *id, double *distance) const;
-    void updatePointClosestCell(const std::array<double, 3> &point, long *id, double *distance) const;
+    void findPointClosestCell(const std::array<double, 3> &point, bool ignoreGhosts, long *id, double *distance) const;
+    void updatePointClosestCell(const std::array<double, 3> &point, bool ignoreGhosts, long *id, double *distance) const;
 
 protected:
     struct Allocator : std::allocator<SkdNode>

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -180,9 +180,9 @@ protected:
 
     std::vector<SkdNode, SkdNode::Allocator> m_nodes;
 
-    bool m_includeGhosts;
+    bool m_interiorOnly;
 
-    PatchSkdTree(const PatchKernel *patch, bool includeGhosts = true);
+    PatchSkdTree(const PatchKernel *patch, bool interiorOnly = false);
 
     SkdNode & _getNode(std::size_t nodeId);
 

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -64,10 +64,30 @@ protected:
 
 };
 
-class SkdNode {
+class SkdBox {
+
+public:
+    SkdBox();
+    SkdBox(const std::array<double,3> &boxMin, const std::array<double,3> &boxMax);
+
+    const std::array<double, 3> & getBoxMin() const;
+    const std::array<double, 3> & getBoxMax() const;
+
+    double evalPointMinDistance(const std::array<double, 3> &point) const;
+    double evalPointMaxDistance(const std::array<double, 3> &point) const;
+
+    bool boxContainsPoint(const std::array<double,3> &point, double offset) const;
+    bool boxIntersectsSphere(const std::array<double,3> &center, double radius) const;
+
+protected:
+    std::array<double, 3> m_boxMin;
+    std::array<double, 3> m_boxMax;
+
+};
+
+class SkdNode : public SkdBox {
 
 friend class PatchSkdTree;
-friend class SkdNodeAllocator;
 
 public:
     static const std::size_t NULL_ID;
@@ -85,19 +105,14 @@ public:
     std::vector<long> getCells() const;
     long getCell(std::size_t n) const;
 
-    const std::array<double, 3> & getBoxMin() const;
-    const std::array<double, 3> & getBoxMax() const ;
+    const SkdBox & getBoundingBox() const;
+
     std::array<double,3> evalBoxWeightedMean() const;
 
     bool isLeaf() const;
     bool hasChild(ChildLocation child) const;
     std::size_t getChildId(ChildLocation child) const;
 
-    bool boxContainsPoint(const std::array<double,3> &point, double offset) const;
-    bool boxIntersectsSphere(const std::array<double,3> &center, double radius) const;
-
-    double evalPointMinDistance(const std::array<double, 3> &point) const;
-    double evalPointMaxDistance(const std::array<double, 3> &point) const;
     double evalPointDistance(const std::array<double, 3> &point) const;
 
     void findPointClosestCell(const std::array<double, 3> &point, long *id, double *distance) const;
@@ -124,9 +139,6 @@ private:
 
     std::size_t m_cellRangeBegin;
     std::size_t m_cellRangeEnd;
-
-    std::array<double,3> m_boxMin;
-    std::array<double,3> m_boxMax;
 
     std::array<std::size_t, MAX_CHILDREN> m_children;
 

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -37,9 +37,10 @@ namespace bitpit {
 * Constructor.
 *
 * \param patch is the surface patch that will be use to build the tree
+* \param interiorOnly if set to true, only interior cells will be considered
 */
-SurfaceSkdTree::SurfaceSkdTree(const SurfaceKernel *patch)
-    : PatchSkdTree(patch)
+SurfaceSkdTree::SurfaceSkdTree(const SurfaceKernel *patch, bool interiorOnly)
+    : PatchSkdTree(patch, interiorOnly)
 {
 }
 

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -71,7 +71,7 @@ void SurfaceSkdTree::clear(bool release)
 */
 double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point) const
 {
-    return evalPointDistance(point, std::numeric_limits<double>::max());
+    return evalPointDistance(point, std::numeric_limits<double>::max(), false);
 }
 
 /*!
@@ -92,10 +92,34 @@ double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point) con
 */
 double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point, double maxDistance) const
 {
+    return evalPointDistance(point, maxDistance, false);
+}
+
+/*!
+* Computes the distance between the specified point and the closest
+* cell contained in the tree. Only cells with a distance less than
+* the specified maximum distance will be considered. If all cells
+* contained in the tree are farther than the maximum distance, the
+* function will return the maximum representable distance.
+*
+* \param[in] point is the point
+* \param[in] maxDistance all cells whose distance is greater than
+* this parameters will not be considered for the evaluation of the
+* distance
+* \param[in] interiorOnly if set to true, only interior cells will be considered,
+* it will be possible to consider non-interior cells only if the tree has been
+* instantiated with non-interior cells support enabled
+* \result The distance between the specified point and the closest
+* cell contained in the tree. If all cells contained in the tree are
+* farther than the maximum distance, the function will return the
+* maximum representable distance.
+*/
+double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point, double maxDistance, bool interiorOnly) const
+{
     long id;
     double distance = maxDistance;
 
-    findPointClosestCell(point, &id, &distance);
+    findPointClosestCell(point, interiorOnly, &id, &distance);
 
     return distance;
 }
@@ -117,7 +141,7 @@ double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point, dou
 */
 long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, long *id, double *distance) const
 {
-    return findPointClosestCell(point, std::numeric_limits<double>::max(), id, distance);
+    return findPointClosestCell(point, std::numeric_limits<double>::max(), false, id, distance);
 }
 
 /*!
@@ -139,6 +163,32 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, lo
 */
 long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, double maxDistance,
                                           long *id, double *distance) const
+{
+    return findPointClosestCell(point, maxDistance, false, id, distance);
+}
+
+/*!
+* Given the specified point find the closest cell contained in the
+* three and evaluates the distance between that cell and the given
+* point.
+*
+* \param[in] point is the point
+* \param[in] maxDistance all cells whose distance is greater than
+* this parameters will not be considered for the evaluation of the
+* distance
+* \param[in] interiorOnly if set to true, only interior cells will be considered,
+* it will be possible to consider non-interior cells only if the tree has been
+* instantiated with non-interior cells support enabled
+* \param[out] id on output it will contain the id of the closest cell.
+* If all cells contained in the tree are farther than the maximum
+* distance, the argument will be set to the null id
+* \param[out] distance on output it will contain the distance between
+* the point and closest cell. If all cells contained in the tree are
+* farther than the maximum distance, the argument will be set to the
+* maximum representable distance
+*/
+long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, double maxDistance,
+                                          bool interiorOnly, long *id, double *distance) const
 {
     // Initialize the cell id
     *id = Cell::NULL_ID;
@@ -209,7 +259,7 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
         std::size_t nodeId = m_candidateIds[k];
         const SkdNode &node = m_nodes[nodeId];
 
-        node.updatePointClosestCell(point, id, distance);
+        node.updatePointClosestCell(point, interiorOnly, id, distance);
         ++nDistanceEvaluations;
     }
 

--- a/src/patchkernel/surface_skd_tree.hpp
+++ b/src/patchkernel/surface_skd_tree.hpp
@@ -44,6 +44,11 @@ public:
     void evalPointDistance(int nPoints, const std::array<double, 3> *points, double maxDistance, double *distances) const;
     void evalPointDistance(int nPoints, const std::array<double, 3> *points, const double *maxDistances, double *distances) const;
     void evalPointDistance(int nPoints, const std::array<double, 3> *points, const double *maxDistances, bool interorOnly, double *distances) const;
+#if BITPIT_ENABLE_MPI
+    void evalPointGlobalDistance(int nPoints, const std::array<double, 3> *points, double *distances) const;
+    void evalPointGlobalDistance(int nPoints, const std::array<double, 3> *points, double maxDistance, double *distances) const;
+    void evalPointGlobalDistance(int nPoints, const std::array<double, 3> *points, const double *maxDistances, double *distances) const;
+#endif
 
     long findPointClosestCell(const std::array<double,3> &point, long *id, double *distance) const;
     long findPointClosestCell(const std::array<double, 3> &point, double maxDistance, long *id, double *distance) const;
@@ -52,6 +57,11 @@ public:
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, double maxDistance, long *ids, double *distances) const;
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, long *ids, double *distances) const;
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, bool interorOnly, long *ids, double *distances) const;
+#if BITPIT_ENABLE_MPI
+    long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, long *ids, int *ranks, double *distances) const;
+    long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, double maxDistance, long *ids, int *ranks, double *distances) const;
+    long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, long *ids, int *ranks, double *distances) const;
+#endif
 
 private:
     mutable std::vector<std::size_t> m_candidateIds;

--- a/src/patchkernel/surface_skd_tree.hpp
+++ b/src/patchkernel/surface_skd_tree.hpp
@@ -33,7 +33,7 @@ namespace bitpit {
 class SurfaceSkdTree : public PatchSkdTree {
 
 public:
-    SurfaceSkdTree(const SurfaceKernel *patch);
+    SurfaceSkdTree(const SurfaceKernel *patch, bool interorOnly = false);
 
     void clear(bool release);
 

--- a/src/patchkernel/surface_skd_tree.hpp
+++ b/src/patchkernel/surface_skd_tree.hpp
@@ -40,10 +40,18 @@ public:
     double evalPointDistance(const std::array<double,3> &point) const;
     double evalPointDistance(const std::array<double,3> &point, double maxDistance) const;
     double evalPointDistance(const std::array<double,3> &point, double maxDistance, bool interorOnly) const;
+    void evalPointDistance(int nPoints, const std::array<double, 3> *points, double *distances) const;
+    void evalPointDistance(int nPoints, const std::array<double, 3> *points, double maxDistance, double *distances) const;
+    void evalPointDistance(int nPoints, const std::array<double, 3> *points, const double *maxDistances, double *distances) const;
+    void evalPointDistance(int nPoints, const std::array<double, 3> *points, const double *maxDistances, bool interorOnly, double *distances) const;
 
     long findPointClosestCell(const std::array<double,3> &point, long *id, double *distance) const;
     long findPointClosestCell(const std::array<double, 3> &point, double maxDistance, long *id, double *distance) const;
     long findPointClosestCell(const std::array<double, 3> &point, double maxDistance, bool interorOnly, long *id, double *distance) const;
+    long findPointClosestCell(int nPoints, const std::array<double, 3> *points, long *ids, double *distances) const;
+    long findPointClosestCell(int nPoints, const std::array<double, 3> *points, double maxDistance, long *ids, double *distances) const;
+    long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, long *ids, double *distances) const;
+    long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, bool interorOnly, long *ids, double *distances) const;
 
 private:
     mutable std::vector<std::size_t> m_candidateIds;

--- a/src/patchkernel/surface_skd_tree.hpp
+++ b/src/patchkernel/surface_skd_tree.hpp
@@ -39,9 +39,11 @@ public:
 
     double evalPointDistance(const std::array<double,3> &point) const;
     double evalPointDistance(const std::array<double,3> &point, double maxDistance) const;
+    double evalPointDistance(const std::array<double,3> &point, double maxDistance, bool interorOnly) const;
 
     long findPointClosestCell(const std::array<double,3> &point, long *id, double *distance) const;
     long findPointClosestCell(const std::array<double, 3> &point, double maxDistance, long *id, double *distance) const;
+    long findPointClosestCell(const std::array<double, 3> &point, double maxDistance, bool interorOnly, long *id, double *distance) const;
 
 private:
     mutable std::vector<std::size_t> m_candidateIds;

--- a/src/patchkernel/volume_skd_tree.cpp
+++ b/src/patchkernel/volume_skd_tree.cpp
@@ -37,9 +37,10 @@ namespace bitpit {
 * Constructor.
 *
 * \param patch is the volume patch that will be use to build the tree
+* \param interiorOnly if set to true, only interior cells will be considered
 */
-VolumeSkdTree::VolumeSkdTree(const VolumeKernel *patch)
-    : PatchSkdTree(patch)
+VolumeSkdTree::VolumeSkdTree(const VolumeKernel *patch, bool interiorOnly)
+    : PatchSkdTree(patch, interiorOnly)
 {
 }
 

--- a/src/patchkernel/volume_skd_tree.hpp
+++ b/src/patchkernel/volume_skd_tree.hpp
@@ -33,7 +33,7 @@ namespace bitpit {
 class VolumeSkdTree : public PatchSkdTree {
 
 public:
-    VolumeSkdTree(const VolumeKernel *patch);
+    VolumeSkdTree(const VolumeKernel *patch, bool interiorOnly = false);
 
 };
 

--- a/test/surfunstructured/CMakeLists.txt
+++ b/test/surfunstructured/CMakeLists.txt
@@ -45,6 +45,7 @@ if (ENABLE_MPI)
 	list(APPEND TESTS "test_surfunstructured_parallel_00003:4")
 	list(APPEND TESTS "test_surfunstructured_parallel_00004:4")
 	list(APPEND TESTS "test_surfunstructured_parallel_00005:3")
+	list(APPEND TESTS "test_surfunstructured_parallel_00006:2")
 endif ()
 
 # Test extra libraries

--- a/test/surfunstructured/test_surfunstructured_parallel_00006.cpp
+++ b/test/surfunstructured/test_surfunstructured_parallel_00006.cpp
@@ -1,0 +1,245 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include <ctime>
+#include <chrono>
+
+#include <bitpit_CG.hpp>
+#include <bitpit_IO.hpp>
+#include <bitpit_surfunstructured.hpp>
+
+using namespace bitpit;
+
+// Subtest 001
+//
+// Evaluation of the closest cell of a surface patch
+int subtest_001()
+{
+    int status = 0;
+    std::chrono::time_point<std::chrono::system_clock> start;
+    std::chrono::time_point<std::chrono::system_clock> end;
+
+    log::cout() << "** ================================================================= **" << std::endl;
+    log::cout() << "** Subtest #001 - Evaluation of the closest cell of a surface patch  **" << std::endl;
+    log::cout() << "** ================================================================= **" << std::endl;
+
+    // Importing STL
+    log::cout() << std::endl;
+    log::cout() << "Importing STL..." << std::endl;
+
+    std::unique_ptr<SurfUnstructured> surfaceMesh(new SurfUnstructured (2, 3));
+
+    // Set communicator ----------------------------------------------------- //
+    surfaceMesh->setCommunicator(MPI_COMM_WORLD);
+
+    int myRank = surfaceMesh->getRank();
+
+    surfaceMesh->setExpert(true);
+    if (myRank == 0) {
+        surfaceMesh->importSTL("./data/buddha.stl");
+        surfaceMesh->deleteCoincidentVertices();
+    }
+    surfaceMesh->buildAdjacencies();
+    surfaceMesh->getVTK().setName("skd_test_STL");
+    surfaceMesh->write();
+
+    log::cout() << "    Number of vertices: " << surfaceMesh->getVertexCount() << std::endl;
+    log::cout() << "    Number of elements : " << surfaceMesh->getCellCount() << std::endl;
+
+
+    {
+        // Scope variables ------------------------------------------------------ //
+        long nCells = surfaceMesh->getCellCount();
+
+        // Evaluation of baricenter ----------------------------------------------//
+        std::array<double, 3> baricenter = {{0, 0, 0}};
+        for (const auto &cell : surfaceMesh->getCells()) {
+            baricenter += surfaceMesh->evalCellCentroid(cell.getId());
+        }
+        baricenter = baricenter / ((double) nCells);
+
+        // Partitioning ----------------------------------------------------------//
+        log::cout() << "Mesh partitioning..." << std::endl;
+
+        std::unordered_map<long, int> cellRanks;
+        if (myRank == 0) {
+            for (const auto &cell : surfaceMesh->getCells()) {
+                long cellId = cell.getId();
+                int rank = (surfaceMesh->evalCellCentroid(cell.getId())[0] > baricenter[0]) ? 0 : 1;
+                cellRanks.insert({cellId, rank});
+            }
+        }
+
+        surfaceMesh->partition(cellRanks, false);
+
+        // Write mesh ----------------------------------------------------------- //
+        log::cout() << "Writing mesh..." << std::endl;
+        surfaceMesh->write();
+
+    }
+
+    // Build skd-tree
+    log::cout() << std::endl;
+    log::cout() << "Building skd-tree..." << std::endl;
+
+    int elapsed_initalization = 0;
+    start = std::chrono::system_clock::now();
+
+    SurfaceSkdTree searchTree(surfaceMesh.get());
+    searchTree.build();
+
+    end = std::chrono::system_clock::now();
+    elapsed_initalization = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
+
+    long treeDepth = searchTree.evalMaxDepth();
+    log::cout() << "    Maximum tree depth................. " << treeDepth << std::endl;
+
+    long expectedTreeDepth = searchTree.evalMaxDepth();
+    log::cout() << "    Expected maximum tree depth........ " << expectedTreeDepth << std::endl;
+
+    if (treeDepth != expectedTreeDepth) {
+        log::cout() << std::endl;
+        log::cout() << "    <<< Maximum tree depth doesn't match expected value >>>>" << std::endl;
+
+        status = 1;
+    }
+
+    assert(status == 0);
+    if (status != 0) {
+        return status;
+    }
+
+    log::cout() << std::endl;
+    log::cout() << "    Elapsed time for skd-tree initialization " << elapsed_initalization << " ms" << std::endl;
+
+    // Evaluate the closest cells
+    log::cout() << std::endl;
+    log::cout() << "Evaluation of the distance..." << std::endl;
+
+
+    std::vector<std::array<double, 3>> points;
+    std::vector<long> expectedIds;
+    if (myRank == 1){
+        points.push_back({{0., 0., 0.}});
+        points.push_back({{50., 0., 0.}});
+        points.push_back({{50., 50., 0.}});
+        points.push_back({{50., 0., 50.}});
+        expectedIds.push_back(8264);
+        expectedIds.push_back(65578);
+        expectedIds.push_back(269555);
+        expectedIds.push_back(73358);
+    }
+    else{
+        points.push_back({{-50., 0., 0.}});
+        points.push_back({{-50., 50., 0.}});
+        points.push_back({{-50., 0., 50.}});
+        expectedIds.push_back(1088);
+        expectedIds.push_back(130695);
+        expectedIds.push_back(33630);
+    }
+
+    int elapsed_distance_evaluation = 0.;
+    start = std::chrono::system_clock::now();
+
+    std::size_t nPoints = points.size();
+    std::vector<long> cellIds(nPoints);
+    std::vector<double> cellDistances(nPoints);
+    std::vector<int> cellRanks(nPoints);
+
+    searchTree.findPointClosestGlobalCell(nPoints, points.data(), cellIds.data(), cellRanks.data(), cellDistances.data());
+
+    for (std::size_t k = 0; k < nPoints; ++k) {
+        const std::array<double, 3> &point = points[k];
+        const long cellId = cellIds[k];
+        const double cellDistance = cellDistances[k];
+        const int rank = cellRanks[k] ;
+
+        log::cout() << std::endl;
+        log::cout() << "    Point .................... (" << point[0] << ", " <<  point[1] << ", " << point[2] << ")" << std::endl;
+        log::cout() << "    Closest cell ............. " << cellId << std::endl;
+        log::cout() << "    Expected closest cell .... " << expectedIds[k] << std::endl;
+        log::cout() << "    Owner Rank ............... " << rank << std::endl;
+        log::cout() << "    Distance ................. " << cellDistance << std::endl;
+
+        if (cellId != expectedIds[k]) {
+            log::cout() << std::endl;
+            log::cout() << "    <<< Closest cell doesn't match expected value >>>>" << std::endl;
+
+            status = 1;
+        }
+
+        assert(status == 0);
+    }
+
+    end = std::chrono::system_clock::now();
+    elapsed_distance_evaluation = std::chrono::duration_cast<std::chrono::milliseconds>(end-start).count();
+    log::cout() << std::endl;
+    log::cout() << "    Elapsed time for distance evaluation " << elapsed_distance_evaluation << " ms" << std::endl;
+
+    return status;
+}
+
+/*!
+* Main program.
+*/
+int main(int argc, char *argv[])
+{
+#if BITPIT_ENABLE_MPI==1
+    MPI_Init(&argc,&argv);
+#else
+    BITPIT_UNUSED(argc);
+    BITPIT_UNUSED(argv);
+#endif
+
+    // ====================================================================== //
+    // Initialize the logger
+    // ====================================================================== //
+#if BITPIT_ENABLE_MPI==1
+    int nProcs;
+    int rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    log::manager().initialize(log::COMBINED, true, nProcs, rank);
+    log::cout().setVisibility(log::GLOBAL);
+#endif
+
+    // Run the subtests
+    int status = 0;
+    try {
+        status = subtest_001();
+        if (status != 0) {
+            return (10 + status);
+        }
+    } catch (const std::exception &exception) {
+        log::cout() << exception.what();
+        exit(1);
+    }
+
+#if BITPIT_ENABLE_MPI==1
+    MPI_Finalize();
+#endif
+
+    return status;
+}


### PR DESCRIPTION
Surface skd-tree searches work now properly on partitioned patches ("partitioned" means that the "PatchKernel::partition" function has been called before building the skd-tree).