### PR TITLE
CG: fix tolerance in intersect methods

### DIFF
--- a/src/CG/CG.hpp
+++ b/src/CG/CG.hpp
@@ -44,6 +44,9 @@ typedef std::array<double,3> array3D ;
  *  \{
  */
 
+static const double DEFAULT_DISTANCE_TOLERANCE = 1.e-12;
+static const double DEFAULT_COPLANARITY_TOLERANCE = 1.e-12;
+
 /*!
  * The edge vertex connectivty of a box
  */
@@ -156,45 +159,76 @@ double distanceLineLine(array3D const &, array3D const &, array3D const &, array
 double distanceLineLine(array3D const &, array3D const &, array3D const &, array3D const &, array3D &, array3D &);
 
 
-bool intersectPointSegment( array3D const &, array3D const &, array3D const & ) ;
-bool intersectPointTriangle( array3D const &, array3D const &, array3D const &, array3D const & ) ;
-bool intersectPointBox( array3D const &, array3D const &, array3D const &, int dim=3 ) ;
+bool intersectPointSegment( array3D const &, array3D const &, array3D const &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectPointTriangle( array3D const &, array3D const &, array3D const &, array3D const &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectPointBox( array3D const &, array3D const &, array3D const &, int dim=3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 
-bool intersectLineLine( array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectLinePlane( array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectLineTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectLinePolygon( array3D const &, array3D const &, std::vector<array3D> const &, array3D & ) ;
-bool intersectLinePolygon( array3D const &, array3D const &, std::size_t, array3D const *, array3D & ) ;
+bool intersectLineLine( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectLinePlane( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, 
+        const double coplanarityTolerance = DEFAULT_COPLANARITY_TOLERANCE) ;
+bool intersectLineTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
+        array3D &, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectLinePolygon( array3D const &, array3D const &, std::vector<array3D> const &, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectLinePolygon( array3D const &, array3D const &, std::size_t, array3D const *, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 
-bool intersectSegmentSegment( array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectSegmentPlane( array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectSegmentTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, array3D & ) ;
-bool intersectSegmentPolygon( array3D const &, array3D const &, std::vector<array3D> const &, array3D & ) ;
-bool intersectSegmentPolygon( array3D const &, array3D const &, std::size_t, array3D const *, array3D & ) ;
+bool intersectSegmentSegment( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectSegmentPlane( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectSegmentTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
+        array3D &, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectSegmentPolygon( array3D const &, array3D const &, std::vector<array3D> const &, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectSegmentPolygon( array3D const &, array3D const &, std::size_t, array3D const *, array3D &, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 
-bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, int  dim = 3 ) ;
-bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, std::vector<array3D> &, int dim=3 );
-bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, std::vector<array3D> &, std::vector<int> &, int dim=3 );
+bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, int  dim = 3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, 
+        std::vector<array3D> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, 
+        std::vector<array3D> &, std::vector<int> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
 
-bool intersectPlanePlane( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, array3D & ) ;
-bool intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, int dim=3);
-bool intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, std::vector<array3D> &, int dim=3);
+bool intersectPlanePlane( array3D const &, array3D const &, array3D const &, array3D const &, 
+        array3D &, array3D &, const double coplanarityTolerance = DEFAULT_COPLANARITY_TOLERANCE) ;
+bool intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, int dim=3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, 
+        std::vector<array3D> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
 
-bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D const &, int  dim = 3 ) ;
-bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D const &, array3D &, array3D &, int  dim = 3 ) ;
+bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D const &, int  dim = 3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D const &, 
+        array3D &, array3D &, int  dim = 3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 
 
-bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, int dim=3 ) ;
-bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, bool, std::vector<array3D> &, int dim=3 ) ;
-bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, bool, std::vector<array3D> &, std::vector<int> &, int dim=3 ) ;
+bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
+        int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
+        bool, bool, bool, std::vector<array3D> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
+bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
+        bool, bool, bool, std::vector<array3D> &, std::vector<int> &, int dim=3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 
 
-bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, int dim=3 );
-bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, int dim=3 );
-bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, bool, bool, bool, std::vector<array3D> &, int dim=3);
-bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, std::vector<array3D> &, int dim=3);
-bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, bool, bool, bool, std::vector<array3D> &, std::vector<int> &, int dim=3);
-bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, std::vector<array3D> &, std::vector<int> &, int dim=3);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, int dim=3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, int dim=3, 
+        const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, bool, bool, bool, 
+        std::vector<array3D> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, 
+        std::vector<array3D> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::vector<array3D> const &, bool, bool, bool, 
+        std::vector<array3D> &, std::vector<int> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+bool intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, 
+        std::vector<array3D> &, std::vector<int> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
 
 
 void computeAABBSegment( array3D const &, array3D const &, array3D &, array3D & ) ;

