### PR TITLE
doc: Enable support for LATEX in doxygen documentation

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1409,7 +1409,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:


### PR DESCRIPTION
Enabled support for LATEX math environment in doxygen documentation.

Tested (and works) with the most common LATEX environment (equation, align, etc.) and sigle-line formula. 