### PR TITLE
IO: coverity error fix for VTK readDataHeader

### DIFF
--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -1199,7 +1199,10 @@ void VTK::readDataHeader( std::fstream &str ){
 
     // Disable all unused fields
     for (const std::string &fieldname : unusedFields) {
-        _findData(fieldname)->disable();
+        VTKField * field = _findData(fieldname);
+        if(field){
+            field->disable();
+        }
     }
 }
 


### PR DESCRIPTION
checking in advance return pointer of _findData method to handle potential null pointer dereferencing.
