### PR TITLE
IO/VTK: return constant references whenever possible

### DIFF
--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -94,7 +94,7 @@ void  VTK::setHeaderType(const std::string &st){
  * Get header type for appended binary output
  * @return header type ["UInt32"/"UInt64"]
  */
-std::string  VTK::getHeaderType( ) const{ 
+const std::string &  VTK::getHeaderType( ) const{
     return m_headerType ;
 }
 

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -251,7 +251,7 @@ class VTKField{
         VTKField();
         VTKField( const std::string & );
 
-        std::string             getName() const;
+        const std::string &     getName() const;
         VTKDataType             getDataType() const;
         VTKFieldType            getFieldType() const;
         VTKLocation             getLocation() const;
@@ -302,7 +302,7 @@ class VTK{
         virtual ~VTK( ) = default;
 
         void                    setHeaderType( const std::string & );
-        std::string             getHeaderType(  ) const;
+        const std::string &     getHeaderType(  ) const;
 
         std::string             getName(  ) const;
         std::string             getDirectory(  ) const;

--- a/src/IO/VTKField.cpp
+++ b/src/IO/VTKField.cpp
@@ -140,7 +140,7 @@ void VTKField::disable(){
  * get name of data field
  * @return  name of data field
  */
-std::string VTKField::getName() const{ 
+const std::string & VTKField::getName() const{
     return m_name; 
 }
 


### PR DESCRIPTION
Some strings can be returned as constant references.