### PR TITLE
IO/STL: speedup reading of ASCII files

### DIFF
--- a/src/IO/STL.hpp
+++ b/src/IO/STL.hpp
@@ -32,6 +32,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "line_stream.hpp"
+
 namespace bitpit {
 
 class STLBase {
@@ -125,6 +127,8 @@ public:
 
 private:
     std::ifstream m_fileHandle;      /**< File handle */
+
+    LineStream m_lineStream;    /**< Line stream */
 
     int inspectASCII(InspectionInfo *info);
     int inspectSolidASCII(std::size_t *nFactes, std::array<bool, 6> *errors);

--- a/src/IO/line_stream.cpp
+++ b/src/IO/line_stream.cpp
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include <cstring>
+
+#include "line_stream.hpp"
+
+namespace bitpit {
+
+/*!
+    \class LineBuffer
+    \brief LineBuffer defines a buffer for reading lines.
+*/
+
+/*!
+    Constructor.
+*/
+LineBuffer::LineBuffer()
+    : m_buffer(CHUNK_SIZE)
+{
+}
+
+/*!
+    Read a line from the file.
+
+    \param fileHandle is the file handle
+*/
+int LineBuffer::readLine(std::ifstream &fileHandle)
+{
+    int lineLength = 0;
+    while (true) {
+        if (m_buffer.size() - lineLength < CHUNK_SIZE) {
+            m_buffer.resize(m_buffer.size() + CHUNK_SIZE);
+        }
+
+        fileHandle.getline(m_buffer.data() + lineLength, CHUNK_SIZE);
+        lineLength = strlen(m_buffer.data());
+
+        // If we haven't find the end of the line, we keep reading
+        if (fileHandle.good() || fileHandle.eof() || fileHandle.bad()) {
+            break;
+        } else if (fileHandle.fail()) {
+            fileHandle.clear();
+        }
+    }
+
+    setg(m_buffer.data(), m_buffer.data(), m_buffer.data() + lineLength);
+
+    if ((fileHandle.eof() || fileHandle.bad()) && lineLength == 0) {
+        return -1;
+    } else {
+        return lineLength;
+    }
+}
+
+/*!
+    Get a copy of the current line.
+
+    \param line on output will contain the current line
+*/
+void LineBuffer::copyLine(std::string *line) const
+{
+    line->assign(eback(), egptr() - eback());
+}
+
+/*!
+    \class LineStream
+    \brief LineStream defines a stream for reading lines.
+*/
+
+/*!
+    Constructor.
+*/
+LineStream::LineStream()
+    : LineBuffer(), std::istream(this)
+{
+}
+
+/*!
+    Read a line from the file.
+
+    \param fileHandle is the file handle
+*/
+int LineStream::readLine(std::ifstream &fileHandle)
+{
+    std::istream::clear();
+
+    return static_cast<LineBuffer *>(std::istream::rdbuf())->readLine(fileHandle);
+}
+
+}

--- a/src/IO/line_stream.hpp
+++ b/src/IO/line_stream.hpp
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#ifndef __BITPIT_LINE_STREAM_HPP__
+#define __BITPIT_LINE_STREAM_HPP__
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+
+namespace bitpit {
+
+class LineBuffer : public std::streambuf {
+
+public:
+    int readLine(std::ifstream &fileHandle);
+    void copyLine(std::string *line) const;
+
+protected:
+    LineBuffer();
+
+private:
+    static const int CHUNK_SIZE = 1024;
+
+    std::vector<char> m_buffer;
+
+};
+
+class LineStream : protected LineBuffer, public std::istream {
+
+public:
+    LineStream();
+
+    int readLine(std::ifstream &fileHandle);
+
+    using LineBuffer::copyLine;
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
The speedup is achieved using a custom stream instead of the std::stingstream. 

With these changes, the time it takes to generate a SurfUnstructured patch form an ASCII file of 450k triangles goes from 11.3 seconds to 9.3 seconds.