### PR TITLE
patchkernel: simplify function that get vertex coordinates

### DIFF
--- a/src/levelset/levelSetKernel.cpp
+++ b/src/levelset/levelSetKernel.cpp
@@ -242,7 +242,7 @@ double LevelSetKernel::isCellInsideBoundingBox( long id, const std::array<double
     int nCellVertices = cellVertexIds.size();
     for (int i = 0; i < nCellVertices; ++i) {
         long vertexId = cellVertexIds[i];
-        std::array<double, 3> vertexCoords = m_mesh->getVertexCoords(vertexId);
+        const std::array<double, 3> &vertexCoords = m_mesh->getVertexCoords(vertexId);
         for (int d = 0; d < 3; ++d) {
             cellMinPoint[d] = std::min( vertexCoords[d] - tolerance, cellMinPoint[d]) ;
             cellMaxPoint[d] = std::max( vertexCoords[d] + tolerance, cellMaxPoint[d]) ;

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -61,7 +61,6 @@ public:
 
     const SurfaceSkdTree & getSearchTree() const ;
 
-    void getSegmentVertexCoords(long id, std::vector<std::array<double,3>> *coords) const;
     int getSegmentInfo( const std::array<double,3> &p, long i, bool signd, double &d, std::array<double,3> &x, std::array<double,3> &n ) const;
 
 private:

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -4309,10 +4309,12 @@ ConstProxyVector<std::array<double, 3>> PatchKernel::getInterfaceVertexCoordinat
 */
 std::array<double, 3> PatchKernel::evalElementCentroid(const Element &element) const
 {
-	std::array<std::array<double, 3>, ReferenceElementInfo::MAX_ELEM_VERTICES> referenceCoordinatesCache;
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates = getElementVertexCoordinates(element, referenceCoordinatesCache.data());
+	ConstProxyVector<long> elementVertexIds = element.getVertexIds();
+	std::size_t nCellVertices = elementVertexIds.size();
+	BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nCellVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
+	getVertexCoords(nCellVertices, elementVertexIds.data(), vertexCoordinates);
 
-	return element.evalCentroid(vertexCoordinates.data());
+	return element.evalCentroid(vertexCoordinates);
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1617,6 +1617,35 @@ const std::array<double, 3> & PatchKernel::getVertexCoords(long id) const
 }
 
 /*!
+	Gets the coordinates of the specified vertices.
+
+	\param nVertices is the number of vertices
+	\param ids are the ids of the requested vertices
+	\param[out] coordinates on output will contain the vertex coordinates
+*/
+void PatchKernel::getVertexCoords(std::size_t nVertices, const long *ids, std::unique_ptr<std::array<double, 3>[]> *coordinates) const
+{
+	*coordinates = std::unique_ptr<std::array<double, 3>[]>(new std::array<double, 3>[nVertices]);
+	getVertexCoords(nVertices, ids, coordinates->get());
+}
+
+/*!
+	Gets the coordinates of the specified vertices.
+
+	\param nVertices is the number of vertices
+	\param ids are the ids of the requested vertices
+	\param[out] coordinates on output will contain the vertex coordinates, it
+	is up to the caller to ensure that the storage has enough space for all
+	the vertex coordinates
+*/
+void PatchKernel::getVertexCoords(std::size_t nVertices, const long *ids, std::array<double, 3> *coordinates) const
+{
+	for (std::size_t i = 0; i < nVertices; ++i) {
+		coordinates[i] = getVertex(ids[i]).getCoords();
+	}
+}
+
+/*!
 	Return true if the patch is emtpy.
 
 	\return Return true if the patch is emtpy.

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -395,7 +395,9 @@ public:
 	long countOrphanCells() const;
 	virtual std::array<double, 3> evalCellCentroid(long id) const;
 	virtual void evalCellBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const;
-	ConstProxyVector<std::array<double, 3>> getCellVertexCoordinates(long id, std::array<double, 3> *staticStorage = nullptr) const;
+	BITPIT_DEPRECATED(ConstProxyVector<std::array<double BITPIT_COMMA 3>> getCellVertexCoordinates(long id) const);
+	void getCellVertexCoordinates(long id, std::unique_ptr<std::array<double, 3>[]> *coordinates) const;
+	void getCellVertexCoordinates(long id, std::array<double, 3> *coordinates) const;
 	std::vector<long> findCellNeighs(long id) const;
 	void findCellNeighs(long id, std::vector<long> *neighs) const;
 	std::vector<long> findCellNeighs(long id, int codimension, bool complete = true) const;
@@ -462,7 +464,9 @@ public:
 	bool isInterfaceOrphan(long id) const;
 	virtual std::array<double, 3> evalInterfaceCentroid(long id) const;
 	virtual void evalInterfaceBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const;
-	ConstProxyVector<std::array<double, 3>> getInterfaceVertexCoordinates(long id, std::array<double, 3> *staticStorage = nullptr) const;
+	BITPIT_DEPRECATED(ConstProxyVector<std::array<double BITPIT_COMMA 3>> getInterfaceVertexCoordinates(long id) const);
+	void getInterfaceVertexCoordinates(long id, std::unique_ptr<std::array<double, 3>[]> *coordinates) const;
+	void getInterfaceVertexCoordinates(long id, std::array<double, 3> *coordinates) const;
 
 	InterfaceIterator getInterfaceIterator(long id);
 	InterfaceIterator interfaceBegin();
@@ -588,7 +592,9 @@ public:
 
 	std::array<double, 3> evalElementCentroid(const Element &element) const;
 	void evalElementBoundingBox(const Element &element, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const;
-	ConstProxyVector<std::array<double, 3>> getElementVertexCoordinates(const Element &element, std::array<double, 3> *externalStorage = nullptr) const;
+	BITPIT_DEPRECATED(ConstProxyVector<std::array<double BITPIT_COMMA 3>> getElementVertexCoordinates(const Element &element) const);
+	void getElementVertexCoordinates(const Element &element, std::unique_ptr<std::array<double, 3>[]> *coordinates) const;
+	void getElementVertexCoordinates(const Element &element, std::array<double, 3> *coordinates) const;
 
 protected:
 #if BITPIT_ENABLE_MPI==1

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -331,6 +331,8 @@ public:
 	Vertex &getVertex(long id);
 	const Vertex & getVertex(long id) const;
 	const std::array<double, 3> & getVertexCoords(long id) const;
+	void getVertexCoords(std::size_t nVertices, const long *ids, std::unique_ptr<std::array<double, 3>[]> *coordinates) const;
+	void getVertexCoords(std::size_t nVertices, const long *ids, std::array<double, 3> *coordinates) const;
 	VertexIterator addVertex(const Vertex &source, long id = Vertex::NULL_ID);
 	VertexIterator addVertex(Vertex &&source, long id = Vertex::NULL_ID);
 	VertexIterator addVertex(const std::array<double, 3> &coords, long id = Vertex::NULL_ID);

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2011,8 +2011,8 @@ bool VolOctree::isPointInside(long id, const std::array<double, 3> &point) const
     int lowerLeftVertex  = 0;
 	int upperRightVertex = pow(2, getDimension()) - 1;
 
-	std::array<double, 3> lowerLeft  = getVertexCoords(cellVertexIds[lowerLeftVertex]);
-	std::array<double, 3> upperRight = getVertexCoords(cellVertexIds[upperRightVertex]);
+	const std::array<double, 3> &lowerLeft  = getVertexCoords(cellVertexIds[lowerLeftVertex]);
+	const std::array<double, 3> &upperRight = getVertexCoords(cellVertexIds[upperRightVertex]);
 
 	const double EPS = getTol();
     for (int d = 0; d < 3; ++d){

--- a/src/volunstructured/volunstructured.cpp
+++ b/src/volunstructured/volunstructured.cpp
@@ -115,15 +115,17 @@ void VolUnstructured::setExpert(bool expert)
 */
 double VolUnstructured::evalCellVolume(long id) const
 {
-	std::array<std::array<double, 3>, ReferenceElementInfo::MAX_ELEM_VERTICES> coordinatesStaticPool;
-
 	const Cell &cell = getCell(id);
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates = getElementVertexCoordinates(cell, coordinatesStaticPool.data());
+
+	ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
+	std::size_t nCellVertices = cellVertexIds.size();
+	BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nCellVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
+	getVertexCoords(nCellVertices, cellVertexIds.data(), vertexCoordinates);
 
 	if (isThreeDimensional()) {
-		return cell.evalVolume(vertexCoordinates.data());
+		return cell.evalVolume(vertexCoordinates);
 	} else {
-		return cell.evalArea(vertexCoordinates.data());
+		return cell.evalArea(vertexCoordinates);
 	}
 }
 
@@ -135,12 +137,14 @@ double VolUnstructured::evalCellVolume(long id) const
 */
 double VolUnstructured::evalCellSize(long id) const
 {
-	std::array<std::array<double, 3>, ReferenceElementInfo::MAX_ELEM_VERTICES> coordinatesStaticPool;
-
 	const Cell &cell = getCell(id);
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates = getElementVertexCoordinates(cell, coordinatesStaticPool.data());
 
-	return cell.evalSize(vertexCoordinates.data());
+	ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
+	std::size_t nCellVertices = cellVertexIds.size();
+	BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nCellVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
+	getVertexCoords(nCellVertices, cellVertexIds.data(), vertexCoordinates);
+
+	return cell.evalSize(vertexCoordinates);
 }
 
 /*!
@@ -151,15 +155,17 @@ double VolUnstructured::evalCellSize(long id) const
 */
 double VolUnstructured::evalInterfaceArea(long id) const
 {
-	std::array<std::array<double, 3>, ReferenceElementInfo::MAX_ELEM_VERTICES> coordinatesStaticPool;
-
 	const Interface &interface = getInterface(id);
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates = getElementVertexCoordinates(interface, coordinatesStaticPool.data());
+
+	ConstProxyVector<long> interfaceVertexIds = interface.getVertexIds();
+	std::size_t nInterfaceVertices = interfaceVertexIds.size();
+	BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nInterfaceVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
+	getVertexCoords(nInterfaceVertices, interfaceVertexIds.data(), vertexCoordinates);
 
 	if (isThreeDimensional()) {
-		return interface.evalArea(vertexCoordinates.data());
+		return interface.evalArea(vertexCoordinates);
 	} else {
-		return interface.evalLength(vertexCoordinates.data());
+		return interface.evalLength(vertexCoordinates);
 	}
 }
 
@@ -171,10 +177,12 @@ double VolUnstructured::evalInterfaceArea(long id) const
 */
 std::array<double, 3> VolUnstructured::evalInterfaceNormal(long id) const
 {
-	std::array<std::array<double, 3>, ReferenceElementInfo::MAX_ELEM_VERTICES> coordinatesStaticPool;
-
 	const Interface &interface = getInterface(id);
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates = getElementVertexCoordinates(interface, coordinatesStaticPool.data());
+
+	ConstProxyVector<long> interfaceVertexIds = interface.getVertexIds();
+	std::size_t nInterfaceVertices = interfaceVertexIds.size();
+	BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nInterfaceVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
+	getVertexCoords(nInterfaceVertices, interfaceVertexIds.data(), vertexCoordinates);
 
 	std::array<double, 3> orientation = {{0., 0., 0.}};
 	if (!isThreeDimensional()) {
@@ -191,7 +199,7 @@ std::array<double, 3> VolUnstructured::evalInterfaceNormal(long id) const
 		orientation = crossProduct(V_B - V_A, V_Z - V_A);
 	}
 
-	return interface.evalNormal(vertexCoordinates.data(), orientation);
+	return interface.evalNormal(vertexCoordinates, orientation);
 }
 
 /*!

--- a/test/discretization/test_discretization_00001.cpp
+++ b/test/discretization/test_discretization_00001.cpp
@@ -59,13 +59,13 @@ int subtest_001()
         long cellId;
         Reconstruction::ReconstructionType reconstructionType;
         std::array<double, 3> reconstructionOrigin = {{0., 0., 0.}};
-        ConstProxyVector<std::array<double, 3>> vertexCoords;
+        std::vector<std::array<double, 3>> vertexCoords(ReferenceElementInfo::getInfo(ElementType::PIXEL).nVertices);
 
         Reconstruction reconstruction(0, dimensions);
 
         // Base cell
         cellId = 12;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_CONSTRAINT;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
@@ -81,37 +81,37 @@ int subtest_001()
         long cellId;
         Reconstruction::ReconstructionType reconstructionType;
         std::array<double, 3> reconstructionOrigin = {{0., 0., 0.}};
-        ConstProxyVector<std::array<double, 3>> vertexCoords;
+        std::vector<std::array<double, 3>> vertexCoords(ReferenceElementInfo::getInfo(ElementType::PIXEL).nVertices);
 
         Reconstruction reconstruction(1, dimensions);
 
         // Base cell
         cellId = 12;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_CONSTRAINT;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // West neighbour
         cellId = 11;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // East neighbour
         cellId = 13;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // South neighbour
         cellId = 7;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // North neighbour
         cellId = 17;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
@@ -139,31 +139,31 @@ int subtest_001()
         long cellId;
         Reconstruction::ReconstructionType reconstructionType;
         std::array<double, 3> reconstructionOrigin = {{0., 0., 0.}};
-        ConstProxyVector<std::array<double, 3>> vertexCoords;
+        std::vector<std::array<double, 3>> vertexCoords(ReferenceElementInfo::getInfo(ElementType::PIXEL).nVertices);
 
         Reconstruction reconstruction(1, dimensions);
 
         // Base cell
         cellId = 12;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_CONSTRAINT;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // West neighbour
         cellId = 11;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // South neighbour
         cellId = 7;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // South-west neighbour
         cellId = 6;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
@@ -179,13 +179,13 @@ int subtest_001()
         long cellId;
         Reconstruction::ReconstructionType reconstructionType;
         std::array<double, 3> reconstructionOrigin = {{0., 0., 0.}};
-        ConstProxyVector<std::array<double, 3>> vertexCoords;
+        std::vector<std::array<double, 3>> vertexCoords(ReferenceElementInfo::getInfo(ElementType::PIXEL).nVertices);
 
         Reconstruction reconstruction(2, dimensions);
 
         // Base cell
         cellId = 12;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_CONSTRAINT;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
@@ -197,7 +197,7 @@ int subtest_001()
                 }
 
                 cellId = patch.getCellLinearId(2 + i, 2 + j, 0);
-                vertexCoords = patch.getCellVertexCoordinates(cellId);
+                patch.getCellVertexCoordinates(cellId, vertexCoords.data());
                 reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
                 reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
             }
@@ -239,25 +239,25 @@ int subtest_002()
         std::array<double, 3> direction;
         Reconstruction::ReconstructionType reconstructionType;
         std::array<double, 3> reconstructionOrigin = {{0., 0., 0.}};
-        ConstProxyVector<std::array<double, 3>> vertexCoords;
+        std::vector<std::array<double, 3>> vertexCoords(ReferenceElementInfo::getInfo(ElementType::PIXEL).nVertices);
 
         Reconstruction reconstruction(1, dimensions);
 
         // Base cell
         cellId = 12;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_CONSTRAINT;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // West neighbour
         cellId = 11;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 
         // South neighbour
         cellId = 7;
-        vertexCoords = patch.getCellVertexCoordinates(cellId);
+        patch.getCellVertexCoordinates(cellId, vertexCoords.data());
         reconstructionType = Reconstruction::TYPE_LEAST_SQUARE;
         reconstruction.addCellAverageEquation(reconstructionType, patch.getCell(cellId), reconstructionOrigin, vertexCoords.data());
 


### PR DESCRIPTION
There is no need to use a ProxyVector to store vertex coordinates, just use plain pointers.