--- a/src/CG/CG.hpp
+++ b/src/CG/CG.hpp
@@ -44,13 +44,13 @@ typedef std::array<double,3> array3D ;
  *  \{
  */
 
-static const double DEFAULT_DISTANCE_TOLERANCE = 1.e-12;
-static const double DEFAULT_COPLANARITY_TOLERANCE = 1.e-12;
+const double DEFAULT_DISTANCE_TOLERANCE = 1.e-12;
+const double DEFAULT_COPLANARITY_TOLERANCE = 1.e-12;
 
 /*!
  * The edge vertex connectivty of a box
  */
-static const std::array< std::array<int,2>,12> boxEdgeVertexConnectivity =
+const std::array< std::array<int,2>,12> boxEdgeVertexConnectivity =
 {{
     std::array<int,2>{ {0,2} },
     std::array<int,2>{ {1,3} },
@@ -70,7 +70,7 @@ static const std::array< std::array<int,2>,12> boxEdgeVertexConnectivity =
 /*!
  * The face vertex connectivty of a box
  */
-static const std::array< std::array<int,4>, 6> boxFaceVertexConnectivity =
+const std::array< std::array<int,4>, 6> boxFaceVertexConnectivity =
 {{
     std::array<int,4>{ {0,2,6,4} },
     std::array<int,4>{ {1,3,7,5} },

--- a/src/CG/CG_private.hpp
+++ b/src/CG/CG_private.hpp
@@ -36,10 +36,10 @@ typedef std::array<double,3> array3D ;
 
 void _projectPointsTriangle( int, array3D const *, array3D const &, array3D const &, array3D const &, array3D *, double *);
 void _projectPointsPlane( int, array3D const *, array3D const &, array3D const &, array3D const &, array3D *, double *);
-bool _intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, std::vector<array3D> *, std::vector<int> *, int  dim = 3 ) ;
-bool _intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, std::vector<array3D> *, int dim=3);
-bool _intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, bool, std::vector<array3D> *, std::vector<int> *, int dim=3 ) ;
-bool _intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, std::vector<array3D> *, std::vector<int> *, int dim=3 );
+bool _intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, std::vector<array3D> *, std::vector<int> *, int  dim = 3, const double tolerance = DEFAULT_DISTANCE_TOLERANCE ) ;
+bool _intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, std::vector<array3D> *, int dim=3, const double tolerance = DEFAULT_DISTANCE_TOLERANCE );
+bool _intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, bool, std::vector<array3D> *, std::vector<int> *, int dim=3, const double tolerance = DEFAULT_DISTANCE_TOLERANCE ) ;
+bool _intersectBoxPolygon( array3D const &, array3D const &, std::size_t, array3D const *, bool, bool, bool, std::vector<array3D> *, std::vector<int> *, int dim=3, const double tolerance = DEFAULT_DISTANCE_TOLERANCE );
 BITPIT_DEPRECATED( bool _intersectBoxSimplex( array3D const &, array3D const &, std::vector<array3D> const &, bool, bool, bool, std::vector<array3D> *, std::vector<int> *, int dim=3 ) );
 
 }


### PR DESCRIPTION
Fix the use of numerical tolerance to identify interesctions in CG module by adding an optional argument to related methods.



