### PR TITLE
patchkernel: build interface also on ghost borders

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5453,7 +5453,7 @@ void PatchKernel::_updateInterfaces()
 
 					buildCellInterface(&cell, face, neigh, neighFace);
 				}
-			} else if (nFaceInterfaces == 0 && cell.isInterior()) {
+			} else if (nFaceInterfaces == 0) {
 				// Internal borderes need an interface
 				buildCellInterface(&cell, face, nullptr, -1);
 			}


### PR DESCRIPTION
Interfaces are now build also on ghost borders.

(Starts from patchkernel.improve.update branch.)