### PR TITLE
discretization: optimize evaluation of pseudo inverse

### DIFF
--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -287,6 +287,7 @@ private:
     mutable std::vector<double> m_U;
     mutable std::vector<double> m_S;
     mutable std::vector<double> m_Vt;
+    mutable std::vector<double> m_SVDWorkspace;
     mutable std::vector<double> m_w;
 
     double * _addEquation(ReconstructionType type, double scaleFactor);


### PR DESCRIPTION
LAPACKE_dgesvd function silently allocates a workspace every time is called. Using the function dgesvd_ it is possible to store the workspace inside the ReconstructionAssembler class.