### PR TITLE
cmake: search header files also in build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ function(addModuleIncludeDirectories MODULE_NAME)
     unset(UPPER_MODULE_NAME)
 
     # Add module directory
-    include_directories("${PROJECT_SOURCE_DIR}/src/${MODULE_NAME}")
+    include_directories("${PROJECT_SOURCE_DIR}/src/${MODULE_NAME}" "${PROJECT_BINARY_DIR}/src/${MODULE_NAME}")
 endfunction()
 
 # Define an experimental feature


### PR DESCRIPTION
This allows the compiler to find the header files generated with the cmake command "configure_file".