### PR TITLE
levelset: optimize evaluation of segmentation vertex normals

### DIFF
--- a/src/CG/CG.hpp
+++ b/src/CG/CG.hpp
@@ -111,6 +111,7 @@ array3D projectPointSegment( array3D const &, array3D const &, array3D const &, 
 array3D projectPointSegment( array3D const &, array3D const &, array3D const &, double* );
 array3D projectPointTriangle( array3D const &, array3D const &, array3D const &, array3D const & );
 array3D projectPointTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D & );
+array3D projectPointTriangle( array3D const &P, array3D const &Q0, array3D const &Q1, array3D const &Q2, double *lambda );
 array3D projectPointPolygon( array3D const &, std::vector<array3D> const & );
 array3D projectPointPolygon( array3D const &, std::size_t, array3D const * );
 array3D projectPointPolygon( array3D const &, std::vector<array3D> const &, std::vector<double> & );

--- a/src/CG/CG_elem.cpp
+++ b/src/CG/CG_elem.cpp
@@ -1049,8 +1049,22 @@ array3D projectPointTriangle( array3D const &P, array3D const &Q0, array3D const
  */
 array3D projectPointTriangle( array3D const &P, array3D const &Q0, array3D const &Q1, array3D const &Q2, array3D &lambda)
 {
+    return projectPointTriangle( P, Q0, Q1, Q2, lambda.data() );
+}
+
+/*!
+ * Computes projection of point on triangle
+ * \param[in] P point coordinates
+ * \param[in] Q0 first triangle vertex
+ * \param[in] Q1 second triangle vertex
+ * \param[in] Q2 third triangle vertex
+ * \param[out] lambda barycentric coordinates of projection point
+ * \return coordinates of projection point
+ */
+array3D projectPointTriangle( array3D const &P, array3D const &Q0, array3D const &Q1, array3D const &Q2, double *lambda)
+{
     array3D xP;
-    _projectPointsTriangle( 1, &P, Q0, Q1, Q2, &xP, lambda.data() );
+    _projectPointsTriangle( 1, &P, Q0, Q1, Q2, &xP, lambda );
 
     return xP;
 }

--- a/src/IO/logger.cpp
+++ b/src/IO/logger.cpp
@@ -831,9 +831,7 @@ void Logger::print(const std::string &message)
 */
 void Logger::print(const std::string &message, log::Priority priority)
 {
-    setPriority(priority);
-
-    (*this) << message;
+    print(message, priority, getVisibility());
 }
 
 /*!
@@ -844,9 +842,7 @@ void Logger::print(const std::string &message, log::Priority priority)
 */
 void Logger::print(const std::string &message, log::Visibility visibility)
 {
-    setVisibility(visibility);
-
-    (*this) << message;
+    print(message, getPriority(), visibility);
 }
 
 /*!
@@ -858,16 +854,25 @@ void Logger::print(const std::string &message, log::Visibility visibility)
 */
 void Logger::print(const std::string &message, log::Priority priority, log::Visibility visibility)
 {
-    log::Priority prevPriority   = getPriority();
-    log::Visibility prevVisibility = getVisibility();
+    log::Priority initialPriority = getPriority();
+    if (priority != initialPriority) {
+        setPriority(priority);
+    }
 
-    setPriority(priority);
-    setVisibility(visibility);
+    log::Visibility initialVisibility = getVisibility();
+    if (visibility != initialVisibility) {
+        setVisibility(visibility);
+    }
 
     (*this) << message;
 
-    setPriority(prevPriority);
-    setVisibility(prevVisibility);
+    if (priority != initialPriority) {
+        setPriority(initialPriority);
+    }
+
+    if (visibility != initialVisibility) {
+        setVisibility(initialVisibility);
+    }
 }
 
 /*!

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -120,8 +120,29 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
         long segmentId = segmentItr.getId() ;
         std::size_t segmentRawId = segmentItr.getRawIndex() ;
         const Cell &segment = *segmentItr;
+        ElementType segmentType = segment.getType() ;
         int nSegmentVertices = segment.getVertexCount() ;
         std::vector<std::array<double,3>> *segmentVertexNormals = m_segmentVertexNormals.rawData(segmentRawId);
+
+        // Check if segment is supported
+        bool segmentSupported ;
+        switch (segmentType) {
+
+        case ElementType::VERTEX :
+        case ElementType::LINE :
+        case ElementType::TRIANGLE :
+            segmentSupported = true ;
+            break ;
+
+        default:
+            segmentSupported = false ;
+            break ;
+
+        }
+
+        if ( !segmentSupported ) {
+            throw std::runtime_error ("levelset: only segments and triangles supported in LevelSetSegmentation!") ;
+        }
 
         // Evaluate segment vertex normals
         //
@@ -166,10 +187,6 @@ void SegmentationKernel::getSegmentVertexCoords( long id, std::vector<std::array
     for (int n = 0; n < nVertices; ++n) {
         long vertexId = segmentConnect[n] ;
         (*coords)[n] = m_surface->getVertexCoords(vertexId);
-    }
-
-    if ( nVertices > 3 ) {
-        log::cout() << "levelset: only segments and triangles supported in LevelSetSegmentation !!" << std::endl ;
     }
 }
 

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -93,6 +93,14 @@ const SurfUnstructured & SegmentationKernel::getSurface() const {
 }
 
 /*!
+ * Get search tree
+ * @return search tree;
+ */
+const SurfaceSkdTree & SegmentationKernel::getSearchTree() const {
+    return *m_searchTree;
+}
+
+/*!
  * Set the surface
  * @param[in] surface pointer to surface
  * @param[in] featureAngle feature angle. If the angle between two segments is bigger than this angle, the enclosed edge is considered as a sharp edge
@@ -139,8 +147,8 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
     }
 
     // Initialize search tree
-    m_searchTreeUPtr = std::unique_ptr<SurfaceSkdTree>(new SurfaceSkdTree(surface));
-    m_searchTreeUPtr->build();
+    m_searchTree = std::unique_ptr<SurfaceSkdTree>(new SurfaceSkdTree(surface));
+    m_searchTree->build();
 }
 
 /*!
@@ -784,7 +792,7 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
             searchRadius = factor *cellSize;
         }
 
-        m_segmentation->m_searchTreeUPtr->findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
+        m_segmentation->getSearchTree().findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
 
         if(segmentId>=0){
 
@@ -835,7 +843,7 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
 
             centroid = visitee->computeCellCentroid(neighId);
             searchRadius =  1.05 *norm2(centroid-root);
-            m_segmentation->m_searchTreeUPtr->findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
+            m_segmentation->getSearchTree().findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
 
             if(segmentId>=0){
 
@@ -904,7 +912,7 @@ void LevelSetSegmentation::updateLSInNarrowBand( LevelSetOctree *visitee, const 
                 searchRadius =  factor *cellSize;
             }
 
-            m_segmentation->m_searchTreeUPtr->findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
+            m_segmentation->getSearchTree().findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
 
             if(segmentId>=0){
 
@@ -952,7 +960,7 @@ void LevelSetSegmentation::updateLSInNarrowBand( LevelSetOctree *visitee, const 
                 root = computeProjectionPoint(neighId);
 
                 searchRadius =  1.05 *norm2(centroid-root);
-                m_segmentation->m_searchTreeUPtr->findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
+                m_segmentation->getSearchTree().findPointClosestCell(centroid, searchRadius, &segmentId, &distance);
 
                 if(segmentId>=0){
 
@@ -1127,7 +1135,7 @@ LevelSetInfo LevelSetSegmentation::computeLevelSetInfo(const std::array<double,3
     std::array<double,3> gradient;
     std::array<double,3> normal;
 
-    m_segmentation->m_searchTreeUPtr->findPointClosestCell(coords, &segmentId, &distance);
+    m_segmentation->getSearchTree().findPointClosestCell(coords, &segmentId, &distance);
 
     int error = m_segmentation->getSegmentInfo(coords, segmentId, false, distance, gradient, normal);
     if (error) {

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -117,6 +117,7 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
 
     std::vector<std::array<double,3>> limitedVertexNormal ;
     std::vector<std::array<double,3>> vertexNormal ;
+    std::vector<long> vertexNeighbours ;
 
     m_surface      = surface;
     m_featureAngle = featureAngle;
@@ -131,8 +132,11 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
 
         double misalignment = 0. ;
         for( int i = 0; i < nVertices; ++i ){
-            vertexNormal[i] = m_surface->evalVertexNormal(segmentId, i) ;
-            limitedVertexNormal[i]   = m_surface->evalLimitedVertexNormal(segmentId, i, m_featureAngle) ;
+            vertexNeighbours.clear();
+            m_surface->findCellVertexNeighs(segmentId, i, &vertexNeighbours);
+
+            vertexNormal[i] = m_surface->evalVertexNormal(segmentId, i, vertexNeighbours.size(), vertexNeighbours.data()) ;
+            limitedVertexNormal[i] = m_surface->evalLimitedVertexNormal(segmentId, i, vertexNeighbours.size(), vertexNeighbours.data(), m_featureAngle) ;
 
             misalignment += norm2(vertexNormal[i] - limitedVertexNormal[i]) ;
         }

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -60,7 +60,7 @@ SegmentationKernel::SegmentationKernel( ) : m_surface(nullptr), m_featureAngle(0
  */
 SegmentationKernel::SegmentationKernel( std::unique_ptr<const SurfUnstructured> &&surface, double featureAngle ) {
 
-    m_ownedSurface = std::shared_ptr<const SurfUnstructured>(surface.release());
+    m_ownedSurface = std::move(surface);
 
     setSurface(m_ownedSurface.get(), featureAngle);
 }

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
     const SurfUnstructured *m_surface;
-    std::shared_ptr<const SurfUnstructured> m_ownedSurface;
+    std::unique_ptr<const SurfUnstructured> m_ownedSurface;
     double m_featureAngle;
 
     PiercedStorage<std::vector< std::array<double,3>>> m_segmentVertexNormals;

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -59,15 +59,17 @@ public:
     const SurfUnstructured & getSurface() const;
     double getFeatureAngle() const;
 
+    const SurfaceSkdTree & getSearchTree() const ;
+
     void getSegmentVertexCoords(long id, std::vector<std::array<double,3>> *coords) const;
     int getSegmentInfo( const std::array<double,3> &p, long i, bool signd, double &d, std::array<double,3> &x, std::array<double,3> &n ) const;
-
-    std::unique_ptr<SurfaceSkdTree> m_searchTreeUPtr;
 
 private:
     const SurfUnstructured *m_surface;
     std::unique_ptr<const SurfUnstructured> m_ownedSurface;
     double m_featureAngle;
+
+    std::unique_ptr<SurfaceSkdTree> m_searchTree;
 
     PiercedStorage<std::vector< std::array<double,3>>> m_segmentVertexNormals;
 

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -62,9 +62,6 @@ public:
     void getSegmentVertexCoords(long id, std::vector<std::array<double,3>> *coords) const;
     int getSegmentInfo( const std::array<double,3> &p, long i, bool signd, double &d, std::array<double,3> &x, std::array<double,3> &n ) const;
 
-    const std::unordered_map<long, std::vector< std::array<double,3>>> & getLimitedVertexNormals() const;
-    const std::unordered_map<long, std::vector< std::array<double,3>>> & getVertexNormals() const;
-
     std::unique_ptr<SurfaceSkdTree> m_searchTreeUPtr;
 
 private:
@@ -72,8 +69,7 @@ private:
     std::shared_ptr<const SurfUnstructured> m_ownedSurface;
     double m_featureAngle;
 
-    std::unordered_map<long, std::vector< std::array<double,3>>> m_limitedVertexNormals;
-    std::unordered_map<long, std::vector< std::array<double,3>>> m_vertexNormals;
+    PiercedStorage<std::vector< std::array<double,3>>> m_segmentVertexNormals;
 
     void setSurface( const SurfUnstructured *surface, double featureAngle);
 

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -56,7 +56,9 @@ public:
         virtual std::array<double, 3> evalFacetNormal(long) const;
         std::array<double, 3> evalEdgeNormal(long, int) const;
         std::array<double, 3> evalVertexNormal(long, int) const;
-        virtual std::array<double, 3> evalLimitedVertexNormal(long, int, double ) const;
+        std::array<double, 3> evalVertexNormal(long, int, std::size_t, const long *) const;
+        std::array<double, 3> evalLimitedVertexNormal(long, int, double ) const;
+        virtual std::array<double, 3> evalLimitedVertexNormal(long, int, std::size_t, const long *, double ) const;
         double evalCellSize(long id) const override;
 
         bool adjustCellOrientation();


### PR DESCRIPTION
Some optimizations that should speedup generation of segmentation and reduce memory allocations:
 - allow to pass the list of vertex neighbours to the PatchKernel functions that evaluate vertex normal, this avoids multiple evaluation of the neighbours when setting segmentation kernel surface;
 - avoid storing both limited and unlimited vertex normals, only the one that will be used to evaluate segment information is now stored;
 - store vertex normals using a PiercedStorage.