### PR TITLE
PABLO: store Morton number instead of octant's coordinates

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -240,9 +240,9 @@ namespace bitpit {
             octvector::const_iterator lastOctant = m_octants.end() - 1;
             uint32_t x,y,z,delta;
             delta = (uint32_t)(1<<((uint8_t)TreeConstants::MAX_LEVEL - lastOctant->m_level)) - 1;
-            x = lastOctant->m_x + delta;
-            y = lastOctant->m_y + delta;
-            z = lastOctant->m_z + (m_dim-2)*delta;
+            x = lastOctant->getLogicalX() + delta;
+            y = lastOctant->getLogicalY() + delta;
+            z = lastOctant->getLogicalZ() + (m_dim-2)*delta;
             Octant lastDesc = Octant(m_dim, TreeConstants::MAX_LEVEL,x,y,z);
             m_lastDescMorton = lastDesc.computeMorton();
         } else {
@@ -1005,7 +1005,12 @@ namespace bitpit {
             sameSizeVirtualNeigh = oct->computePeriodicOctant(iface);
         }
         else{
-            sameSizeVirtualNeigh = Octant(m_dim, level, int32_t(oct->m_x)+int32_t(cxyz[0]*size), int32_t(oct->m_y)+int32_t(cxyz[1]*size), int32_t(oct->m_z)+int32_t(cxyz[2]*size));
+            u32array3 sameSizeVirtualNeighCoords = oct->getLogicalCoordinates();
+            sameSizeVirtualNeighCoords[0] += cxyz[0] * size;
+            sameSizeVirtualNeighCoords[1] += cxyz[1] * size;
+            sameSizeVirtualNeighCoords[2] += cxyz[2] * size;
+
+            sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
         uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();
@@ -1256,7 +1261,12 @@ namespace bitpit {
             sameSizeVirtualNeigh = oct->computeEdgePeriodicOctant(iedge);
         }
         else{
-            sameSizeVirtualNeigh = Octant(m_dim, level, oct->m_x+cxyz[0]*size, oct->m_y+cxyz[1]*size, oct->m_z+cxyz[2]*size);
+            u32array3 sameSizeVirtualNeighCoords = oct->getLogicalCoordinates();
+            sameSizeVirtualNeighCoords[0] += cxyz[0] * size;
+            sameSizeVirtualNeighCoords[1] += cxyz[1] * size;
+            sameSizeVirtualNeighCoords[2] += cxyz[2] * size;
+
+            sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
         uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();
@@ -1496,7 +1506,12 @@ namespace bitpit {
             sameSizeVirtualNeigh = oct->computeNodePeriodicOctant(inode);
         }
         else{
-            sameSizeVirtualNeigh = Octant(m_dim, oct->m_level, oct->m_x+cxyz[0]*size, oct->m_y+cxyz[1]*size, oct->m_z+cxyz[2]*size);
+            u32array3 sameSizeVirtualNeighCoords = oct->getLogicalCoordinates();
+            sameSizeVirtualNeighCoords[0] += cxyz[0] * size;
+            sameSizeVirtualNeighCoords[1] += cxyz[1] * size;
+            sameSizeVirtualNeighCoords[2] += cxyz[2] * size;
+
+            sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
         uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -1045,7 +1045,7 @@ namespace bitpit {
         if (candidateIdx < m_sizeOctants){
             while(true){
                 // Detect if the candidate is a neighbour
-                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoord();
+                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoordinates();
 
                 bool isNeighbourCandidate = true;
                 for (int idim=0; idim<m_dim; idim++){
@@ -1136,7 +1136,7 @@ namespace bitpit {
             if (candidateIdx < m_sizeGhosts){
                 while(true){
                     // Detect if the candidate is a neighbour
-                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoord();
+                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoordinates();
 
                     bool isNeighbourCandidate = true;
                     for (int idim=0; idim<m_dim; idim++){
@@ -1296,7 +1296,7 @@ namespace bitpit {
         if (candidateIdx < m_sizeOctants) {
             while(true){
                 // Detect if the candidate is a neighbour
-                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoord();
+                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoordinates();
 
                 bool isNeighbourCandidate = true;
                 for (int idim=0; idim<m_dim; idim++){
@@ -1377,7 +1377,7 @@ namespace bitpit {
             if (candidateIdx < m_sizeGhosts){
                 while(true){
                     // Detect if the candidate is a neighbour
-                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoord();
+                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoordinates();
 
                     bool isNeighbourCandidate = true;
                     for (int idim=0; idim<m_dim; idim++){
@@ -1536,7 +1536,7 @@ namespace bitpit {
         if (candidateIdx < m_sizeOctants) {
             while(true){
                 // Detect if the candidate is a neighbour
-                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoord();
+                u32array3 coordtry = m_octants[candidateIdx].getLogicalCoordinates();
 
                 bool isNeighbour = true;
                 for (int idim=0; idim<m_dim; idim++){
@@ -1587,7 +1587,7 @@ namespace bitpit {
             if (candidateIdx < m_sizeGhosts) {
                 while(true){
                     // Detect if the candidate is a neighbour
-                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoord();
+                    u32array3 coordtry = m_ghosts[candidateIdx].getLogicalCoordinates();
 
                     bool isNeighbour = true;
                     for (int idim=0; idim<m_dim; idim++){

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -137,15 +137,15 @@ namespace bitpit {
         return m_octants[idx].computeMorton();
     };
 
-    /** Compute the Morton index of the specified node of the idx-th octant
+    /** Compute the persistent XYZ key of the specified node of an octant
      * (without level).
      * \param[in] idx Local index of the target octant.
      * \param[in] inode Index of the target node.
-     * \return Morton index of the octant.
+     * \return persistent XYZ key of the node.
      */
     uint64_t
-    LocalTree::computeNodeMorton(int32_t idx, uint8_t inode) const {
-        return m_octants[idx].computeNodeMorton(inode);
+    LocalTree::computeNodePersistentKey(int32_t idx, uint8_t inode) const {
+        return m_octants[idx].computeNodePersistentKey(inode);
     };
 
     /** Get refinement/coarsening marker for idx-th ghost octant
@@ -166,15 +166,15 @@ namespace bitpit {
         return m_ghosts[idx].computeMorton();
     };
 
-    /** Compute the Morton index of the specified node of the idx-th ghost
-     * octant (without level).
+    /** Compute the persistent XYZ key of the specified node of a ghost octant
+     * (without level).
      * \param[in] idx Local index of the target octant.
      * \param[in] inode Index of the target node.
-     * \return Morton index of the octant.
+     * \return persistent XYZ key of the node.
      */
     uint64_t
-    LocalTree::computeGhostNodeMorton(int32_t idx, uint8_t inode) const {
-        return m_ghosts[idx].computeNodeMorton(inode);
+    LocalTree::computeGhostNodePersistentKey(int32_t idx, uint8_t inode) const {
+        return m_ghosts[idx].computeNodePersistentKey(inode);
     };
 
     /** Get if balancing-blocked idx-th octant
@@ -3193,7 +3193,7 @@ namespace bitpit {
                 u32array3 node;
                 octant->getLogicalNode(node, i);
 
-                uint64_t morton = octant->computeNodeMorton(node);
+                uint64_t morton = octant->computeNodePersistentKey(node);
                 if (nodeCoords.count(morton) == 0) {
                     mortonList.push_back(morton);
                     nodeCoords.insert({{morton, std::move(node)}});

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -133,8 +133,8 @@ namespace bitpit {
      * \return Morton index of the octant.
      */
     uint64_t
-    LocalTree::computeMorton(int32_t idx) const {
-        return m_octants[idx].computeMorton();
+    LocalTree::getMorton(int32_t idx) const {
+        return m_octants[idx].getMorton();
     };
 
     /** Compute the persistent XYZ key of the specified node of an octant
@@ -163,7 +163,7 @@ namespace bitpit {
      */
     uint64_t
     LocalTree::computeGhostMorton(int32_t idx) const {
-        return m_ghosts[idx].computeMorton();
+        return m_ghosts[idx].getMorton();
     };
 
     /** Compute the persistent XYZ key of the specified node of a ghost octant
@@ -226,7 +226,7 @@ namespace bitpit {
     LocalTree::setFirstDescMorton(){
         if(m_sizeOctants){
             octvector::const_iterator firstOctant = m_octants.begin();
-            m_firstDescMorton = firstOctant->computeMorton();
+            m_firstDescMorton = firstOctant->getMorton();
         } else {
             m_firstDescMorton = std::numeric_limits<uint64_t>::max();
         }
@@ -244,7 +244,7 @@ namespace bitpit {
             y = lastOctant->getLogicalY() + delta;
             z = lastOctant->getLogicalZ() + (m_dim-2)*delta;
             Octant lastDesc = Octant(m_dim, TreeConstants::MAX_LEVEL,x,y,z);
-            m_lastDescMorton = lastDesc.computeMorton();
+            m_lastDescMorton = lastDesc.getMorton();
         } else {
             m_lastDescMorton = 0;
         }
@@ -559,7 +559,7 @@ namespace bitpit {
             while(check){
                 check = idx1_gh < m_sizeGhosts;
                 if (check){
-                    check = m_ghosts[idx1_gh].computeMorton() > m_firstDescMorton;
+                    check = m_ghosts[idx1_gh].getMorton() > m_firstDescMorton;
                 }
                 if (check) idx1_gh--;
             }
@@ -568,7 +568,7 @@ namespace bitpit {
             while(check){
                 check = idx2_gh < m_sizeGhosts;
                 if (check){
-                    check = m_ghosts[idx2_gh].computeMorton() < m_lastDescMorton;
+                    check = m_ghosts[idx2_gh].getMorton() < m_lastDescMorton;
                 }
                 if (check) idx2_gh++;
             }
@@ -897,7 +897,7 @@ namespace bitpit {
         if (m_sizeOctants>0){
 
             idx = 0;
-            if (m_octants[idx].computeMorton() < partLastDesc){
+            if (m_octants[idx].getMorton() < partLastDesc){
 
                 Octant father0 = m_octants[idx].buildFather();
                 Octant father = father0;
@@ -1013,7 +1013,7 @@ namespace bitpit {
             sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
-        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();
+        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.getMorton();
 
         //
         // Search in the internal octants
@@ -1033,7 +1033,7 @@ namespace bitpit {
         //
         // This is the Morton number of the last discendent of the same-size
         // virtual neighbour.
-        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().computeMorton();
+        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().getMorton();
 
         // Compute coordinates
         std::array<int64_t,3> coord;
@@ -1105,7 +1105,7 @@ namespace bitpit {
                     break;
                 }
 
-                candidateMorton = m_octants[candidateIdx].computeMorton();
+                candidateMorton = m_octants[candidateIdx].getMorton();
                 if (candidateMorton > lastCandidateMorton){
                     break;
                 }
@@ -1195,7 +1195,7 @@ namespace bitpit {
                         break;
                     }
 
-                    candidateMorton = m_ghosts[candidateIdx].computeMorton();
+                    candidateMorton = m_ghosts[candidateIdx].getMorton();
                     if (candidateMorton > lastCandidateMorton){
                         break;
                     }
@@ -1269,7 +1269,7 @@ namespace bitpit {
             sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
-        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();
+        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.getMorton();
 
         //
         // Search in the internal octants
@@ -1289,7 +1289,7 @@ namespace bitpit {
         //
         // This is the Morton number of the last discendent of the same-size
         // virtual neighbour.
-        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().computeMorton();
+        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().getMorton();
 
         // Compute coordinates
         std::array<int64_t,3> coord;
@@ -1362,7 +1362,7 @@ namespace bitpit {
                     break;
                 }
 
-                candidateMorton = m_octants[candidateIdx].computeMorton();
+                candidateMorton = m_octants[candidateIdx].getMorton();
                 if (candidateMorton > lastCandidateMorton){
                     break;
                 }
@@ -1443,7 +1443,7 @@ namespace bitpit {
                         break;
                     }
 
-                    candidateMorton = m_ghosts[candidateIdx].computeMorton();
+                    candidateMorton = m_ghosts[candidateIdx].getMorton();
                     if (candidateMorton > lastCandidateMorton){
                         break;
                     }
@@ -1514,7 +1514,7 @@ namespace bitpit {
             sameSizeVirtualNeigh = Octant(m_dim, level, sameSizeVirtualNeighCoords[0], sameSizeVirtualNeighCoords[1], sameSizeVirtualNeighCoords[2]);
         }
 
-        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.computeMorton();
+        uint64_t sameSizeVirtualNeighMorton = sameSizeVirtualNeigh.getMorton();
 
         //
         // Search in the internal octants
@@ -1534,7 +1534,7 @@ namespace bitpit {
         //
         // This is the Morton number of the last discendent of the same-size
         // virtual neighbour.
-        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().computeMorton();
+        uint64_t lastCandidateMorton = sameSizeVirtualNeigh.buildLastDesc().getMorton();
 
         // Compute coordinates
         std::array<int64_t,3> coord;
@@ -1576,7 +1576,7 @@ namespace bitpit {
                     break;
                 }
 
-                candidateMorton = m_octants[candidateIdx].computeMorton();
+                candidateMorton = m_octants[candidateIdx].getMorton();
                 if (candidateMorton > lastCandidateMorton){
                     break;
                 }
@@ -1627,7 +1627,7 @@ namespace bitpit {
                         break;
                     }
 
-                    candidateMorton = m_ghosts[candidateIdx].computeMorton();
+                    candidateMorton = m_ghosts[candidateIdx].getMorton();
                     if (candidateMorton > lastCandidateMorton){
                         break;
                     }
@@ -1896,7 +1896,7 @@ namespace bitpit {
             *searchBeginMorton = lowerBoundMorton;
         } else {
             *searchBeginIdx    = lowerBoundIdx - 1;
-            *searchBeginMorton = octants[*searchBeginIdx].computeMorton();
+            *searchBeginMorton = octants[*searchBeginIdx].getMorton();
         }
 
     }
@@ -1937,13 +1937,13 @@ namespace bitpit {
         bool checkend = true;
         bool checkstart = true;
         if (m_ghosts.size()){
-            while(m_ghosts[idx2_gh].computeMorton() <= m_lastDescMorton){
+            while(m_ghosts[idx2_gh].getMorton() <= m_lastDescMorton){
                 idx2_gh++;
                 if (idx2_gh > m_sizeGhosts-1) break;
             }
             if (idx2_gh > m_sizeGhosts-1) checkend = false;
 
-            while(m_ghosts[idx1_gh].computeMorton() <= m_octants[0].computeMorton()){
+            while(m_ghosts[idx1_gh].getMorton() <= m_octants[0].getMorton()){
                 idx1_gh++;
                 if (idx1_gh > m_sizeGhosts-1) break;
             }
@@ -2043,12 +2043,12 @@ namespace bitpit {
             if (internal){
                 father = m_octants[0].buildFather();
                 lastdesc = father.buildLastDesc();
-                mortonld = lastdesc.computeMorton();
+                mortonld = lastdesc.getMorton();
                 nbro = 0;
                 for (idx=0; idx<m_treeConstants->nChildren; idx++){
                     if (idx<nocts){
                         // Check if family is complete or to be checked in the internal loop (some brother refined)
-                        if (m_octants[idx].computeMorton() <= mortonld){
+                        if (m_octants[idx].getMorton() <= mortonld){
                             nbro++;
                         }
                     }
@@ -2120,13 +2120,13 @@ namespace bitpit {
         bool checkend = true;
         bool checkstart = true;
         if (m_ghosts.size()){
-            while(m_ghosts[idx2_gh].computeMorton() <= m_lastDescMorton){
+            while(m_ghosts[idx2_gh].getMorton() <= m_lastDescMorton){
                 idx2_gh++;
                 if (idx2_gh > m_sizeGhosts-1) break;
             }
             if (idx2_gh > m_sizeGhosts-1) checkend = false;
 
-            while(m_ghosts[idx1_gh].computeMorton() <= m_octants[0].computeMorton()){
+            while(m_ghosts[idx1_gh].getMorton() <= m_octants[0].getMorton()){
                 idx1_gh++;
                 if (idx1_gh > m_sizeGhosts-1) break;
             }
@@ -2227,12 +2227,12 @@ namespace bitpit {
         // Check first internal octants
         father = m_octants[0].buildFather();
         lastdesc = father.buildLastDesc();
-        mortonld = lastdesc.computeMorton();
+        mortonld = lastdesc.getMorton();
         nbro = 0;
         for (idx=0; idx<m_treeConstants->nChildren; idx++){
             // Check if family is complete or to be checked in the internal loop (some brother refined)
             if (idx<nocts){
-                if (m_octants[idx].computeMorton() <= mortonld){
+                if (m_octants[idx].getMorton() <= mortonld){
                     nbro++;
                 }
             }
@@ -3083,7 +3083,7 @@ namespace bitpit {
         uint64_t midMorton = PABLO::INVALID_MORTON;
         while (lowIndex < highIndex) {
             midIndex  = lowIndex + (highIndex - lowIndex) / 2;
-            midMorton = octants[midIndex].computeMorton();
+            midMorton = octants[midIndex].getMorton();
             if (targetMorton < midMorton) {
                 highIndex = midIndex;
             }
@@ -3103,7 +3103,7 @@ namespace bitpit {
             *lowerBoundMorton = midMorton;
         }
         else if (*lowerBoundIdx < nOctants) {
-            *lowerBoundMorton = octants[*lowerBoundIdx].computeMorton();
+            *lowerBoundMorton = octants[*lowerBoundIdx].getMorton();
         }
         else {
             *lowerBoundMorton = PABLO::INVALID_MORTON;
@@ -3138,7 +3138,7 @@ namespace bitpit {
         uint64_t midMorton = PABLO::INVALID_MORTON;
         while (lowIndex < highIndex) {
             midIndex  = lowIndex + (highIndex - lowIndex) / 2;
-            midMorton = octants[midIndex].computeMorton();
+            midMorton = octants[midIndex].getMorton();
             if (targetMorton < midMorton) {
                 highIndex = midIndex;
             }
@@ -3152,7 +3152,7 @@ namespace bitpit {
             *upperBoundMorton = midMorton;
         }
         else if (*upperBoundIdx < nOctants) {
-            *upperBoundMorton = octants[*upperBoundIdx].computeMorton();
+            *upperBoundMorton = octants[*upperBoundIdx].getMorton();
         }
         else {
             *upperBoundMorton = PABLO::INVALID_MORTON;

--- a/src/PABLO/LocalTree.hpp
+++ b/src/PABLO/LocalTree.hpp
@@ -161,10 +161,10 @@ private:
 	int8_t 			getMarker(int32_t idx) const;
 	uint8_t 		getLevel(int32_t idx) const;
 	uint64_t 		computeMorton(int32_t idx) const;
-	uint64_t 		computeNodeMorton(int32_t idx, uint8_t inode) const;
+	uint64_t 		computeNodePersistentKey(int32_t idx, uint8_t inode) const;
 	uint8_t 		getGhostLevel(int32_t idx) const;
 	uint64_t 		computeGhostMorton(int32_t idx) const;
-	uint64_t 		computeGhostNodeMorton(int32_t idx, uint8_t inode) const;
+	uint64_t 		computeGhostNodePersistentKey(int32_t idx, uint8_t inode) const;
 	bool 			getBalance(int32_t idx) const;
 	uint8_t 		getBalanceCodim() const;
 	void 			setMarker(int32_t idx, int8_t marker);

--- a/src/PABLO/LocalTree.hpp
+++ b/src/PABLO/LocalTree.hpp
@@ -160,7 +160,7 @@ private:
 	int8_t 			getLocalMaxDepth() const;
 	int8_t 			getMarker(int32_t idx) const;
 	uint8_t 		getLevel(int32_t idx) const;
-	uint64_t 		computeMorton(int32_t idx) const;
+	uint64_t 		getMorton(int32_t idx) const;
 	uint64_t 		computeNodePersistentKey(int32_t idx, uint8_t inode) const;
 	uint8_t 		getGhostLevel(int32_t idx) const;
 	uint64_t 		computeGhostMorton(int32_t idx) const;

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -546,22 +546,8 @@ Octant::getLogicalNodes(u32arr3vector & nodes) const{
  */
 u32arr3vector
 Octant::getLogicalNodes() const{
-	uint8_t		i;
-	uint32_t	dh;
-	uint8_t nn = uint8_t(1)<<m_dim;
 	u32arr3vector nodes;
-
-	dh = getLogicalSize();
-	nodes.resize(nn);
-
-	u32array3 coords = getLogicalCoordinates();
-
-	for (i = 0; i < nn; i++){
-		nodes[i][0] = coords[0] + sm_treeConstants[m_dim].nodeCoordinates[i][0]*dh;
-		nodes[i][1] = coords[1] + sm_treeConstants[m_dim].nodeCoordinates[i][1]*dh;
-		nodes[i][2] = coords[2] + sm_treeConstants[m_dim].nodeCoordinates[i][2]*dh;
-	}
-
+	getLogicalNodes(nodes);
 	return nodes;
 };
 
@@ -587,15 +573,8 @@ void		Octant::getLogicalNode(u32array3 & node, uint8_t inode) const{
  * \return Array[3] with the logical coordinates of the node of the octant.
  */
 u32array3		Octant::getLogicalNode(uint8_t inode) const{
-	uint32_t	dh;
-
-	dh = getLogicalSize();
-
-	u32array3 node = getLogicalCoordinates();
-
-	node[0] += sm_treeConstants[m_dim].nodeCoordinates[inode][0]*dh;
-	node[1] += sm_treeConstants[m_dim].nodeCoordinates[inode][1]*dh;
-	node[2] += sm_treeConstants[m_dim].nodeCoordinates[inode][2]*dh;
+	u32array3 node;
+	getLogicalNode(node, inode);
 	return node;
 };
 

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -236,11 +236,11 @@ Octant::getDim() const{return m_dim;};
  */
 u32array3
 Octant::getLogicalCoordinates() const{
-	u32array3 xx;
-	xx[0] = m_x;
-	xx[1] = m_y;
-	xx[2] = m_z;
-	return xx;
+	u32array3 coords;
+	coords[0] = m_x;
+	coords[1] = m_y;
+	coords[2] = m_z;
+	return coords;
 };
 
 /*! Get the coordinates of an octant, i.e. the coordinates of its node 0.
@@ -260,18 +260,6 @@ Octant::getLogicalY() const{return m_y;};
  */
 uint32_t
 Octant::getLogicalZ() const{return m_z;};
-
-/*! Get the coordinates of an octant, i.e. the coordinates of its node 0.
- * \return Coordinates of node 0.
- */
-u32array3
-Octant::getLogicalCoord() const {
-	u32array3 coord;
-	coord[0] = m_x;
-	coord[1] = m_y;
-	coord[2] = m_z;
-	return coord;
-};
 
 /*! Get the level of an octant.
  * \return Level of octant.

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -600,15 +600,15 @@ uint64_t	Octant::computeMorton() const{
 	return morton;
 };
 
-/** Compute the Morton index of the given node (without level).
+/** Compute the persistent XYZ key of the given node (without level).
  * \param[in] inode Local index of the node
- * \return morton Morton index of the node.
+ * \return persistent XYZ key of the node.
  */
-uint64_t	Octant::computeNodeMorton(uint8_t inode) const{
+uint64_t	Octant::computeNodePersistentKey(uint8_t inode) const{
 
 	u32array3 node = getLogicalNode(inode);
 
-	return computeNodeMorton(node);
+	return computeNodePersistentKey(node);
 };
 
 /** Compute the Morton index of the father of this octant.
@@ -632,11 +632,11 @@ u32array3	Octant::computeFatherCoordinates() const {
 	return fatherCoordinates;
 };
 
-/** Compute the Morton index of the given node (without level).
+/** Compute the persistent XYZ key of the given node (without level).
  * \param[in] node Logical coordinates of the node
- * \return morton Morton index of the node.
+ * \return persistent XYZ key of the node.
  */
-uint64_t	Octant::computeNodeMorton(const u32array3 &node) const{
+uint64_t	Octant::computeNodePersistentKey(const u32array3 &node) const{
 
 	return PABLO::computeXYZKey(node[0], node[1], node[2], TreeConstants::MAX_LEVEL);
 };

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -591,10 +591,10 @@ void		Octant::getNormal(uint8_t iface, i8array3 & normal, const int8_t (&normals
 };
 
 
-/** Compute the Morton index of the octant (without level).
+/** Get the Morton index of the octant (without level).
  * \return morton Morton index of the octant.
  */
-uint64_t	Octant::computeMorton() const{
+uint64_t	Octant::getMorton() const{
 	return m_morton;
 };
 
@@ -1411,7 +1411,7 @@ void Octant::computeNodeMinSizeMorton(uint8_t inode, uint8_t maxdepth, const uin
 		uint8_t iface = nodeface[inode][i];
 		if (m_info[iface]) {
 			*hasMorton = false;
-			*morton = this->computeMorton();
+			*morton = this->getMorton();
 			return;
 		}
 	}
@@ -1528,7 +1528,7 @@ uint64_t Octant::computePeriodicMorton(uint8_t iface) const {
 	u32array3 coords = getLogicalCoordinates();
 
 	if (!m_info[iface]){
-		return this->computeMorton();
+		return this->getMorton();
 	}
 	else{
 		switch (iface) {

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -50,9 +50,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Octant 
 
     octant.initialize(dimensions, level, true);
 
-    buffer >> octant.m_x;
-    buffer >> octant.m_y;
-    buffer >> octant.m_z;
+    buffer >> octant.m_morton;
 
     buffer >> octant.m_marker;
 
@@ -80,9 +78,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::
     buffer << octant.m_dim;
     buffer << octant.m_level;
 
-    buffer << octant.m_x;
-    buffer << octant.m_y;
-    buffer << octant.m_z;
+    buffer << octant.m_morton;
 
     buffer << octant.m_marker;
 
@@ -141,10 +137,9 @@ Octant::Octant(uint8_t dim){
 Octant::Octant(uint8_t dim, uint8_t level, int32_t x, int32_t y, int32_t z){
 	initialize(dim, level, true);
 
-	// Set the coordinates
-	m_x = x;
-	m_y = y;
-	m_z = (m_dim-2) * z;
+	// Set the morton
+	m_morton = PABLO::computeMorton(x, y, (m_dim-2) * z);
+
 };
 
 /*! Custom constructor of an octant.
@@ -159,10 +154,9 @@ Octant::Octant(uint8_t dim, uint8_t level, int32_t x, int32_t y, int32_t z){
 Octant::Octant(bool bound, uint8_t dim, uint8_t level, int32_t x, int32_t y, int32_t z){
 	initialize(dim, level, bound);
 
-	// Set the coordinates
-	m_x = x;
-	m_y = y;
-	m_z = (m_dim-2) * z;
+	// Set the morton
+	m_morton = PABLO::computeMorton(x, y, (m_dim-2) * z);
+
 };
 
 /*! Check if two octants are equal (no check on info)
@@ -170,9 +164,7 @@ Octant::Octant(bool bound, uint8_t dim, uint8_t level, int32_t x, int32_t y, int
 bool Octant::operator ==(const Octant & oct2){
 	bool check = true;
 	check = check && (m_dim == oct2.m_dim);
-	check = check && (m_x == oct2.m_x);
-	check = check && (m_y == oct2.m_y);
-	check = check && (m_z == oct2.m_z);
+	check = check && (m_morton == oct2.m_morton);
 	check = check && (m_level == oct2.m_level);
 	return check;
 }
@@ -201,10 +193,8 @@ Octant::initialize(uint8_t dim, uint8_t level, bool bound) {
 	// Reset the marker
 	m_marker = 0;
 
-	// Set the coordinates
-	m_x = 0;
-	m_y = 0;
-	m_z = 0;
+	// Reset the morton
+	m_morton = 0;
 
 	// Initialize octant info
 	m_info.reset();
@@ -247,19 +237,29 @@ Octant::getLogicalCoordinates() const{
  * \return Coordinate X of node 0.
  */
 uint32_t
-Octant::getLogicalX() const{return m_x;};
+Octant::getLogicalX() const{
+	return PABLO::computeCoordinate3D(m_morton, 0);
+};
 
 /*! Get the coordinates of an octant, i.e. the coordinates of its node 0.
  * \return Coordinate Y of node 0.
  */
 uint32_t
-Octant::getLogicalY() const{return m_y;};
+Octant::getLogicalY() const{
+	return PABLO::computeCoordinate3D(m_morton, 1);
+};
 
 /*! Get the coordinates of an octant, i.e. the coordinates of its node 0.
  * \return Coordinate Z of node 0.
  */
 uint32_t
-Octant::getLogicalZ() const{return m_z;};
+Octant::getLogicalZ() const{
+	if (m_dim == 3) {
+		return PABLO::computeCoordinate3D(m_morton, 2);
+	} else {
+		return 0;
+	}
+};
 
 /*! Get the level of an octant.
  * \return Level of octant.
@@ -595,9 +595,7 @@ void		Octant::getNormal(uint8_t iface, i8array3 & normal, const int8_t (&normals
  * \return morton Morton index of the octant.
  */
 uint64_t	Octant::computeMorton() const{
-	uint64_t morton = 0;
-	morton = PABLO::computeMorton(this->m_x,this->m_y,this->m_z);
-	return morton;
+	return m_morton;
 };
 
 /** Compute the persistent XYZ key of the given node (without level).
@@ -649,7 +647,7 @@ unsigned int Octant::getBinarySize()
     unsigned int binarySize = 0;
     binarySize += sizeof(uint8_t); // dimensions
     binarySize += sizeof(uint8_t); // level
-    binarySize += 3 * sizeof(uint32_t); // 3 coordinates
+    binarySize += sizeof(uint64_t); // morton
     binarySize += sizeof(int8_t); // marker
     binarySize += sizeof(int); // ghost layer
     binarySize += INFO_ITEM_COUNT * sizeof(bool); // info
@@ -720,6 +718,8 @@ vector< Octant >	Octant::buildChildren() const {
  *   the possible children.
  */
 void	Octant::buildChildren(Octant *children) const {
+
+	u32array3 coords = getLogicalCoordinates();
 
 	int nChildren = countChildren();
 	for (int i=0; i<nChildren; ++i){
@@ -833,10 +833,7 @@ void	Octant::buildChildren(Octant *children) const {
 		oct.setLevel(oct.m_level + 1);
 
 		uint32_t dh = oct.getLogicalSize();
-
-		oct.m_x += dh * dx;
-		oct.m_y += dh * dy;
-		oct.m_z += dh * dz;
+		oct.m_morton = PABLO::computeMorton(coords[0] + dh * dx, coords[1] + dh * dy, coords[2] + dh * dz);
 
 		oct.m_info[OctantInfo::INFO_NEW4REFINEMENT] = true;
 

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -237,9 +237,9 @@ Octant::getDim() const{return m_dim;};
 u32array3
 Octant::getLogicalCoordinates() const{
 	u32array3 coords;
-	coords[0] = m_x;
-	coords[1] = m_y;
-	coords[2] = m_z;
+	coords[0] = getLogicalX();
+	coords[1] = getLogicalY();
+	coords[2] = getLogicalZ();
 	return coords;
 };
 
@@ -473,9 +473,9 @@ Octant::getLogicalCenter() const{
 	darray3 center;
 
 	dh = double(getLogicalSize())*0.5;
-	center[0] = (double)m_x + dh;
-	center[1] = (double)m_y + dh;
-	center[2] = (double)m_z + double(m_dim-2)*dh;
+	center[0] = getLogicalX() + dh;
+	center[1] = getLogicalY() + dh;
+	center[2] = getLogicalZ() + double(m_dim-2)*dh;
 	return center;
 };
 
@@ -493,9 +493,9 @@ Octant::getLogicalFaceCenter(uint8_t iface) const{
 	assert(iface < m_dim*2);
 
 	dh_2 = double(getLogicalSize())*0.5;
-	center[0] = (double)m_x + (double)sm_treeConstants[m_dim].faceDisplacements[iface][0] * dh_2;
-	center[1] = (double)m_y + (double)sm_treeConstants[m_dim].faceDisplacements[iface][1] * dh_2;
-	center[2] = (double)m_z + double(m_dim-2) * (double)sm_treeConstants[m_dim].faceDisplacements[iface][2] * dh_2;
+	center[0] = getLogicalX() + (double)sm_treeConstants[m_dim].faceDisplacements[iface][0] * dh_2;
+	center[1] = getLogicalY() + (double)sm_treeConstants[m_dim].faceDisplacements[iface][1] * dh_2;
+	center[2] = getLogicalZ() + double(m_dim-2) * (double)sm_treeConstants[m_dim].faceDisplacements[iface][2] * dh_2;
 
 	return center;
 };
@@ -512,9 +512,9 @@ Octant::getLogicalEdgeCenter(uint8_t iedge) const{
 	darray3 center;
 
 	dh_2 = double(getLogicalSize())*0.5;
-	center[0] = (double)m_x + (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][0] * dh_2;
-	center[1] = (double)m_y + (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][1] * dh_2;
-	center[2] = (double)m_z + double(m_dim-2) * (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][2] * dh_2;
+	center[0] = getLogicalX() + (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][0] * dh_2;
+	center[1] = getLogicalY() + (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][1] * dh_2;
+	center[2] = getLogicalZ() + double(m_dim-2) * (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][2] * dh_2;
 	return center;
 };
 
@@ -532,10 +532,12 @@ Octant::getLogicalNodes(u32arr3vector & nodes) const{
 	dh = getLogicalSize();
 	nodes.resize(nn);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	for (i = 0; i < nn; i++){
-		nodes[i][0] = m_x + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][0])*dh;
-		nodes[i][1] = m_y + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][1])*dh;
-		nodes[i][2] = m_z + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][2])*dh;
+		nodes[i][0] = coords[0] + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][0])*dh;
+		nodes[i][1] = coords[1] + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][1])*dh;
+		nodes[i][2] = coords[2] + uint32_t(sm_treeConstants[m_dim].nodeCoordinates[i][2])*dh;
 	}
 };
 
@@ -552,10 +554,12 @@ Octant::getLogicalNodes() const{
 	dh = getLogicalSize();
 	nodes.resize(nn);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	for (i = 0; i < nn; i++){
-		nodes[i][0] = m_x + sm_treeConstants[m_dim].nodeCoordinates[i][0]*dh;
-		nodes[i][1] = m_y + sm_treeConstants[m_dim].nodeCoordinates[i][1]*dh;
-		nodes[i][2] = m_z + sm_treeConstants[m_dim].nodeCoordinates[i][2]*dh;
+		nodes[i][0] = coords[0] + sm_treeConstants[m_dim].nodeCoordinates[i][0]*dh;
+		nodes[i][1] = coords[1] + sm_treeConstants[m_dim].nodeCoordinates[i][1]*dh;
+		nodes[i][2] = coords[2] + sm_treeConstants[m_dim].nodeCoordinates[i][2]*dh;
 	}
 
 	return nodes;
@@ -569,9 +573,12 @@ void		Octant::getLogicalNode(u32array3 & node, uint8_t inode) const{
 	uint32_t	dh;
 
 	dh = getLogicalSize();
-	node[0] = m_x + sm_treeConstants[m_dim].nodeCoordinates[inode][0]*dh;
-	node[1] = m_y + sm_treeConstants[m_dim].nodeCoordinates[inode][1]*dh;
-	node[2] = m_z + sm_treeConstants[m_dim].nodeCoordinates[inode][2]*dh;
+
+	node = getLogicalCoordinates();
+
+	node[0] += sm_treeConstants[m_dim].nodeCoordinates[inode][0]*dh;
+	node[1] += sm_treeConstants[m_dim].nodeCoordinates[inode][1]*dh;
+	node[2] += sm_treeConstants[m_dim].nodeCoordinates[inode][2]*dh;
 
 };
 
@@ -580,13 +587,15 @@ void		Octant::getLogicalNode(u32array3 & node, uint8_t inode) const{
  * \return Array[3] with the logical coordinates of the node of the octant.
  */
 u32array3		Octant::getLogicalNode(uint8_t inode) const{
-	u32array3 	node;
 	uint32_t	dh;
 
 	dh = getLogicalSize();
-	node[0] = m_x + sm_treeConstants[m_dim].nodeCoordinates[inode][0]*dh;
-	node[1] = m_y + sm_treeConstants[m_dim].nodeCoordinates[inode][1]*dh;
-	node[2] = m_z + sm_treeConstants[m_dim].nodeCoordinates[inode][2]*dh;
+
+	u32array3 node = getLogicalCoordinates();
+
+	node[0] += sm_treeConstants[m_dim].nodeCoordinates[inode][0]*dh;
+	node[1] += sm_treeConstants[m_dim].nodeCoordinates[inode][1]*dh;
+	node[2] += sm_treeConstants[m_dim].nodeCoordinates[inode][2]*dh;
 	return node;
 };
 
@@ -637,7 +646,7 @@ uint64_t	Octant::computeFatherMorton() const {
  * of this octant.
  */
 u32array3	Octant::computeFatherCoordinates() const {
-	u32array3 fatherCoordinates = {{m_x, m_y, m_z}};
+	u32array3 fatherCoordinates = getLogicalCoordinates();
 	for (int i=0; i<m_dim; i++){
 		fatherCoordinates[i] -= fatherCoordinates[i]%(uint32_t(1) << (TreeConstants::MAX_LEVEL - max(0,(m_level-1))));
 	}
@@ -677,11 +686,12 @@ unsigned int Octant::getBinarySize()
  * \return Last descendant octant.
  */
 Octant	Octant::buildLastDesc() const {
-	u32array3 delta = { {0,0,0} };
+	u32array3 lastDescCoords = getLogicalCoordinates();
 	for (int i=0; i<m_dim; i++){
-		delta[i] = (uint32_t(1) << (TreeConstants::MAX_LEVEL - m_level)) - 1;
+		lastDescCoords[i] += (uint32_t(1) << (TreeConstants::MAX_LEVEL - m_level)) - 1;
 	}
-	Octant last_desc(m_dim, TreeConstants::MAX_LEVEL, (m_x+delta[0]), (m_y+delta[1]), (m_z+delta[2]));
+
+	Octant last_desc(m_dim, TreeConstants::MAX_LEVEL, lastDescCoords[0], lastDescCoords[1], lastDescCoords[2]);
 	return last_desc;
 };
 
@@ -880,15 +890,17 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	*nMortons = (m_level < TreeConstants::MAX_LEVEL) ? nchildren/2 : 1;
 	mortons->resize(*nMortons);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	uint32_t dh  = (m_level < TreeConstants::MAX_LEVEL) ? getLogicalSize()/2 : getLogicalSize();
 	uint32_t dh2 = getLogicalSize();
 	switch (iface) {
 	case 0 :
 	{
-		uint32_t x = m_x - dh;
+		uint32_t x = coords[0] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + ((i == 1) || (i == 3)) * dh;
-			uint32_t z = m_z + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
+			uint32_t y = coords[1] + ((i == 1) || (i == 3)) * dh;
+			uint32_t z = coords[2] + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -896,10 +908,10 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	break;
 	case 1 :
 	{
-		uint32_t x = m_x + dh2;
+		uint32_t x = coords[0] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + ((i == 1) || (i == 3)) * dh;
-			uint32_t z = m_z + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
+			uint32_t y = coords[1] + ((i == 1) || (i == 3)) * dh;
+			uint32_t z = coords[2] + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -907,10 +919,10 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	break;
 	case 2 :
 	{
-		uint32_t y = m_y - dh;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((i == 1) || (i == 3)) * dh;
-			uint32_t z = m_z + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
+			uint32_t x = coords[0] + ((i == 1) || (i == 3)) * dh;
+			uint32_t z = coords[2] + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -918,10 +930,10 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	break;
 	case 3 :
 	{
-		uint32_t y = m_y + dh2;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((i == 1) || (i == 3)) * dh;
-			uint32_t z = m_z + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
+			uint32_t x = coords[0] + ((i == 1) || (i == 3)) * dh;
+			uint32_t z = coords[2] + ((m_dim  ==  3) && ((i == 2) || (i == 3))) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -929,10 +941,10 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	break;
 	case 4 :
 	{
-		uint32_t z = m_z - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((i == 1) || (i == 3)) * dh;
-			uint32_t y = m_y + ((i == 2) || (i == 3)) * dh;
+			uint32_t x = coords[0] + ((i == 1) || (i == 3)) * dh;
+			uint32_t y = coords[1] + ((i == 2) || (i == 3)) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -940,10 +952,10 @@ void Octant::computeHalfSizeMortons(uint8_t iface, uint32_t *nMortons, std::vect
 	break;
 	case 5 :
 	{
-		uint32_t z = m_z + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((i == 1) || (i == 3)) * dh;
-			uint32_t y = m_y + ((i == 2) || (i == 3)) * dh;
+			uint32_t x = coords[0] + ((i == 1) || (i == 3)) * dh;
+			uint32_t y = coords[1] + ((i == 2) || (i == 3)) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -971,16 +983,18 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	*nMortons = (m_level < TreeConstants::MAX_LEVEL) ? uint32_t(1)<<((m_dim-1)*(maxdepth-m_level)) : 1;
 	mortons->resize(*nMortons);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	uint32_t dh    = (m_level < TreeConstants::MAX_LEVEL) ? uint32_t(1)<<(TreeConstants::MAX_LEVEL - maxdepth) : getLogicalSize();
 	uint32_t dh2   = getLogicalSize();
 	uint32_t nline = uint32_t(1)<<(maxdepth-m_level);
 	switch (iface) {
 	case 0 :
 	{
-		uint32_t x = m_x - dh;
+		uint32_t x = coords[0] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
-			uint32_t z = m_z + (m_dim - 2) * (i % nline) * dh;
+			uint32_t y = coords[1] + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
+			uint32_t z = coords[2] + (m_dim - 2) * (i % nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -988,10 +1002,10 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	break;
 	case 1 :
 	{
-		uint32_t x = m_x + dh2;
+		uint32_t x = coords[0] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
-			uint32_t z = m_z + (m_dim - 2) * (i % nline) * dh;
+			uint32_t y = coords[1] + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
+			uint32_t z = coords[2] + (m_dim - 2) * (i % nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -999,10 +1013,10 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	break;
 	case 2 :
 	{
-		uint32_t y = m_y - dh;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
-			uint32_t z = m_z + (m_dim - 2) * (i % nline) * dh;
+			uint32_t x = coords[0] + ((m_dim == 2) * (i % nline) + (m_dim - 2) * (i / nline)) * dh;
+			uint32_t z = coords[2] + (m_dim - 2) * (i % nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1010,10 +1024,10 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	break;
 	case 3 :
 	{
-		uint32_t y = m_y + dh2;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + ((m_dim == 2) * (i%nline) + (m_dim - 2) * (i / nline)) * dh;
-			uint32_t z = m_z + (m_dim - 2) * (i%nline) * dh;
+			uint32_t x = coords[0] + ((m_dim == 2) * (i%nline) + (m_dim - 2) * (i / nline)) * dh;
+			uint32_t z = coords[2] + (m_dim - 2) * (i%nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1021,10 +1035,10 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	break;
 	case 4 :
 	{
-		uint32_t z = m_z - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i / nline) * dh;
-			uint32_t y = m_y + (i % nline) * dh;
+			uint32_t x = coords[0] + (i / nline) * dh;
+			uint32_t y = coords[1] + (i % nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1032,10 +1046,10 @@ void Octant::computeMinSizeMortons(uint8_t iface, uint8_t maxdepth, uint32_t *nM
 	break;
 	case 5 :
 	{
-		uint32_t z = m_z + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i / nline) * dh;
-			uint32_t y = m_y + (i % nline) * dh;
+			uint32_t x = coords[0] + (i / nline) * dh;
+			uint32_t y = coords[1] + (i % nline) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1083,16 +1097,18 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	*nMortons = (m_level < TreeConstants::MAX_LEVEL) ? 2 : 1;
 	mortons->resize(*nMortons);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	uint32_t dh = (m_level < TreeConstants::MAX_LEVEL) ? getLogicalSize()/2 : getLogicalSize();
 	uint32_t dh2 = getLogicalSize();
 
 	switch (iedge) {
 	case 0 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t z = m_z - dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + (i == 1) * dh;
+			uint32_t y = coords[1] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1100,10 +1116,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 1 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t z = m_z - dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + (i == 1) * dh;
+			uint32_t y = coords[1] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1111,10 +1127,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 2 :
 	{
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z - dh;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i == 1) * dh;
+			uint32_t x = coords[0] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1122,10 +1138,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 3 :
 	{
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z - dh;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i == 1) * dh;
+			uint32_t x = coords[0] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1133,10 +1149,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 4 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y - dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + (i == 1) * dh;
+			uint32_t z = coords[2] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1144,10 +1160,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 5 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y - dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + (i == 1) * dh;
+			uint32_t z = coords[2] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1155,10 +1171,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 6 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + (i == 1) * dh;
+			uint32_t z = coords[2] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1166,10 +1182,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 7 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + (i == 1) * dh;
+			uint32_t z = coords[2] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1177,10 +1193,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 8 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + (i == 1) * dh;
+			uint32_t y = coords[1] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1188,10 +1204,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 9 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + (i == 1) * dh;
+			uint32_t y = coords[1] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1199,10 +1215,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 10 :
 	{
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i == 1) * dh;
+			uint32_t x = coords[0] + (i == 1) * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1210,10 +1226,10 @@ void Octant::computeEdgeHalfSizeMortons(uint8_t iedge, const uint8_t (&edgeface)
 	break;
 	case 11 :
 	{
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + (i == 1) *  dh;
+			uint32_t x = coords[0] + (i == 1) *  dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1244,25 +1260,27 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	*nMortons = (m_level < TreeConstants::MAX_LEVEL) ? uint32_t(1)<<(maxdepth-m_level) : 1;
 	mortons->resize(*nMortons);
 
+	u32array3 coords = getLogicalCoordinates();
+
 	uint32_t dh = (m_level < TreeConstants::MAX_LEVEL) ? uint32_t(1)<<(TreeConstants::MAX_LEVEL - maxdepth) : getLogicalSize();
 	uint32_t dh2 = getLogicalSize();
 	switch (iedge) {
 	case 0 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t z = m_z - dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + i * dh;
+			uint32_t y = coords[1] + i * dh;
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
 	}
 	break;
 	case 1 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t z = m_z - dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + i * dh;
+			uint32_t y = coords[1] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1270,10 +1288,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 2 :
 	{
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z - dh;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + i * dh;
+			uint32_t x = coords[0] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1281,10 +1299,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 3 :
 	{
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z - dh;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + i * dh;
+			uint32_t x = coords[0] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1292,10 +1310,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 4 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y - dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + i * dh;
+			uint32_t z = coords[2] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1303,10 +1321,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 5 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y - dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] - dh;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + i * dh;
+			uint32_t z = coords[2] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1314,10 +1332,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 6 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + i * dh;
+			uint32_t z = coords[2] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1325,10 +1343,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 7 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t z = m_z + i * dh;
+			uint32_t z = coords[2] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1336,10 +1354,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 8 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + i * dh;
+			uint32_t y = coords[1] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1347,10 +1365,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 9 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t y = m_y + i * dh;
+			uint32_t y = coords[1] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1358,10 +1376,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 10 :
 	{
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + i * dh;
+			uint32_t x = coords[0] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1369,10 +1387,10 @@ void Octant::computeEdgeMinSizeMortons(uint8_t iedge, uint8_t maxdepth, const ui
 	break;
 	case 11 :
 	{
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] + dh2;
 		for (uint32_t i = 0; i < *nMortons; ++i) {
-			uint32_t x = m_x + i * dh;
+			uint32_t x = coords[0] + i * dh;
 
 			(*mortons)[i] = PABLO::computeMorton(x, y, z);
 		}
@@ -1424,77 +1442,79 @@ void Octant::computeNodeMinSizeMorton(uint8_t inode, uint8_t maxdepth, const uin
 
 	*hasMorton = true;
 
+	u32array3 coords = getLogicalCoordinates();
+
 	uint32_t dh  = (m_level < TreeConstants::MAX_LEVEL) ? uint32_t(1)<<(TreeConstants::MAX_LEVEL - maxdepth) : getLogicalSize();
 	uint32_t dh2 = getLogicalSize();
 	switch (inode) {
 	case 0 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z - (m_dim - 2) * dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] - (m_dim - 2) * dh;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 1 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z - (m_dim - 2) * dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] - (m_dim - 2) * dh;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 2 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z - (m_dim - 2) * dh;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] - (m_dim - 2) * dh;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 3 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z - (m_dim - 2) * dh;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] - (m_dim - 2) * dh;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 4 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] + dh2;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 5 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y - dh;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] - dh;
+		uint32_t z = coords[2] + dh2;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 6 :
 	{
-		uint32_t x = m_x - dh;
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] - dh;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] + dh2;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
 	break;
 	case 7 :
 	{
-		uint32_t x = m_x + dh2;
-		uint32_t y = m_y + dh2;
-		uint32_t z = m_z + dh2;
+		uint32_t x = coords[0] + dh2;
+		uint32_t y = coords[1] + dh2;
+		uint32_t z = coords[2] + dh2;
 
 		*morton = PABLO::computeMorton(x, y, z);
 	}
@@ -1529,6 +1549,8 @@ uint64_t Octant::computePeriodicMorton(uint8_t iface) const {
 	dh = getLogicalSize();
 	uint32_t maxLength = uint32_t(1)<<TreeConstants::MAX_LEVEL;
 
+	u32array3 coords = getLogicalCoordinates();
+
 	if (!m_info[iface]){
 		return this->computeMorton();
 	}
@@ -1536,32 +1558,32 @@ uint64_t Octant::computePeriodicMorton(uint8_t iface) const {
 		switch (iface) {
 		case 0 :
 		{
-			Morton = PABLO::computeMorton(maxLength-dh,this->m_y,this->m_z);
+			Morton = PABLO::computeMorton(maxLength-dh,coords[1],coords[2]);
 		}
 		break;
 		case 1 :
 		{
-			Morton = PABLO::computeMorton(0,this->m_y,this->m_z);
+			Morton = PABLO::computeMorton(0,coords[1],coords[2]);
 		}
 		break;
 		case 2 :
 		{
-			Morton = PABLO::computeMorton(this->m_x,maxLength-dh,this->m_z);
+			Morton = PABLO::computeMorton(coords[0],maxLength-dh,coords[2]);
 		}
 		break;
 		case 3 :
 		{
-			Morton = PABLO::computeMorton(this->m_x,0,this->m_z);
+			Morton = PABLO::computeMorton(coords[0],0,coords[2]);
 		}
 		break;
 		case 4 :
 		{
-			Morton = PABLO::computeMorton(this->m_x,this->m_y,maxLength-dh);
+			Morton = PABLO::computeMorton(coords[0],coords[1],maxLength-dh);
 		}
 		break;
 		case 5 :
 		{
-			Morton = PABLO::computeMorton(this->m_x,this->m_y,0);
+			Morton = PABLO::computeMorton(coords[0],coords[1],0);
 		}
 		break;
 		default:
@@ -1576,10 +1598,10 @@ uint64_t Octant::computePeriodicMorton(uint8_t iface) const {
  * may be not living in octree).
  */
 Octant Octant::computePeriodicOctant(uint8_t iface) const {
-	Octant degOct(this->m_dim, this->m_level, this->m_x, this->m_y, this->m_z);
 	uint32_t maxLength = uint32_t(1)<<TreeConstants::MAX_LEVEL;
 	uint32_t dh = this->getLogicalSize();
 
+	u32array3 periodicCoords = getLogicalCoordinates();
 	if (!m_info[iface]){
 		return *this;
 	}
@@ -1587,36 +1609,37 @@ Octant Octant::computePeriodicOctant(uint8_t iface) const {
 		switch (iface) {
 		case 0 :
 		{
-			degOct.m_x = maxLength-dh;
+			periodicCoords[0] = maxLength-dh;
 		}
 		break;
 		case 1 :
 		{
-			degOct.m_x = 0;
+			periodicCoords[0] = 0;
 		}
 		break;
 		case 2 :
 		{
-			degOct.m_y = maxLength-dh;
+			periodicCoords[1] = maxLength-dh;
 		}
 		break;
 		case 3 :
 		{
-			degOct.m_y = 0;
+			periodicCoords[1] = 0;
 		}
 		break;
 		case 4 :
 		{
-			degOct.m_z = maxLength-dh;
+			periodicCoords[2] = maxLength-dh;
 		}
 		break;
 		case 5 :
 		{
-			degOct.m_z = 0;
+			periodicCoords[2] = 0;
 		}
 		break;
 		}
-		degOct.m_level = this->m_level;
+
+		Octant degOct(m_dim, m_level, periodicCoords[0], periodicCoords[1], periodicCoords[2]);
 		degOct.m_info = false;
 		return degOct;
 	}
@@ -1629,7 +1652,6 @@ Octant Octant::computePeriodicOctant(uint8_t iface) const {
  * \param[in] inode Local index of the node target.
  */
 Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
-    Octant degOct(this->m_dim, this->m_level, this->m_x, this->m_y, this->m_z);
     uint32_t maxLength = sm_treeConstants[m_dim].MAX_LENGTH;
     uint32_t dh = this->getLogicalSize();
 
@@ -1637,6 +1659,7 @@ Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
     uint8_t iface2 = sm_treeConstants[m_dim].nodeFace[inode][1];
     uint8_t iface3 = sm_treeConstants[m_dim].nodeFace[inode][m_dim-1];
 
+    u32array3 periodicCoords = getLogicalCoordinates();
     if (!m_info[iface1] && !m_info[iface2] && !m_info[iface3]){
         return *this;
     }
@@ -1645,20 +1668,20 @@ Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
         case 0 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE0]){
-                degOct.m_x = maxLength-dh;
+                periodicCoords[0] = maxLength-dh;
             }
             else{
-                degOct.m_x -= dh;
+                periodicCoords[0] -= dh;
             }
         }
         break;
         case 1 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE1]){
-                degOct.m_x = 0;
+                periodicCoords[0] = 0;
             }
             else{
-                degOct.m_x += dh;
+                periodicCoords[0] += dh;
             }
         }
         break;
@@ -1668,20 +1691,20 @@ Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
         case 2 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE2]){
-                degOct.m_y = maxLength-dh;
+                periodicCoords[1] = maxLength-dh;
             }
             else{
-                degOct.m_y -= dh;
+                periodicCoords[1] -= dh;
             }
         }
         break;
         case 3 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE3]){
-                degOct.m_y = 0;
+                periodicCoords[1] = 0;
             }
             else{
-                degOct.m_y += dh;
+                periodicCoords[1] += dh;
             }
         }
         break;
@@ -1691,26 +1714,26 @@ Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
         case 4 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE4]){
-                degOct.m_z = maxLength-dh;
+                periodicCoords[2] = maxLength-dh;
             }
             else{
-                degOct.m_z -= dh;
+                periodicCoords[2] -= dh;
             }
         }
         break;
         case 5 :
         {
             if (m_info[OctantInfo::INFO_BOUNDFACE5]){
-                degOct.m_z = 0;
+                periodicCoords[2] = 0;
             }
             else{
-                degOct.m_z += dh;
+                periodicCoords[2] += dh;
             }
         }
         break;
         }
 
-        degOct.m_level = this->m_level;
+        Octant degOct(m_dim, m_level, periodicCoords[0], periodicCoords[1], periodicCoords[2]);
         degOct.m_info = false;
         return degOct;
     }
@@ -1723,7 +1746,6 @@ Octant Octant::computeNodePeriodicOctant(uint8_t inode) const {
  * \param[in] iedge Local index of the edge target.
  */
 Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
-    Octant degOct(this->m_dim, this->m_level, this->m_x, this->m_y, this->m_z);
     uint32_t maxLength = uint32_t(1)<<TreeConstants::MAX_LEVEL;
     uint32_t dh = this->getLogicalSize();
 
@@ -1736,6 +1758,7 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
         cxyz[idim] = sm_treeConstants[m_dim].edgeCoeffs[iedge][idim];
     }
 
+    u32array3 periodicCoords = getLogicalCoordinates();
     if (!m_info[iface[0]] && !m_info[iface[1]]){
         return *this;
     }
@@ -1745,10 +1768,10 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             case 0 :
                 if (cxyz[0] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE0]){
-                        degOct.m_x = maxLength-dh;
+                        periodicCoords[0] = maxLength-dh;
                     }
                     else{
-                        degOct.m_x -= dh;
+                        periodicCoords[0] -= dh;
                     }
                 }
                 break;
@@ -1756,10 +1779,10 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             {
                 if (cxyz[0] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE1]){
-                        degOct.m_x = 0;
+                        periodicCoords[0] = 0;
                     }
                     else{
-                        degOct.m_x += dh;
+                        periodicCoords[0] += dh;
                     }
                 }
             }
@@ -1768,10 +1791,10 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             {
                 if (cxyz[1] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE2]){
-                        degOct.m_y = maxLength-dh;
+                        periodicCoords[1] = maxLength-dh;
                     }
                     else{
-                        degOct.m_y -= dh;
+                        periodicCoords[1] -= dh;
                     }
                 }
             }
@@ -1780,10 +1803,10 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             {
                 if (cxyz[1] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE3]){
-                        degOct.m_y = 0;
+                        periodicCoords[1] = 0;
                     }
                     else{
-                        degOct.m_y += dh;
+                        periodicCoords[1] += dh;
                     }
                 }
             }
@@ -1792,10 +1815,10 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             {
                 if (cxyz[2] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE4]){
-                        degOct.m_z = maxLength-dh;
+                        periodicCoords[2] = maxLength-dh;
                     }
                     else{
-                        degOct.m_z -= dh;
+                        periodicCoords[2] -= dh;
                     }
                 }
             }
@@ -1804,17 +1827,18 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
             {
                 if (cxyz[2] != 0){
                     if (m_info[OctantInfo::INFO_BOUNDFACE5]){
-                        degOct.m_z = 0;
+                        periodicCoords[2] = 0;
                     }
                     else{
-                        degOct.m_z += dh;
+                        periodicCoords[2] += dh;
                     }
                 }
             }
             break;
             }
         } // end loop on i
-        degOct.m_level = this->m_level;
+
+        Octant degOct(m_dim, m_level, periodicCoords[0], periodicCoords[1], periodicCoords[2]);
         degOct.m_info = false;
         return degOct;
     }
@@ -1829,9 +1853,9 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
  */
 array<int64_t,3> Octant::getPeriodicCoord(uint8_t iface) const {
 	array<int64_t,3> coord;
-	coord[0] = this->m_x;
-	coord[1] = this->m_y;
-	coord[2] = this->m_z;
+	coord[0] = getLogicalX();
+	coord[1] = getLogicalY();
+	coord[2] = getLogicalZ();
 	int64_t dh = this->getLogicalSize();
 	int64_t maxLength = int64_t(1)<<TreeConstants::MAX_LEVEL;
 
@@ -1879,9 +1903,9 @@ array<int64_t,3> Octant::getPeriodicCoord(uint8_t iface) const {
  */
 array<int64_t,3> Octant::getNodePeriodicCoord(uint8_t inode) const {
     array<int64_t,3> coord;
-    coord[0] = this->m_x;
-    coord[1] = this->m_y;
-    coord[2] = this->m_z;
+    coord[0] = getLogicalX();
+    coord[1] = getLogicalY();
+    coord[2] = getLogicalZ();
     int64_t dh = this->getLogicalSize();
     int64_t maxLength = int64_t(1)<<TreeConstants::MAX_LEVEL;
 
@@ -1952,9 +1976,9 @@ array<int64_t,3> Octant::getNodePeriodicCoord(uint8_t inode) const {
  */
 array<int64_t,3> Octant::getEdgePeriodicCoord(uint8_t iedge) const {
     array<int64_t,3> coord;
-    coord[0] = this->m_x;
-    coord[1] = this->m_y;
-    coord[2] = this->m_z;
+    coord[0] = getLogicalX();
+    coord[1] = getLogicalY();
+    coord[2] = getLogicalZ();
     int64_t dh = this->getLogicalSize();
     int64_t maxLength = int64_t(1)<<TreeConstants::MAX_LEVEL;
 
@@ -2035,13 +2059,11 @@ array<int64_t,3> Octant::getEdgePeriodicCoord(uint8_t iedge) const {
  */
 uint8_t Octant::getFamilySplittingNode() const {
 
-	bool delta[3];
-	uint32_t xx[3];
-	xx[0] = m_x;
-	xx[1] = m_y;
-	xx[2] = m_z;
-	delta[2] = 0;
+	u32array3 xx = getLogicalCoordinates();
+
 	//Delta to build father (use the boolean negation to identify the splitting node)
+	bool delta[3];
+	delta[2] = 0;
 	for (int i=0; i<m_dim; i++){
 		delta[i] = ((xx[i]%(uint32_t(1) << (TreeConstants::MAX_LEVEL - max(0,(m_level-1))))) == 0);
 	}

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -192,7 +192,6 @@ public:
     uint32_t    getLogicalX() const;
     uint32_t    getLogicalY() const;
     uint32_t    getLogicalZ() const;
-    u32array3   getLogicalCoord() const;
     uint8_t     getLevel() const;
     int8_t      getMarker() const;
     bool        getBound(uint8_t face) const;

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -229,8 +229,8 @@ public:
     u32array3       getLogicalNode(uint8_t inode) const;
     void            getNormal(uint8_t iface, i8array3 & normal, const int8_t (&normals)[6][3]) const;
     uint64_t        computeMorton() const;
-    uint64_t        computeNodeMorton(uint8_t inode) const;
-    uint64_t        computeNodeMorton(const u32array3 &node) const;
+    uint64_t        computeNodePersistentKey(uint8_t inode) const;
+    uint64_t        computeNodePersistentKey(const u32array3 &node) const;
 
     // =================================================================================== //
     // OTHER METHODS                                                                   //

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -226,7 +226,7 @@ public:
     void            getLogicalNode(u32array3 & node, uint8_t inode) const;
     u32array3       getLogicalNode(uint8_t inode) const;
     void            getNormal(uint8_t iface, i8array3 & normal, const int8_t (&normals)[6][3]) const;
-    uint64_t        computeMorton() const;
+    uint64_t        getMorton() const;
     uint64_t        computeNodePersistentKey(uint8_t inode) const;
     uint64_t        computeNodePersistentKey(const u32array3 &node) const;
 

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -133,9 +133,7 @@ class Octant{
     };
 
 private:
-    uint32_t                        m_x;            /**< Coordinate x */
-    uint32_t                        m_y;            /**< Coordinate y */
-    uint32_t                        m_z;            /**< Coordinate z (2D case = 0)*/
+    uint64_t                        m_morton;       /**< Morton number */
     uint8_t                         m_level;        /**< Refinement level (0=root) */
     int8_t                          m_marker;       /**< Set for Refinement(m>0) or Coarsening(m<0) |m|-times */
     std::bitset<INFO_ITEM_COUNT>    m_info;         /**< -Info[0..5]: true if 0..5 face is a boundary face [bound] \n

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -26,9 +26,6 @@
 // INCLUDES                                                                            //
 // =================================================================================== //
 #include "bitpit_common.hpp"
-#if BITPIT_ENABLE_MPI==1
-#include "bitpit_communications.hpp"
-#endif
 
 #include "ParaTree.hpp"
 #include <climits>

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -1493,15 +1493,15 @@ namespace bitpit {
         return m_octree.computeMorton(idx);
     };
 
-    /** Compute the Morton index of the specified node of the idx-th octant
-     * (without level).
+    /** Compute the persistent XYZ key of the specified node of an octant (without
+     * level).
      * \param[in] idx Local index of the target octant.
      * \param[in] inode Index of the target node.
-     * \return Morton index of the node.
+     * \return persistent XYZ key of the node.
      */
     uint64_t
-    ParaTree::getNodeMorton(uint32_t idx, uint8_t inode) const {
-        return m_octree.computeNodeMorton(idx, inode);
+    ParaTree::computeNodePersistentKey(uint32_t idx, uint8_t inode) const {
+        return m_octree.computeNodePersistentKey(idx, inode);
     };
 
     /*! Get the balancing condition of an octant.
@@ -1952,15 +1952,15 @@ namespace bitpit {
         return oct->buildLastDesc().computeMorton();
     };
 
-    /** Compute the Morton index of the specified node of an octant (without
+    /** Compute the persistent XYZ key of the specified node of an octant (without
      * level).
      * \param[in] oct Pointer to the target octant
      * \param[in] inode Index of the target node.
-     * \return Morton index of the node.
+     * \return persistent XYZ key of the node.
      */
     uint64_t
-    ParaTree::getNodeMorton(const Octant* oct, uint8_t inode) const {
-        return oct->computeNodeMorton(inode);
+    ParaTree::computeNodePersistentKey(const Octant* oct, uint8_t inode) const {
+        return oct->computeNodePersistentKey(inode);
     };
 
     /*! Get the balancing condition of an octant.

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -1487,7 +1487,7 @@ namespace bitpit {
      */
     uint64_t
     ParaTree::getMorton(uint32_t idx) const {
-        return m_octree.computeMorton(idx);
+        return m_octree.getMorton(idx);
     };
 
     /** Compute the persistent XYZ key of the specified node of an octant (without
@@ -1937,7 +1937,7 @@ namespace bitpit {
      */
     uint64_t
     ParaTree::getMorton(const Octant* oct) const {
-        return oct->computeMorton();
+        return oct->getMorton();
     };
 
     /*!Get the morton index of the last possible descendant with maximum refinement level of a target octant.
@@ -1946,7 +1946,7 @@ namespace bitpit {
      */
     uint64_t
     ParaTree::getLastDescMorton(const Octant* oct) const {
-        return oct->buildLastDesc().computeMorton();
+        return oct->buildLastDesc().getMorton();
     };
 
     /** Compute the persistent XYZ key of the specified node of an octant (without
@@ -2033,10 +2033,10 @@ namespace bitpit {
     ParaTree::getIdx(const Octant* oct) const {
 #if BITPIT_ENABLE_MPI==1
         if (getIsGhost(oct)){
-            return m_octree.findGhostMorton(oct->computeMorton());
+            return m_octree.findGhostMorton(oct->getMorton());
         }
 #endif
-        return m_octree.findMorton(oct->computeMorton());
+        return m_octree.findMorton(oct->getMorton());
     };
 
     /*! Get the global index of an octant.
@@ -2193,7 +2193,7 @@ namespace bitpit {
      */
     uint64_t
     ParaTree::getLastDescMorton(uint32_t idx) const {
-        return m_octree.m_octants[idx].buildLastDesc().computeMorton();
+        return m_octree.m_octants[idx].buildLastDesc().getMorton();
     };
 
     /*!Get the begin position for the iterator of the local internal octants.
@@ -3085,7 +3085,7 @@ namespace bitpit {
         int32_t jump = idxtry;
         while(abs(jump) > 0){
 
-            mortontry = m_octree.m_octants[idxtry].computeMorton();
+            mortontry = m_octree.m_octants[idxtry].getMorton();
             jump = ((mortontry<morton)-(mortontry>morton))*abs(jump)/2;
             idxtry += jump;
             if (idxtry > noctants-1){
@@ -3099,20 +3099,20 @@ namespace bitpit {
                 }
             }
         }
-        if(m_octree.m_octants[idxtry].computeMorton() == morton){
+        if(m_octree.m_octants[idxtry].getMorton() == morton){
             return idxtry;
         }
         else{
             // Step until the mortontry lower than morton (one idx of distance)
             {
-                while(m_octree.m_octants[idxtry].computeMorton() < morton){
+                while(m_octree.m_octants[idxtry].getMorton() < morton){
                     idxtry++;
                     if(idxtry > noctants-1){
                         idxtry = noctants-1;
                         break;
                     }
                 }
-                while(m_octree.m_octants[idxtry].computeMorton() > morton){
+                while(m_octree.m_octants[idxtry].getMorton() > morton){
                     idxtry--;
                     if(idxtry > noctants-1){
                         idxtry = 0;
@@ -3163,7 +3163,7 @@ namespace bitpit {
             int32_t jump = idxtry;
             while(abs(jump) > 0){
                 
-                mortontry = m_octree.m_octants[idxtry].computeMorton();
+                mortontry = m_octree.m_octants[idxtry].getMorton();
                 jump = ((mortontry<morton)-(mortontry>morton))*abs(jump)/2;
                 idxtry += jump;
                 if (idxtry > noctants-1){
@@ -3177,20 +3177,20 @@ namespace bitpit {
                     }
                 }
             }
-            if(m_octree.m_octants[idxtry].computeMorton() == morton){
+            if(m_octree.m_octants[idxtry].getMorton() == morton){
                 return idxtry;
             }
             else{
                 // Step until the mortontry lower than morton (one idx of distance)
                 {
-                    while(m_octree.m_octants[idxtry].computeMorton() < morton){
+                    while(m_octree.m_octants[idxtry].getMorton() < morton){
                         idxtry++;
                         if(idxtry > noctants-1){
                             idxtry = noctants-1;
                             break;
                         }
                     }
-                    while(m_octree.m_octants[idxtry].computeMorton() > morton){
+                    while(m_octree.m_octants[idxtry].getMorton() > morton){
                         idxtry--;
                         if(idxtry > noctants-1){
                             idxtry = 0;
@@ -3211,7 +3211,7 @@ namespace bitpit {
             int32_t jump = idxtry;
             while(abs(jump) > 0){
                 
-                mortontry = m_octree.m_ghosts[idxtry].computeMorton();
+                mortontry = m_octree.m_ghosts[idxtry].getMorton();
                 jump = ((mortontry<morton)-(mortontry>morton))*abs(jump)/2;
                 idxtry += jump;
                 if (idxtry > nghosts-1){
@@ -3225,21 +3225,21 @@ namespace bitpit {
                     }
                 }
             }
-            if(m_octree.m_ghosts[idxtry].computeMorton() == morton){
+            if(m_octree.m_ghosts[idxtry].getMorton() == morton){
                 isghost = true;
                 return idxtry;
             }
             else{
                 // Step until the mortontry lower than morton (one idx of distance)
                 {
-                    while(m_octree.m_ghosts[idxtry].computeMorton() < morton){
+                    while(m_octree.m_ghosts[idxtry].getMorton() < morton){
                         idxtry++;
                         if(idxtry > nghosts-1){
                             idxtry = nghosts-1;
                             break;
                         }
                     }
-                    while(m_octree.m_ghosts[idxtry].computeMorton() > morton){
+                    while(m_octree.m_ghosts[idxtry].getMorton() > morton){
                         idxtry--;
                         if(idxtry > nghosts-1){
                             idxtry = 0;
@@ -3902,7 +3902,7 @@ namespace bitpit {
     };
 
     /** It finds the process owning the element definded by the Morton number passed as argument
-     * The Morton number can be computed using the method computeMorton() of Octant.
+     * The Morton number can be obtained using the method getMorton() of Octant.
      * \param[in] morton Morton number of the element you want find the owner of
      * \return Rank of the process owning the element
      */
@@ -5084,7 +5084,7 @@ namespace bitpit {
                 }
                 else if(m_octree.isEdgePeriodic(&octant, e)){
                     Octant periodicNeighbor = octant.computeEdgePeriodicOctant(e);
-                    int neighProc = findOwner(periodicNeighbor.computeMorton());
+                    int neighProc = findOwner(periodicNeighbor.getMorton());
                     if(neighProc != m_rank){
                         neighProcs.insert(neighProc);
                     }
@@ -5104,7 +5104,7 @@ namespace bitpit {
                 }
                 else if(m_octree.isNodePeriodic(&octant, c)){
                     Octant periodicNeighbor = octant.computeNodePeriodicOctant(c);
-                    int neighProc = findOwner(periodicNeighbor.computeMorton());
+                    int neighProc = findOwner(periodicNeighbor.getMorton());
                     if(neighProc != m_rank){
                         neighProcs.insert(neighProc);
                     }

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -293,7 +293,7 @@ namespace bitpit {
         int8_t 		getMarker(uint32_t idx) const;
         uint8_t 	getLevel(uint32_t idx) const;
         uint64_t 	getMorton(uint32_t idx) const;
-        uint64_t 	getNodeMorton(uint32_t idx, uint8_t inode) const;
+        uint64_t 	computeNodePersistentKey(uint32_t idx, uint8_t inode) const;
         bool 		getBalance(uint32_t idx) const;
         bool		getBound(uint32_t idx, uint8_t iface) const;
         bool		getBound(uint32_t idx) const;
@@ -336,7 +336,7 @@ namespace bitpit {
         uint8_t 	getLevel(const Octant* oct) const;
         uint64_t 	getMorton(const Octant* oct) const;
         uint64_t 	getLastDescMorton(const Octant* oct) const;
-        uint64_t 	getNodeMorton(const Octant* oct, uint8_t inode) const;
+        uint64_t 	computeNodePersistentKey(const Octant* oct, uint8_t inode) const;
         bool 		getBalance(const Octant* oct) const;
         bool		getBound(const Octant* oct, uint8_t iface) const;
         bool		getBound(const Octant* oct) const;

--- a/src/PABLO/morton.hpp
+++ b/src/PABLO/morton.hpp
@@ -75,6 +75,45 @@ inline uint64_t splitBy2(uint32_t a)
 }
 
 /**
+* Get the third bits of the given Morton number.
+*
+* The function comes from libmorton (see https://github.com/Forceflow/libmorton).
+*
+* \param morton is the morton number
+* \result The third bit of the given Morton number.
+*/
+inline uint32_t getThirdBits(uint64_t morton)
+{
+    uint64_t x = morton & 0x1249249249249249;
+    x = (x ^ (x >> 2)) & 0x10c30c30c30c30c3;
+    x = (x ^ (x >> 4)) & 0x100f00f00f00f00f;
+    x = (x ^ (x >> 8)) & 0x1f0000ff0000ff;
+    x = (x ^ (x >> 16)) & 0x1f00000000ffff;
+    x = (x ^ ((uint_fast64_t)x >> 32)) & 0x1fffff;
+
+    return static_cast<uint32_t>(x);
+}
+
+/**
+* Get the second bits of the given Morton number.
+*
+* The function comes from libmorton (see https://github.com/Forceflow/libmorton).
+*
+* \param morton is the morton number
+* \result The third bit of the given Morton number.
+*/
+inline uint32_t getSecondBits(uint64_t morton)
+{
+    uint64_t x = morton & 0x5555555555555555;
+    x = (x ^ (x >> 2)) & 0x3333333333333333;
+    x = (x ^ (x >> 4)) & 0xF0F0F0F0F0F0F0F;
+    x = (x ^ (x >> 8)) & 0xFF00FF00FF00FF;
+    x = (x ^ (x >> 16)) & 0xFFFF0000FFFF;
+
+    return static_cast<uint32_t>(x);
+}
+
+/**
 * Compute the Morton number of the given set of coordinates.
 *
 * The function uses the "magic bits" algorithm of the libmorton library
@@ -107,6 +146,36 @@ inline uint64_t computeMorton(uint32_t x, uint32_t y)
     uint64_t morton = splitBy2(x) | splitBy2(y) << 1;
 
     return morton;
+}
+
+/**
+* Compute the specified coordinate value from the given Morton number.
+*
+* The function uses the "magic bits" algorithm of the libmorton library
+* (see https://github.com/Forceflow/libmorton).
+*
+* \param morton is the morton number
+* \param coord is the coordinate that will be computed
+* \result The coordinate value.
+*/
+inline uint32_t computeCoordinate3D(uint64_t morton, int coord)
+{
+    return getThirdBits(morton >> coord);
+}
+
+/**
+* Compute the specified coordinate value from the given Morton number.
+*
+* The function uses the "magic bits" algorithm of the libmorton library
+* (see https://github.com/Forceflow/libmorton).
+*
+* \param morton is the morton number
+* \param coord is the coordinate that will be computed
+* \result The coordinate value.
+*/
+inline uint32_t computeCoordinate2D(uint64_t morton, int coord)
+{
+    return getSecondBits(morton >> coord);
 }
 
 /**

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1682,8 +1682,8 @@ VolOctree::StitchInfo VolOctree::deleteCells(const std::vector<DeleteInfo> &dele
 
 		for (int k = 0; k < nCellVertices; ++k) {
 			long vertexId = cellVertexIds[k];
-			uint64_t vertexTreeMorton = m_tree->getNodeMorton(octant, k);
-			stitchVertices.insert({vertexTreeMorton, vertexId});
+			uint64_t vertexTreeKey = m_tree->computeNodePersistentKey(octant, k);
+			stitchVertices.insert({vertexTreeKey, vertexId});
 			deadVertices.erase(vertexId);
 		}
 
@@ -1713,8 +1713,8 @@ VolOctree::StitchInfo VolOctree::deleteCells(const std::vector<DeleteInfo> &dele
 			const int *localFaceConnect = m_cellTypeInfo->faceConnectStorage[ownerFace].data();
 			for (int k = 0; k < nInterfaceVertices; ++k) {
 				long vertexId = ownerCellVertexIds[localFaceConnect[k]];
-				uint64_t vertexTreeMorton = m_tree->getNodeMorton(ownerOctant, localFaceConnect[k]);
-				stitchVertices.insert({vertexTreeMorton, vertexId});
+				uint64_t vertexTreeKey = m_tree->computeNodePersistentKey(ownerOctant, localFaceConnect[k]);
+				stitchVertices.insert({vertexTreeKey, vertexId});
 				deadVertices.erase(vertexId);
 			}
 		}
@@ -1781,8 +1781,8 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 	for (const OctantInfo &octantInfo : octantInfoList) {
 		Octant *octant = getOctantPointer(octantInfo);
 		for (int k = 0; k < nCellVertices; ++k) {
-			uint64_t vertexTreeMorton = m_tree->getNodeMorton(octant, k);
-			if (stitchInfo.count(vertexTreeMorton) == 0) {
+			uint64_t vertexTreeKey = m_tree->computeNodePersistentKey(octant, k);
+			if (stitchInfo.count(vertexTreeKey) == 0) {
 				// Vertex coordinates
 				std::array<double, 3> nodeCoords = m_tree->getNode(octant, k);
 
@@ -1812,7 +1812,7 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 				}
 
 				// Add the vertex to the stitching info
-				stitchInfo[vertexTreeMorton] = vertexId;
+				stitchInfo[vertexTreeKey] = vertexId;
 			}
 		}
 	}
@@ -1840,8 +1840,8 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 		// Cell connectivity
 		std::unique_ptr<long[]> cellConnect = std::unique_ptr<long[]>(new long[nCellVertices]);
 		for (int k = 0; k < nCellVertices; ++k) {
-			uint64_t vertexTreeMorton = m_tree->getNodeMorton(octant, k);
-			cellConnect[k] = stitchInfo.at(vertexTreeMorton);
+			uint64_t vertexTreeKey = m_tree->computeNodePersistentKey(octant, k);
+			cellConnect[k] = stitchInfo.at(vertexTreeKey);
 		}
 
 #if BITPIT_ENABLE_MPI==1


### PR DESCRIPTION
Instead of storing octant's coordinates, we can store the Morton number. This allows to reduce PABLO memory footprint and speeds up neighbour search.

(This branch starts from PABLO.optimize.find.neighbours.)