### PR TITLE
levelset: fix evaluation of segment information for points that lie on the segmentation

### DIFF
--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -184,6 +184,7 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
  */
 int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords, long segmentId, bool signd, double &distance, std::array<double,3> &gradient, std::array<double,3> &normal ) const {
 
+    // Segment information
     SurfUnstructured::CellConstIterator segmentIterator = m_surface->getCellConstIterator(segmentId);
     const Cell &segment = *segmentIterator ;
     ElementType segmentType = segment.getType();
@@ -191,14 +192,15 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
     int nSegmentVertices = segmentVertexIds.size() ;
     const std::vector<std::array<double,3>> &segmentVertexNormals = m_segmentVertexNormals.rawAt(segmentIterator.getRawIndex());
 
+    // Projct the point on the surface and evaluate the point-projeciont vector
     BITPIT_CREATE_WORKSPACE(lambda, double, nSegmentVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
-    std::array<double,3> projectionCoords;
+    std::array<double,3> pointProjectionVector = pointCoords;
     switch (segmentType) {
 
     case ElementType::VERTEX :
     {
         long id = segmentVertexIds[0] ;
-        projectionCoords = m_surface->getVertexCoords(id);
+        pointProjectionVector -= m_surface->getVertexCoords(id);
 
         break;
     }
@@ -207,7 +209,7 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
     {
         long id0 = segmentVertexIds[0] ;
         long id1 = segmentVertexIds[1] ;
-        projectionCoords = CGElem::projectPointSegment( pointCoords, m_surface->getVertexCoords(id0), m_surface->getVertexCoords(id1), lambda);
+        pointProjectionVector -= CGElem::projectPointSegment( pointCoords, m_surface->getVertexCoords(id0), m_surface->getVertexCoords(id1), lambda);
 
         break;
     }
@@ -217,7 +219,7 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
         long id0 = segmentVertexIds[0] ;
         long id1 = segmentVertexIds[1] ;
         long id2 = segmentVertexIds[2] ;
-        projectionCoords = CGElem::projectPointTriangle( pointCoords, m_surface->getVertexCoords(id0), m_surface->getVertexCoords(id1), m_surface->getVertexCoords(id2), lambda );
+        pointProjectionVector -= CGElem::projectPointTriangle( pointCoords, m_surface->getVertexCoords(id0), m_surface->getVertexCoords(id1), m_surface->getVertexCoords(id2), lambda );
 
         break;
     }
@@ -240,18 +242,36 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
         normal.fill(0.);
     }
 
-    gradient = pointCoords-projectionCoords;
-    distance = norm2(gradient); 
-    gradient /= distance;
+    // Evaluate distance from surface
+    distance = norm2(pointProjectionVector);
 
-    // the sign is computed by determining the side of point p
-    // with respect to the normal plane 
-    int s = sign( dotProduct(gradient, normal) );
+    // Check if the point lies on the segmentation
+    //
+    // If the distance is zero, the point and the projection are coincident,
+    // this means that the point lies on the segmentation.
+    double distanceTolerance = m_surface->getTol();
+    bool pointOnSegmentation = utils::DoubleFloatingEqual()(distance, 0., distanceTolerance, distanceTolerance);
 
-    // If the point lies on the normal plane (s = 0), but its distance is
-    // finite the sign must be evaluated considering the curvature of the
-    // surface. This is not implemented yet.
-    if(s==0 && distance>0){
+    // Evaluate levelset gradient
+    if (!pointOnSegmentation) {
+        gradient = pointProjectionVector / distance;
+    } else {
+        if (signd) {
+            gradient = normal;
+        } else {
+            gradient = {{0., 0., 0.}};
+        }
+    }
+
+    // Evaluate levelset sign
+    //
+    // The sign is computed by determining the side of the point with respect
+    // to the normal plane. The sign will be zero if the point lies exaclty
+    // on the segmentation or on the normal plane. In the latter case the sign
+    // must be evaluated taking into account the the curvature of the surface.
+    // However, this is not yet implemented.
+    int s = sign( dotProduct(pointProjectionVector, normal) );
+    if (!pointOnSegmentation && s == 0) {
         distance = levelSetDefaults::VALUE;
         gradient = levelSetDefaults::GRADIENT;
         normal   = levelSetDefaults::GRADIENT;
@@ -259,13 +279,17 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
         return 1;
     }
 
+    // Use sign to update levelset information
+    //
     // If signed distance are computed, the distance value and gradient
     // need to be changed accordingly. If unsigned distance are computed
     // the orientation of the suraface normal is discarded and in order
     // to agnostic with repect the two sides of the surface
-    distance *= (double) ( signd *s + (!signd) *1);
-    gradient *= (double) ( signd *s + (!signd) *1);
-    normal   *= (double) ( signd *1 + (!signd) *s);
+    if (s < 0) {
+        distance *= (double) ( signd *s + (!signd) *1);
+        gradient *= (double) ( signd *s + (!signd) *1);
+        normal   *= (double) ( signd *1 + (!signd) *s);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Due to numerical errors, points that lie on the surface may have a distance slightly grater than zero. Therefore, a small tolerance is now used when checking if a point lies on the segmentation.

Moreover, if a point lies on the segmentation, we assume that it is on the outer side of the surface, this means that the distance is a positive zero and that the gradient is set equal to the surface normal.