### PR TITLE
reconstruction: optimize storage for assembler equation coefficients

### DIFF
--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -280,8 +280,8 @@ private:
 
     std::vector<double> m_leastSquaresScaleFactors;
 
-    std::vector<std::vector<double>> m_A;
-    std::vector<std::vector<double>> m_C;
+    std::vector<double> m_A;
+    std::vector<double> m_C;
 
     mutable std::vector<double> m_sigma;
     mutable std::vector<double> m_U;


### PR DESCRIPTION
Coefficients are now stored using a plain vector instead of a vector of vectors.