### PR TITLE
levelset: cells that intersect the surface should always be included in the narrowband

### DIFF
--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -501,6 +501,11 @@ void LevelSet::setPropagateSign(bool flag){
 
 /*!
  * Manually set the physical size of the narrow band.
+ * Setting a size equal or less than zero levelset will be evaluated only on
+ * cells that intersect the surface.
+ * After setting the size of the narrowband, the levelset is not automatically
+ * updated. It's up to the caller to make sure the levelset will be properly
+ * updated if the size of the narrowband changes.
  * @param[in] r Size of the narrow band.
  */
 void LevelSet::setSizeNarrowBand(double r){

--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -70,7 +70,7 @@ LevelSet::LevelSet() {
 
     m_objects.clear() ;
 
-    m_useNarrowBand = false ;
+    m_narrowBandSize = levelSetDefaults::NARROWBAND_SIZE;
 
     m_signedDF    = true ;
     m_propagateS  = false;
@@ -334,6 +334,10 @@ int LevelSet::registerObject( std::unique_ptr<LevelSetObject> &&object ) {
         object->setKernel(m_kernel.get());
     }
 
+    if (m_narrowBandSize > 0.) {
+        object->setSizeNarrowBand(m_narrowBandSize);
+    }
+
     int objectId = object->getId();
 
     m_objects[objectId] = std::move(object) ;
@@ -509,9 +513,10 @@ void LevelSet::setPropagateSign(bool flag){
  * @param[in] r Size of the narrow band.
  */
 void LevelSet::setSizeNarrowBand(double r){
-    m_useNarrowBand = true ;
+    m_narrowBandSize = r;
+
     for( auto &object :m_objects){
-        object.second->setSizeNarrowBand(r) ;
+        object.second->setSizeNarrowBand(m_narrowBandSize);
     }
 }
 
@@ -615,7 +620,7 @@ void LevelSet::partition( const std::vector<adaption::Info> &mapper ){
 void LevelSet::dump( std::ostream &stream ){
 
     utils::binary::write(stream, m_order);
-    utils::binary::write(stream, m_useNarrowBand);
+    utils::binary::write(stream, m_narrowBandSize);
     utils::binary::write(stream, m_signedDF);
     utils::binary::write(stream, m_propagateS);
 
@@ -631,7 +636,7 @@ void LevelSet::dump( std::ostream &stream ){
 void LevelSet::restore( std::istream &stream ){
 
     utils::binary::read(stream, m_order);
-    utils::binary::read(stream, m_useNarrowBand);
+    utils::binary::read(stream, m_narrowBandSize);
     utils::binary::read(stream, m_signedDF);
     utils::binary::read(stream, m_propagateS);
 

--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -504,6 +504,16 @@ void LevelSet::setPropagateSign(bool flag){
 }
 
 /*!
+ * Get the physical size of the narrow band.
+ * A size equal or less than zero means that the levelset will be evaluated
+ * only on cells that intersect the surface.
+ * @return the physical size of the narrow band
+ */
+double LevelSet::getSizeNarrowBand() const{
+    return m_narrowBandSize;
+}
+
+/*!
  * Manually set the physical size of the narrow band.
  * Setting a size equal or less than zero levelset will be evaluated only on
  * cells that intersect the surface.

--- a/src/levelset/levelSet.hpp
+++ b/src/levelset/levelSet.hpp
@@ -55,7 +55,7 @@ class LevelSet{
     std::unordered_map<int,std::unique_ptr<LevelSetObject>>     m_objects ;              /**< Objects defining the boundaries */
 
     std::vector<int>        m_order ;               /**< Processing order of objects */
-    bool                    m_useNarrowBand;        /**< Flag if user has set size of narrow band (default=false)  */
+    double                  m_narrowBandSize;       /**< Size of narrowban, negative values means that the narrowband is disabled  */
     bool                    m_signedDF;             /**< Flag for sigend/unsigned distance function (default = true) */
     bool                    m_propagateS;           /**< Flag for sign propagation from narrow band (default = false) */
 

--- a/src/levelset/levelSet.hpp
+++ b/src/levelset/levelSet.hpp
@@ -102,6 +102,7 @@ class LevelSet{
     std::vector<int>        getObjectIds( ) const ;
 
     void                    setSizeNarrowBand(double) ;
+    double                  getSizeNarrowBand() const ;
 
     void                    setSign(bool);
     void                    setPropagateSign(bool) ;

--- a/src/levelset/levelSetCommon.hpp
+++ b/src/levelset/levelSetCommon.hpp
@@ -44,6 +44,7 @@ namespace levelSetDefaults{
     const int                               OBJECT = -1 ;               /**< Default value for closest object  */
     const int                               PART  = -1 ;                /**< Default value for closest patch  */
     const long                              SUPPORT = -1 ;              /**< Default value for closest support element */
+    const double                            NARROWBAND_SIZE = -1 ;      /**< Default value for the narrowband size */
 };
 
 struct LevelSetInfo{

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -55,7 +55,7 @@ LevelSetObject::~LevelSetObject( ){
  * Constructor
  * @param[in] id id assigned to object
  */
-LevelSetObject::LevelSetObject(int id) : m_id(id), m_kernelPtr(nullptr), m_narrowBand(-10.) {
+LevelSetObject::LevelSetObject(int id) : m_id(id), m_kernelPtr(nullptr), m_narrowBand(levelSetDefaults::NARROWBAND_SIZE) {
 }
 
 /*!

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -190,6 +190,11 @@ double LevelSetObject::getSizeNarrowBand()const{
 
 /*!
  * Manually set the size of the narrow band.
+ * Setting a size equal or less than zero levelset will be evaluated only on
+ * cells that intersect the surface.
+ * After setting the size of the narrowband, the levelset is not automatically
+ * updated. It's up to the caller to make sure the levelset will be properly
+ * updated if the size of the narrowband changes.
  * @param[in] r size of the narrow band.
  */
 void LevelSetObject::setSizeNarrowBand(double r){

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -182,6 +182,8 @@ bool LevelSetObject::isInNarrowBand(long i)const{
 
 /*!
  * Get the current size of the narrow band.
+ * A size equal or less than zero means that the levelset will be evaluated
+ * only on cells that intersect the surface.
  * @return size of the current narrow band
  */
 double LevelSetObject::getSizeNarrowBand()const{


### PR DESCRIPTION
Even if the distance of a cell is greater than the narrow band size, if that cell intersects the surface, it should be included in the narrow band.