### PR TITLE
volcartesian: add functions to get vertex/centroid positions along a direction

### DIFF
--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -46,7 +46,7 @@ namespace bitpit {
 	to reduce its memory footprint, it will also limit the functionalites
 	available when operating in light memory mode. Features that are
 	available in light memory mode are:
-	- evaluation of vertices/cell/interface topological properties;
+	- evaluation of vertex/cell/interface topological properties;
 	- evaluation of cell/interface geometrical properties;
 	- evaluation of cell neighbours.
 	Features that are NOT available in light memory mode are:
@@ -872,7 +872,7 @@ std::array<int, 3> VolCartesian::getInterfaceCountDirection(int direction)
 /*!
 	Creates the interfaces normal to the given direction.
 
-	\param direction the method will creat the interfaces normal to this
+	\param direction the method will create the interfaces normal to this
 	                 direction
 */
 void VolCartesian::addInterfacesDirection(int direction)

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -481,6 +481,17 @@ long VolCartesian::getCellCount() const
 }
 
 /*!
+	Gets the number of cells along the specified direction.
+
+	\param direction is the direction along which cell count is requested
+	\return The number of cells along the specified.
+*/
+int VolCartesian::getCellCount(int direction) const
+{
+	return m_nCells1D[direction];
+}
+
+/*!
 	Gets the element type for the cell with the specified id.
 
 	\param id is the id of the requested cell

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -2024,4 +2024,15 @@ std::array<double, 3> VolCartesian::evalCellCentroid(long id) const
 	return centroid;
 }
 
+/*!
+	Get cell centroids along the specified direction.
+
+	\param direction is the direction along which cell centroids are requested
+	\result Cell centroids along the specified direction.
+*/
+const std::vector<double> & VolCartesian::getCellCentroids(int direction) const
+{
+	return m_cellCenters[direction];
+}
+
 }

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -47,10 +47,9 @@ namespace bitpit {
 	available when operating in light memory mode. Features that are
 	available in light memory mode are:
 	- evaluation of vertex/cell/interface topological properties;
-	- evaluation of cell/interface geometrical properties;
+	- evaluation of vertex/cell/interface geometrical properties;
 	- evaluation of cell neighbours.
 	Features that are NOT available in light memory mode are:
-	- evaluation of vertex geometrical properties;
 	- access to vertex/cell/interface data structures;
 	- access to vertex/cell/interface iterators;
 	- writing of VTK files.
@@ -543,6 +542,19 @@ ElementType VolCartesian::getInterfaceType() const
 	} else {
 		return ElementType::LINE;
 	}
