### PR TITLE
patchkernel: fix identification of halo cells during partitioning

### DIFF
--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -4000,9 +4000,6 @@ std::unordered_map<long, int> PatchKernel::evaluateExchangeVertexOwners() const
 */
 void PatchKernel::updateGhostCellExchangeInfo()
 {
-	// Check if all structures needed are ready
-	assert(getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
-
 	// Clear targets
 	m_ghostCellExchangeTargets.clear();
 
@@ -4061,6 +4058,8 @@ std::vector<long> PatchKernel::_findGhostCellExchangeSources(int rank)
 	std::vector<long> &rankTargets = ghostExchangeTargetsItr->second;
 
 	// The internal neighbours of the ghosts will be sources for the rank
+	assert(getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
+
 	std::vector<long> neighIds;
 	std::unordered_set<long> exchangeSources;
 	exchangeSources.reserve(rankTargets.size());

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2125,10 +2125,10 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                             // Find vertex neighbours
                             neighsList.clear();
                             int vertex = frontierFaceLocalVerticesIds[k];
-                            findCellVertexNeighs(cellId, vertex, &neighsList);
+                            findCellVertexNeighs(frontierCellId, vertex, &neighsList);
 
                             // Check if the vertex is on the inner frontier
-                            bool innerFrontierVertex = (m_partitioningOutgoings.count(cellId) == 0);
+                            bool innerFrontierVertex = (m_partitioningOutgoings.count(frontierCellId) == 0);
                             if (!innerFrontierVertex) {
                                 for (long frontierNeighId : neighsList) {
                                     if (m_partitioningOutgoings.count(frontierNeighId) == 0) {
@@ -2198,7 +2198,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                                 findCellEdgeNeighs(frontierCellId, edge, &neighsList);
 
                                 // Check if the vertex is on the inner frontier
-                                bool innerFrontierEdge = (m_partitioningOutgoings.count(cellId) == 0);
+                                bool innerFrontierEdge = (m_partitioningOutgoings.count(frontierCellId) == 0);
                                 if (!innerFrontierEdge) {
                                     for (long frontierNeighId : neighsList) {
                                         if (m_partitioningOutgoings.count(frontierNeighId) == 0) {

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2079,25 +2079,27 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                         //
 
                         // Check if the face is on the inner frontier
-                        bool innerFrontierFace = false;
-                        if (m_partitioningOutgoings.count(cellId) == 0) {
-                            innerFrontierFace = true;
-                        } else if (m_partitioningOutgoings.count(neighId) == 0) {
-                            innerFrontierFace = true;
-                        }
+                        //
+                        // To be on the inner frontier, the face needs to be
+                        // on a cell not explicitly marked for being sent to
+                        // any rank. We are iterating on the cells explicitly
+                        // marked for being sent to the receiver rank, hence
+                        // the current cell is definitely an outgoing cell.
+                        // Therefore, the face will be on the inner frontier
+                        // if the neighbour is not an outgoing cell.
+                        bool innerFrontierFace = (m_partitioningOutgoings.count(neighId) == 0);
 
                         // Add the neighbours to the list
+                        //
+                        // If the face is on the inner frontier, the outgoing
+                        // cell is the current cell (neighbour cannot be an
+                        // outgoing cell, otherwise the face will not be on
+                        // the inner frontier).
                         frontierNeighs.insert(cellId);
                         frontierNeighs.insert(neighId);
 
                         if (innerFrontierFace) {
-                            if (m_partitioningOutgoings.count(cellId) > 0) {
-                                ghostCellsOverall.insert(cellId);
-                            }
-
-                            if (m_partitioningOutgoings.count(neighId) > 0) {
-                                ghostCellsOverall.insert(neighId);
-                            }
+                            ghostCellsOverall.insert(cellId);
                         }
 
                         //

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2006,19 +2006,23 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
         // The faces that tell apart cells explicitly marked for sending from
         // halo cells are called "frontier faces". We can identify frontier
         // faces looping through the outgoing cells an looking for faces with
-        // a neighbour not explicitly marked for sending.
+        // a neighbour not explicitly marked for being sent to the receiver
+        // rank.
         //
-        // Frame is made up by cells explicitly marked for sending that have
-        // a face, an edge or a vertex on a frontier face.
+        // Frame is made up by cells explicitly marked for being sent to the
+        // receiver rank that have a face, an edge or a vertex on a frontier
+        // face.
         //
-        // Halo is made up by cells not explicitly marked for sending that
-        // have a face, an edge or a vertex on a frontier face.
+        // Halo is made up by cells not explicitly marked for being sent to
+        // the receiver that have a face, an edge or a vertex on a frontier
+        // face.
         //
         // We also identify cells that, at the end of the partitionig, will
-        // be ghosts for the current rank. These are all non-outgonig cells
+        // be ghosts for the current rank. These are all the outgonig cells
         // that have a face/edge/vertex on the inner frontier. A face/edge/
         // vertex is on the inner frontier if its on the frontier and one of
-        // the cells that contain that item is not an outgoing cell.
+        // the cells that contain that item is not an outgoing cell (i.e.,
+        // is not explicitly marked for being sent to any rank).
         //
         // There are no halo nor frame cells if we are serializing a patch.
         //


### PR DESCRIPTION
There was an error in the identification of the ghost cells during partitioning (the problem was found by code inspection, I don't have a test case that shows the problem).