### PR TITLE
IO/VTK: silence Coverity error when disabling unnused fields

### DIFF
--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -1199,7 +1199,9 @@ void VTK::readDataHeader( std::fstream &str ){
 
     // Disable all unused fields
     for (const std::string &fieldname : unusedFields) {
-        _findData(fieldname)->disable();
+        VTKField *field = _findData(fieldname);
+        assert(field);
+        field->disable();
     }
 }
 


### PR DESCRIPTION
Assert that a valid unused field was found before disabling it (there should be no reasons for the assert to fail, this check is added to silence a Coverity error).