### PR TITLE
PABLO: fix evaluation of first layer of ghost on periodic boundaries

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -257,6 +257,73 @@ namespace bitpit {
     // OTHER GET/SET METHODS
     // =================================================================================== //
 
+    /*!Check if the face of the specified octant is on a periodic boundary.
+     * \param[in] oct Pointer to the current octant
+     * \param[in] iface Index of face
+     * \return Returns true if the face of the specified octant is on a
+     * periodic boundary, false otherwise.
+     */
+    bool
+    LocalTree::isPeriodic(const Octant* oct, uint8_t iface) const{
+        // Check if face is on a boundary
+        if (!oct->getBound(iface)) {
+            return false;
+        }
+
+        // Check if boundary is periodic
+        return m_periodic[iface];
+    };
+
+    /*!Check if the edge of the specified octant is on a periodic boundary.
+     * \param[in] oct Pointer to the current octant
+     * \param[in] iedge Index of edge
+     * \return Returns true if the edge of the specified octant is on a
+     * periodic boundary, false otherwise.
+     */
+    bool
+    LocalTree::isEdgePeriodic(const Octant* oct, uint8_t iedge) const{
+        // The edge needs to be on a border
+        if (!oct->getEdgeBound(iedge)) {
+            return false;
+        }
+
+        // If one of the edge faces is on a non-periodic border the edge is
+        // non-periodic
+        for (int face : m_treeConstants->edgeFace[iedge]) {
+            if (oct->getBound(face) && !isPeriodic(oct, face)) {
+                return false;
+            }
+        }
+
+        // The edge is periodic
+        return true;
+    };
+
+    /*!Check if the node of the specified octant is on a periodic boundary.
+     * \param[in] oct Pointer to the current octant
+     * \param[in] inode Index of node
+     * \return Returns true if the node of the specified octant is on a
+     * periodic boundary, false otherwise.
+     */
+    bool
+    LocalTree::isNodePeriodic(const Octant* oct, uint8_t inode) const{
+        // The node needs to be on a border
+        if (!oct->getNodeBound(inode)) {
+            return false;
+        }
+
+        // If one of the node faces is on a non-periodic border the node is
+        // non-periodic
+        for (int face : m_treeConstants->nodeFace[inode]) {
+            if (oct->getBound(face) && !isPeriodic(oct, face)) {
+                return false;
+            }
+        }
+
+        // The edge is periodic
+        return true;
+    };
+
     // =================================================================================== //
     // OTHER METHODS
     // =================================================================================== //

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -1598,11 +1598,8 @@ namespace bitpit {
         uint32_t  	noctants = getNumOctants();
         uint32_t 	idxtry;
         uint32_t 	size = oct->getLogicalSize();
-        uint8_t 	iface1, iface2, iface3;
 
         bool amIghost = oct->getIsGhost();
-
-        bool isperiodic = false;
 
         int8_t 			cxyz[3] = {0,0,0};
         for (int idim=0; idim<m_dim; idim++){
@@ -1617,24 +1614,11 @@ namespace bitpit {
             return;
         }
 
-        // Check if octants node is a boundary
-        iface1 = m_treeConstants->nodeFace[inode][0];
-        iface2 = m_treeConstants->nodeFace[inode][1];
-        iface3 = m_treeConstants->nodeFace[inode][m_dim-1];
-
-        // If a face is a boundary, the node can have neighbours only if this face periodic
-        // Set periodic direction flags for the current octant
-        bool xperiodic = (oct->m_info[iface1] && m_periodic[iface1]);
-        bool yperiodic = (oct->m_info[iface2] && m_periodic[iface2]);
-        bool zperiodic = (oct->m_info[iface3] && m_periodic[iface3]);
-        if (oct->m_info[iface1] || oct->m_info[iface2] || oct->m_info[iface3]){
-            // Set searching periodic neighbours
-            if ((xperiodic || !oct->m_info[iface1]) &&
-                    (yperiodic || !oct->m_info[iface2]) &&
-                    (zperiodic || !oct->m_info[iface3]) ){
-                isperiodic = true;
-            }
-            else{
+        // If a node is a on boundary, it can have neighbours only if periodic
+        bool isperiodic = false;
+        if (oct->getNodeBound(inode)) {
+            isperiodic = isNodePeriodic(oct, inode);
+            if (!isperiodic) {
                 return;
             }
         }

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -1297,11 +1297,8 @@ namespace bitpit {
         uint32_t  		noctants = getNumOctants();
         uint32_t 		idxtry;
         uint32_t 		size = oct->getLogicalSize();
-        uint8_t 		iface1, iface2;
 
         bool amIghost = oct->getIsGhost();
-
-        bool isperiodic = false;
 
         //Alternative to switch case
         int8_t          cxyz[3] = {0,0,0};
@@ -1320,21 +1317,11 @@ namespace bitpit {
             return;
         }
 
-        // Check if octants edge is a process boundary
-        iface1 = m_treeConstants->edgeFace[iedge][0];
-        iface2 = m_treeConstants->edgeFace[iedge][1];
-
-        // If a face is a boundary, the edge can have neighbours only if this face periodic
-        // Set periodic face flags for the current octant edge
-        bool periodic_face1 = (oct->m_info[iface1] && m_periodic[iface1]);
-        bool periodic_face2 = (oct->m_info[iface2] && m_periodic[iface2]);
-        if (oct->m_info[iface1] || oct->m_info[iface2]){
-            // Set searching periodic neighbours
-            if ((periodic_face1 || !oct->m_info[iface1]) &&
-                    (periodic_face2 || !oct->m_info[iface2]) ){
-                isperiodic = true;
-            }
-            else{
+        // If a edge is a on boundary, it can have neighbours only if periodic
+        bool isperiodic = false;
+        if (oct->getEdgeBound(iedge)) {
+            isperiodic = isEdgePeriodic(oct, iedge);
+            if (!isperiodic) {
                 return;
             }
         }

--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -967,8 +967,6 @@ namespace bitpit {
 
         bool amIghost = oct->getIsGhost();
 
-        bool isperiodic = false;
-
         int8_t 			cxyz[3] = {0,0,0};
         for (int idim=0; idim<m_dim; idim++){
             cxyz[idim] = m_treeConstants->normals[iface][idim];
@@ -983,12 +981,10 @@ namespace bitpit {
         }
 
         // If a face is a boundary, it can have neighbours only if periodic
-        if (oct->m_info[iface]){
-            // Set searching periodic neighbours
-            if (m_periodic[iface]){
-                isperiodic = true;
-            }
-            else{
+        bool isperiodic = false;
+        if (oct->getBound(iface)) {
+            isperiodic = isPeriodic(oct, iface);
+            if (!isperiodic) {
                 return;
             }
         }

--- a/src/PABLO/LocalTree.hpp
+++ b/src/PABLO/LocalTree.hpp
@@ -177,6 +177,9 @@ private:
 	// =================================================================================== //
 	// OTHER GET/SET METHODS
 	// =================================================================================== //
+	bool 		isPeriodic(const Octant* oct, uint8_t iface) const;
+	bool 		isEdgePeriodic(const Octant* oct, uint8_t iedge) const;
+	bool 		isNodePeriodic(const Octant* oct, uint8_t inode) const;
 
 	// =================================================================================== //
 	// OTHER METHODS

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -294,6 +294,36 @@ Octant::getBound(uint8_t face) const{
 	return (m_info[OctantInfo::INFO_BOUNDFACE0 + face]);
 };
 
+/*! Get the bound flag on an octant edge.
+ * \param[in] edge local index of the edge.
+ * \return true if the edge is on a boundary.
+ */
+bool
+Octant::getEdgeBound(uint8_t edge) const{
+	for (int face : sm_treeConstants[m_dim].edgeFace[edge]) {
+		if (getBound(face)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+/*! Get the bound flag on an octant node.
+ * \param[in] node local index of the node.
+ * \return true if the node is on a boundary.
+ */
+bool
+Octant::getNodeBound(uint8_t node) const{
+	for (int face : sm_treeConstants[m_dim].nodeFace[node]) {
+		if (getBound(face)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 /*! Get the bound flag on an octant.
  * \return true if the octant is a boundary octant.
  */

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -287,11 +287,11 @@ Octant::getMarker() const{return m_marker;};
 
 /*! Get the bound flag on an octant face.
  * \param[in] face local index of the face.
- * \return true if the face face is a boundary face.
+ * \return true if the face is a boundary.
  */
 bool
 Octant::getBound(uint8_t face) const{
-	return m_info[face];
+	return (m_info[OctantInfo::INFO_BOUNDFACE0 + face]);
 };
 
 /*! Get the bound flag on an octant.
@@ -299,9 +299,13 @@ Octant::getBound(uint8_t face) const{
  */
 bool
 Octant::getBound() const{
-	return m_info[OctantInfo::INFO_BOUNDFACE0]||m_info[OctantInfo::INFO_BOUNDFACE1]||
-	        m_info[OctantInfo::INFO_BOUNDFACE2]||m_info[OctantInfo::INFO_BOUNDFACE3]||
-	        ((m_dim==3)&&(m_info[OctantInfo::INFO_BOUNDFACE4]||m_info[OctantInfo::INFO_BOUNDFACE5]));
+	for (int i = 0; i < sm_treeConstants[m_dim].nFaces; ++i) {
+		if (getBound(i)) {
+			return true;
+		}
+	}
+
+	return false;
 };
 
 /*! Set the boundary flag to true on an octant face.
@@ -309,7 +313,7 @@ Octant::getBound() const{
  */
 void
 Octant::setBound(uint8_t face) {
-	m_info[face] = true;
+	m_info[INFO_BOUNDFACE0 + face] = true;
 };
 
 /*! Get the pbound flag on an octant face.

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -322,7 +322,7 @@ Octant::setBound(uint8_t face) {
  */
 bool
 Octant::getPbound(uint8_t face) const{
-	return m_info[6+face];
+	return m_info[INFO_PBOUNDFACE0 + face];
 };
 
 /*! Get the pbound flag on an octant face.
@@ -330,9 +330,13 @@ Octant::getPbound(uint8_t face) const{
  */
 bool
 Octant::getPbound() const{
-	return m_info[OctantInfo::INFO_PBOUNDFACE0]||m_info[OctantInfo::INFO_PBOUNDFACE1]||
-	        m_info[OctantInfo::INFO_PBOUNDFACE2]||m_info[OctantInfo::INFO_PBOUNDFACE3]||
-	        ((m_dim==3)&&(m_info[OctantInfo::INFO_PBOUNDFACE4]||m_info[OctantInfo::INFO_PBOUNDFACE5]));
+	for (int i = 0; i < sm_treeConstants[m_dim].nFaces; ++i) {
+		if (getPbound(i)) {
+			return true;
+		}
+	}
+
+	return false;
 };
 
 /*! Get if the octant is new after a refinement.
@@ -399,7 +403,7 @@ Octant::setLevel(uint8_t level){
  */
 void
 Octant::setPbound(uint8_t face, bool flag){
-	m_info[6+face] = flag;
+	m_info[INFO_PBOUNDFACE0 + face] = flag;
 };
 
 /*! Set the ghost specifier of an octant.

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -196,6 +196,8 @@ public:
     uint8_t     getLevel() const;
     int8_t      getMarker() const;
     bool        getBound(uint8_t face) const;
+    bool        getEdgeBound(uint8_t edge) const;
+    bool        getNodeBound(uint8_t node) const;
     bool        getBound() const;
     bool        getPbound(uint8_t face) const;
     bool        getPbound() const;

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -5425,6 +5425,13 @@ namespace bitpit {
                         //					if (abs(pBegin-pEnd) <= 1) ee = maxDelta + 1;
                     }
                 }
+                else if(m_octree.isEdgePeriodic(&octant, e)){
+                    Octant periodicNeighbor = octant.computeEdgePeriodicOctant(e);
+                    int neighProc = findOwner(periodicNeighbor.computeMorton());
+                    if(neighProc != m_rank){
+                        neighProcs.insert(neighProc);
+                    }
+                }
             }
 
             // Virtual Corner Neighbors
@@ -5435,6 +5442,13 @@ namespace bitpit {
                 if(hasVirtualNeighbour){
                     int neighProc = findOwner(virtualNeighbor);
                     if (neighProc != m_rank) {
+                        neighProcs.insert(neighProc);
+                    }
+                }
+                else if(m_octree.isNodePeriodic(&octant, c)){
+                    Octant periodicNeighbor = octant.computeNodePeriodicOctant(c);
+                    int neighProc = findOwner(periodicNeighbor.computeMorton());
+                    if(neighProc != m_rank){
                         neighProcs.insert(neighProc);
                     }
                 }

--- a/test/PABLO/CMakeLists.txt
+++ b/test/PABLO/CMakeLists.txt
@@ -41,6 +41,7 @@ if (ENABLE_MPI)
 	list(APPEND TESTS "test_PABLO_parallel_00002")
 	list(APPEND TESTS "test_PABLO_parallel_00003")
 	list(APPEND TESTS "test_PABLO_parallel_00004")
+	list(APPEND TESTS "test_PABLO_parallel_00005:4")
 endif()
 
 # Test extra libraries

--- a/test/PABLO/test_PABLO_parallel_00005.cpp
+++ b/test/PABLO/test_PABLO_parallel_00005.cpp
@@ -1,0 +1,287 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include <mpi.h>
+
+#include "bitpit_PABLO.hpp"
+
+using namespace bitpit;
+
+/*!
+* Subtest 001
+*
+* Testing adaptive mesh refinement (AMR) with full periodic boundary conditions.
+*/
+int subtest_001()
+{
+    /**<Instantation of a 3D pablo uniform object.*/
+    PabloUniform tree(3);
+
+    /** Set Periodic boundary conditions */
+    tree.setPeriodic(0);
+    tree.setPeriodic(2);
+    tree.setPeriodic(4);
+
+    /**<Refine globally one level and write the octree.*/
+    tree.adaptGlobalRefine();
+
+    /**<Refine globally one level and write the octree.*/
+    tree.adaptGlobalRefine();
+
+    /**<Partition the tree.*/
+    tree.loadBalance();
+
+    /**<Update tree connectivity.*/
+    tree.updateConnectivity();
+
+    /**<Tree infromation.*/
+    uint32_t nOctants = tree.getNumOctants();
+
+    /**<Write the tree.*/
+    std::vector<double> octantIds(nOctants);
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        octantIds[i] = i;
+    }
+    tree.writeTest("pablo_parallel_00005_01", octantIds);
+
+    /**<Extract and print face neighsbors.*/
+    log::cout() << "Number of Octants : " << nOctants << std::endl;
+    log::cout() << "Extracting the four face neighsbours of each Octant " << std::endl;
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k=0; k<tree.getNfaces(); ++k) {
+            tree.findNeighbours(i, k, 1, neighs, isGhost);
+            log::cout() << " - For face " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    /**<Extract and print vertex neighsbors .*/
+    log::cout() << "Extracting the four vertex neighsbours of each Octant " << std::endl;
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k=0; k<tree.getNnodes(); ++k) {
+            tree.findNeighbours(i, k, 3, neighs, isGhost);
+            log::cout() << " - For vertex " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    /**<Extract and print edge neighsbors .*/
+    log::cout() << "Extracting the four edge neighsbours of each Octant " << std::endl;
+    for (uint32_t i=0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k = 0; k<tree.getNedges(); ++k) {
+            tree.findNeighbours(i, k, 2, neighs, isGhost);
+            log::cout() << " - For edge " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    return 0;
+}
+
+/*!
+* Subtest 002
+*
+* Testing adaptive mesh refinement (AMR) with partial periodic boundary
+* conditions.
+*/
+int subtest_002()
+{
+    /**<Instantation of a 3D pablo uniform object.*/
+    PabloUniform tree(3);
+
+    /** Set Periodic boundary conditions */
+    tree.setPeriodic(0);
+    tree.setPeriodic(4);
+
+    /**<Refine globally one level and write the octree.*/
+    tree.adaptGlobalRefine();
+
+    /**<Refine globally one level and write the octree.*/
+    tree.adaptGlobalRefine();
+
+    /**<Partition the tree.*/
+    tree.loadBalance();
+
+    /**<Update tree connectivity.*/
+    tree.updateConnectivity();
+
+    /**<Tree infromation.*/
+    uint32_t nOctants = tree.getNumOctants();
+
+    /**<Write the tree.*/
+    std::vector<double> octantIds(nOctants);
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        octantIds[i] = i;
+    }
+    tree.writeTest("pablo_parallel_00005_02", octantIds);
+
+    /**<Extract and print face neighsbors.*/
+    log::cout() << "Number of Octants : " << nOctants << std::endl;
+    log::cout() << "Extracting the four face neighsbours of each Octant " << std::endl;
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k=0; k<tree.getNfaces(); ++k) {
+            tree.findNeighbours(i, k, 1, neighs, isGhost);
+            log::cout() << " - For face " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    /**<Extract and print vertex neighsbors .*/
+    log::cout() << "Extracting the four vertex neighsbours of each Octant " << std::endl;
+    for (uint32_t i = 0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k=0; k<tree.getNnodes(); ++k) {
+            tree.findNeighbours(i, k, 3, neighs, isGhost);
+            log::cout() << " - For vertex " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    /**<Extract and print edge neighsbors .*/
+    log::cout() << "Extracting the four edge neighsbours of each Octant " << std::endl;
+    for (uint32_t i=0; i < nOctants; ++i) {
+        std::vector<uint32_t> neighs;
+        std::vector<bool> isGhost;
+        log::cout() << ". Octant index : " << i << std::endl;
+        for (uint8_t k = 0; k<tree.getNedges(); ++k) {
+            tree.findNeighbours(i, k, 2, neighs, isGhost);
+            log::cout() << " - For edge " << (int)k << "; " << neighs.size() << " neighsbours: [ ";
+            for (std::size_t n = 0; n < neighs.size(); ++n) {
+                uint32_t neigh = neighs[n];
+                if (!isGhost[n]) {
+                    Octant *neighOctant = tree.getOctant(neigh);
+                    log::cout() << neigh << " " << " : Center = " << tree.getCenter(neighOctant);
+                } else {
+                    Octant *neighOctant = tree.getGhostOctant(neigh);
+                    log::cout() << neigh << " " << " (ghost) : Center = " << tree.getCenter(neighOctant);
+                }
+            }
+            log::cout() << "]" << std::endl;
+        }
+    }
+
+    return 0;
+}
+
+/*!
+* Main program.
+*/
+int main(int argc, char *argv[])
+{
+    MPI_Init(&argc,&argv);
+
+    int nProcs;
+    int rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    // Initialize the logger
+    log::manager().initialize(log::COMBINED, true, nProcs, rank);
+    log::cout().setVisibility(log::GLOBAL);
+
+    // Run the subtests
+    log::cout() << "Testing parallel AMR with periodic boundary conditions." << std::endl;
+
+    int status;
+    try {
+        status = subtest_001();
+        if (status != 0) {
+            return status;
+        }
+
+        status = subtest_002();
+        if (status != 0) {
+            return status;
+        }
+    } catch (const std::exception &exception) {
+        log::cout() << exception.what();
+        exit(1);
+    }
+
+    MPI_Finalize();
+}


### PR DESCRIPTION
Ghost octants there are edge or node neighbours of internal octants were not detected properly on periodic boundaries.

Shuold fix #98.