+}
+
+/*!
+	Get vertex coordinates along the specified direction.
+
+	\param direction is the direction along which vertex coordinates are
+	requested
+
+	\result Vertex coordinates along the specified direction.
+*/
+const std::vector<double> & VolCartesian::getVertexCoords(int direction) const
+{
+	return m_vertexCoords[direction];
 }
 
 /*!

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -471,6 +471,17 @@ long VolCartesian::getVertexCount() const
 }
 
 /*!
+	Gets the number of vertices along the specified direction.
+
+	\param direction is the direction along which vertex count is requested
+	\return The number of vertices along the specified.
+*/
+int VolCartesian::getVertexCount(int direction) const
+{
+	return m_nVertices1D[direction];
+}
+
+/*!
 	Gets the number of cells in the patch.
 
 	\return The number of cells in the patch

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -567,6 +567,28 @@ ElementType VolCartesian::getInterfaceType() const
 }
 
 /*!
+	Evaluates the coordinate of the specified vertex.
+
+	\param id is the id of the vertex
+	\result The coordinate of the specified vertex.
+*/
+std::array<double, 3> VolCartesian::evalVertexCoords(long id)
+{
+	std::array<int, 3> ijk = getVertexCartesianId(id);
+
+	std::array<double, 3> coords;
+	coords[Vertex::COORD_X] = m_vertexCoords[Vertex::COORD_X][ijk[0]];
+	coords[Vertex::COORD_Y] = m_vertexCoords[Vertex::COORD_Y][ijk[1]];
+	if (isThreeDimensional()) {
+		coords[Vertex::COORD_Z] = m_vertexCoords[Vertex::COORD_Z][ijk[2]];
+	} else {
+		coords[Vertex::COORD_Z] = 0.0;
+	}
+
+	return coords;
+}
+
+/*!
 	Get vertex coordinates along the specified direction.
 
 	\param direction is the direction along which vertex coordinates are
@@ -806,28 +828,6 @@ void VolCartesian::addVertices()
 			}
 		}
 	}
-}
-
-/*!
-	Evaluates the coordinate of the specified vertex.
-
-	\param id is the id of the vertex
-	\result The coordinate of the specified vertex.
-*/
-std::array<double, 3> VolCartesian::evalVertexCoords(long id)
-{
-	std::array<int, 3> ijk = getVertexCartesianId(id);
-
-	std::array<double, 3> coords;
-	coords[Vertex::COORD_X] = m_vertexCoords[Vertex::COORD_X][ijk[0]];
-	coords[Vertex::COORD_Y] = m_vertexCoords[Vertex::COORD_Y][ijk[1]];
-	if (isThreeDimensional()) {
-		coords[Vertex::COORD_Z] = m_vertexCoords[Vertex::COORD_Z][ijk[2]];
-	} else {
-		coords[Vertex::COORD_Z] = 0.0;
-	}
-
-	return coords;
 }
 
 /*!

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -73,6 +73,7 @@ public:
 	void setDiscretization(const std::array<int, 3> &nCells);
 
 	long getVertexCount() const override;
+	int getVertexCount(int direction) const;
 
 	long getCellCount() const override;
 	int getCellCount(int direction) const;

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -121,10 +121,8 @@ public:
 	std::vector<double> convertToVertexData(const std::vector<double> &cellData) const;
 	std::vector<double> convertToCellData(const std::vector<double> &nodeData) const;
 
-	int linearCellInterpolation(std::array<double,3> &point,
-		std::vector<int> &stencil, std::vector<double> &weights);
-	int linearVertexInterpolation(std::array<double,3> &point,
-		std::vector<int> &stencil, std::vector<double> &weights);
+	int linearCellInterpolation(std::array<double,3> &point, std::vector<int> &stencil, std::vector<double> &weights);
+	int linearVertexInterpolation(std::array<double,3> &point, std::vector<int> &stencil, std::vector<double> &weights);
 
 	long getCellLinearId(int i, int j, int k) const;
 	long getCellLinearId(const std::array<int, 3> &ijk) const;

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -75,6 +75,8 @@ public:
 	long getVertexCount() const override;
 
 	long getCellCount() const override;
+	int getCellCount(int direction) const;
+
 	ElementType getCellType() const;
 	ElementType getCellType(long id) const override;
 

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -85,6 +85,7 @@ public:
 	ElementType getInterfaceType() const;
 	ElementType getInterfaceType(long id) const override;
 
+	std::array<double, 3> evalVertexCoords(long id);
 	const std::vector<double> & getVertexCoords(int direction) const;
 
 	double evalCellVolume(long id) const override;
@@ -186,7 +187,6 @@ private:
 	void setMemoryMode(MemoryMode mode);
 
 	void addVertices();
-	std::array<double, 3> evalVertexCoords(long id);
 
 	void addCells();
 

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -82,6 +82,8 @@ public:
 	ElementType getInterfaceType() const;
 	ElementType getInterfaceType(long id) const override;
 
+	const std::vector<double> & getVertexCoords(int direction) const;
+
 	double evalCellVolume(long id) const override;
 	double evalCellSize(long id) const override;
 	std::array<double, 3> evalCellCentroid(long id) const override;

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -85,6 +85,7 @@ public:
 	double evalCellVolume(long id) const override;
 	double evalCellSize(long id) const override;
 	std::array<double, 3> evalCellCentroid(long id) const override;
+	const std::vector<double> & getCellCentroids(int direction) const;
 
 	double evalInterfaceArea(long id) const override;
 	std::array<double, 3> evalInterfaceNormal(long id) const override;


### PR DESCRIPTION
Add functions to get vertex coordinates and cell centroid positions along a specified direction.