### PR TITLE
patchkernel: make the MPI communicator a mandatory argument for the constructors

### DIFF
--- a/examples/POD_example_00002.cpp
+++ b/examples/POD_example_00002.cpp
@@ -88,7 +88,11 @@ void run(int rank, int nProcs)
     if (rank==0) 
         std::cout<< "2. Read snapshot for reconstruction ..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    VolumeKernel* meshr = new VolOctree(MPI_COMM_NULL);
+#else
     VolumeKernel* meshr = new VolOctree();
+#endif
     {
         int dumpBlock = (nProcs > 1) ? rank : -1;
         std::string filename = "./data/test.0.mesh";

--- a/examples/voloctree_adaptation_example_00001.cpp
+++ b/examples/voloctree_adaptation_example_00001.cpp
@@ -105,7 +105,11 @@ int main(int argc, char *argv[])
     std::array<double, 3> minimum = center  - length / 2.;
     double dh = length / 16.;
 
+#if BITPIT_ENABLE_MPI
+    VolOctree mesh(3, minimum, length, dh, MPI_COMM_NULL);
+#else
     VolOctree mesh(3, minimum, length, dh);
+#endif
     mesh.initializeAdjacencies();
     mesh.update();
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -48,31 +48,33 @@ namespace bitpit {
 	PatchKernel is the base class for defining patches.
 */
 
-/*!
-	Creates a serial patch.
-
-	\param expert if true, the expert mode will be enabled
-*/
-PatchKernel::PatchKernel(bool expert)
 #if BITPIT_ENABLE_MPI==1
-    : PatchKernel(MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
 
 	Patches that are filled automatically (e.g. VolOctree) will initialize
 	the cells only on the process identified by the rank zero in the
 	communicator.
 
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
 */
 PatchKernel::PatchKernel(MPI_Comm communicator, std::size_t haloSize, bool expert)
+#else
+/*!
+	Creates a patch.
+
+	\param expert if true, the expert mode will be enabled
+*/
+PatchKernel::PatchKernel(bool expert)
 #endif
 	: m_expert(expert)
 {
@@ -87,33 +89,35 @@ PatchKernel::PatchKernel(MPI_Comm communicator, std::size_t haloSize, bool exper
 	patch::manager().registerPatch(this);
 }
 
-/*!
-	Creates a serial patch.
-
-	\param dimension is the dimension of the patch
-	\param expert if true, the expert mode will be enabled
-*/
-PatchKernel::PatchKernel(int dimension, bool expert)
 #if BITPIT_ENABLE_MPI==1
-    : PatchKernel(dimension, MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
 
 	Patches that are filled automatically (e.g. VolOctree) will initialize
 	the cells only on the process identified by the rank zero in the
 	communicator.
 
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
 */
 PatchKernel::PatchKernel(int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert)
+#else
+/*!
+	Creates a patch.
+
+	\param dimension is the dimension of the patch
+	\param expert if true, the expert mode will be enabled
+*/
+PatchKernel::PatchKernel(int dimension, bool expert)
 #endif
 	: m_expert(expert)
 {
@@ -131,35 +135,37 @@ PatchKernel::PatchKernel(int dimension, MPI_Comm communicator, std::size_t haloS
 	setDimension(dimension);
 }
 
+#if BITPIT_ENABLE_MPI==1
 /*!
-	Creates a serial patch.
+	Creates a patch.
+
+	Patches that are filled automatically (e.g. VolOctree) will initialize
+	the cells only on the process identified by the rank zero in the
+	communicator.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
+	\param id is the id that will be assigned to the patch
+	\param dimension is the dimension of the patch
+	\param communicator is the communicator to be used for exchanging data
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
+	\param expert if true, the expert mode will be enabled
+*/
+PatchKernel::PatchKernel(int id, int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert)
+#else
+/*!
+	Creates a patch.
 
 	\param id is the id that will be assigned to the patch
 	\param dimension is the dimension of the patch
 	\param expert if true, the expert mode will be enabled
 */
 PatchKernel::PatchKernel(int id, int dimension, bool expert)
-#if BITPIT_ENABLE_MPI==1
-    : PatchKernel(id, dimension, MPI_COMM_NULL, 0, expert)
-{
-}
-
-/*!
-	Creates a partitioned patch.
-
-	Patches that are filled automatically (e.g. VolOctree) will initialize
-	the cells only on the process identified by the rank zero in the
-	communicator.
-
-	\param id is the id that will be assigned to the patch
-	\param dimension is the dimension of the patch
-	\param communicator is the communicator to be used for exchanging data
-	among the processes
-	\param haloSize is the size, expressed in number of layers, of the ghost
-	cells halo
-	\param expert if true, the expert mode will be enabled
-*/
-PatchKernel::PatchKernel(int id, int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert)
 #endif
 	: m_expert(expert)
 {

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -720,13 +720,14 @@ protected:
 	AlterationFlagsStorage m_alteredCells;
 	AlterationFlagsStorage m_alteredInterfaces;
 
-	PatchKernel(bool expert);
-	PatchKernel(int dimension, bool expert);
-	PatchKernel(int id, int dimension, bool expert);
 #if BITPIT_ENABLE_MPI==1
 	PatchKernel(MPI_Comm communicator, std::size_t haloSize, bool expert);
 	PatchKernel(int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert);
 	PatchKernel(int id, int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert);
+#else
+	PatchKernel(bool expert);
+	PatchKernel(int dimension, bool expert);
+	PatchKernel(int id, int dimension, bool expert);
 #endif
 	PatchKernel(const PatchKernel &other);
     PatchKernel & operator=(const PatchKernel &other) = delete;

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -57,22 +57,17 @@ const unsigned short SurfaceKernel::SELECT_TRIANGLE = 1;
 const unsigned short SurfaceKernel::SELECT_QUAD     = 2;
 const unsigned short SurfaceKernel::SELECT_ALL      = 3;
 
-/*!
-	Creates a serial patch.
-
-	\param expert if true, the expert mode will be enabled
-*/
-SurfaceKernel::SurfaceKernel(bool expert)
 #if BITPIT_ENABLE_MPI==1
-	: SurfaceKernel(MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -80,32 +75,31 @@ SurfaceKernel::SurfaceKernel(bool expert)
 SurfaceKernel::SurfaceKernel(MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param expert if true, the expert mode will be enabled
+*/
+SurfaceKernel::SurfaceKernel(bool expert)
 	: PatchKernel(expert)
 #endif
 {
 	initialize();
 }
 
-/*!
-	Creates a serial patch.
-
-	\param patch_dim is the dimension of the patch
-	\param space_dim is the dimension of the space
-	\param expert if true, the expert mode will be enabled
-*/
-SurfaceKernel::SurfaceKernel(int patch_dim, int space_dim, bool expert)
 #if BITPIT_ENABLE_MPI==1
-	: SurfaceKernel(patch_dim, space_dim, MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param patch_dim is the dimension of the patch
 	\param space_dim is the dimension of the space
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -113,6 +107,14 @@ SurfaceKernel::SurfaceKernel(int patch_dim, int space_dim, bool expert)
 SurfaceKernel::SurfaceKernel(int patch_dim, int space_dim, MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(patch_dim, communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param patch_dim is the dimension of the patch
+	\param space_dim is the dimension of the space
+	\param expert if true, the expert mode will be enabled
+*/
+SurfaceKernel::SurfaceKernel(int patch_dim, int space_dim, bool expert)
 	: PatchKernel(patch_dim, expert)
 #endif
 {
@@ -122,28 +124,20 @@ SurfaceKernel::SurfaceKernel(int patch_dim, int space_dim, MPI_Comm communicator
     setSpaceDimension(space_dim);
 }
 
-/*!
-	Creates a serial patch.
-
-	\param id is the id that will be assigned to the patch
-	\param patch_dim is the dimension of the patch
-	\param space_dim is the dimension of the space
-	\param expert if true, the expert mode will be enabled
-*/
-SurfaceKernel::SurfaceKernel(int id, int patch_dim, int space_dim, bool expert)
 #if BITPIT_ENABLE_MPI==1
-    : SurfaceKernel(id, patch_dim, space_dim, MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param id is the id that will be assigned to the patch
 	\param patch_dim is the dimension of the patch
 	\param space_dim is the dimension of the space
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -151,6 +145,15 @@ SurfaceKernel::SurfaceKernel(int id, int patch_dim, int space_dim, bool expert)
 SurfaceKernel::SurfaceKernel(int id, int patch_dim, int space_dim, MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(id, patch_dim, communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param id is the id that will be assigned to the patch
+	\param patch_dim is the dimension of the patch
+	\param space_dim is the dimension of the space
+	\param expert if true, the expert mode will be enabled
+*/
+SurfaceKernel::SurfaceKernel(int id, int patch_dim, int space_dim, bool expert)
 	: PatchKernel(id, patch_dim, expert)
 #endif
 {

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -79,15 +79,16 @@ private:
 protected:
         int                     m_spaceDim;
 
-        SurfaceKernel(bool expert);
-        SurfaceKernel(int patch_dim, int space_dim, bool expert);
-        SurfaceKernel(int id, int patch_dim, int space_dim, bool expert);
 #if BITPIT_ENABLE_MPI==1
         SurfaceKernel(MPI_Comm communicator, std::size_t haloSize, bool expert);
         SurfaceKernel(int patch_dim, int space_dim, MPI_Comm communicator, std::size_t haloSize, bool expert);
         SurfaceKernel(int id, int patch_dim, int space_dim, MPI_Comm communicator, std::size_t haloSize, bool expert);
+#else
+        SurfaceKernel(bool expert);
+        SurfaceKernel(int patch_dim, int space_dim, bool expert);
+        SurfaceKernel(int id, int patch_dim, int space_dim, bool expert);
 #endif
-        
+
 };
 
 }

--- a/src/patchkernel/volume_kernel.cpp
+++ b/src/patchkernel/volume_kernel.cpp
@@ -36,22 +36,17 @@ namespace bitpit {
 	VolumeKernel is the base class for defining voulme patches.
 */
 
-/*!
-	Creates a serial patch.
-
-	\param expert if true, the expert mode will be enabled
-*/
-VolumeKernel::VolumeKernel(bool expert)
 #if BITPIT_ENABLE_MPI==1
-	: VolumeKernel(MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -59,29 +54,29 @@ VolumeKernel::VolumeKernel(bool expert)
 VolumeKernel::VolumeKernel(MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param expert if true, the expert mode will be enabled
+*/
+VolumeKernel::VolumeKernel(bool expert)
 	: PatchKernel(expert)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch.
-
-	\param dimension is the dimension of the patch
-	\param expert if true, the expert mode will be enabled
-*/
-VolumeKernel::VolumeKernel(int dimension, bool expert)
 #if BITPIT_ENABLE_MPI==1
-	: VolumeKernel(dimension, MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -89,31 +84,31 @@ VolumeKernel::VolumeKernel(int dimension, bool expert)
 VolumeKernel::VolumeKernel(int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(dimension, communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param dimension is the dimension of the patch
+	\param expert if true, the expert mode will be enabled
+*/
+VolumeKernel::VolumeKernel(int dimension, bool expert)
 	: PatchKernel(dimension, expert)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch.
-
-	\param id is the id that will be assigned to the patch
-	\param dimension is the dimension of the patch
-	\param expert if true, the expert mode will be enabled
-*/
-VolumeKernel::VolumeKernel(int id, int dimension, bool expert)
 #if BITPIT_ENABLE_MPI==1
-	: VolumeKernel(id, dimension, MPI_COMM_NULL, 0, expert)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param id is the id that will be assigned to the patch
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 	\param expert if true, the expert mode will be enabled
@@ -121,6 +116,14 @@ VolumeKernel::VolumeKernel(int id, int dimension, bool expert)
 VolumeKernel::VolumeKernel(int id, int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert)
 	: PatchKernel(id, dimension, communicator, haloSize, expert)
 #else
+/*!
+	Creates a patch.
+
+	\param id is the id that will be assigned to the patch
+	\param dimension is the dimension of the patch
+	\param expert if true, the expert mode will be enabled
+*/
+VolumeKernel::VolumeKernel(int id, int dimension, bool expert)
 	: PatchKernel(id, dimension, expert)
 #endif
 {

--- a/src/patchkernel/volume_kernel.hpp
+++ b/src/patchkernel/volume_kernel.hpp
@@ -45,13 +45,14 @@ public:
         virtual std::array<double,3> evalInterfaceNormal(long id)const = 0;
 
 protected:
-	VolumeKernel(bool expert);
-	VolumeKernel(int dimension, bool expert);
-	VolumeKernel(int id, int dimension, bool expert);
 #if BITPIT_ENABLE_MPI==1
 	VolumeKernel(MPI_Comm communicator, std::size_t haloSize, bool expert);
 	VolumeKernel(int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert);
 	VolumeKernel(int id, int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert);
+#else
+	VolumeKernel(bool expert);
+	VolumeKernel(int dimension, bool expert);
+	VolumeKernel(int id, int dimension, bool expert);
 #endif
 
 };

--- a/src/surfunstructured/surfunstructured.cpp
+++ b/src/surfunstructured/surfunstructured.cpp
@@ -38,17 +38,13 @@ namespace bitpit {
 	SurfUnstructured defines an unstructured surface triangulation.
 */
 
-/*!
-	Creates an uninitialized serial patch.
-*/
-SurfUnstructured::SurfUnstructured()
 #if BITPIT_ENABLE_MPI==1
-	: SurfUnstructured(MPI_COMM_NULL)
-{
-}
-
 /*!
 	Creates an uninitialized partitioned patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param communicator is the communicator to be used for exchanging data
 	among the processes
@@ -56,25 +52,22 @@ SurfUnstructured::SurfUnstructured()
 SurfUnstructured::SurfUnstructured(MPI_Comm communicator)
 	: SurfaceKernel(communicator, 1, true)
 #else
+/*!
+	Creates an uninitialized serial patch.
+*/
+SurfUnstructured::SurfUnstructured()
 	: SurfaceKernel(true)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch.
-
-	\param patch_dim is the dimension of the patch
-	\param space_dim is the dimension of the space
-*/
-SurfUnstructured::SurfUnstructured(int patch_dim, int space_dim)
 #if BITPIT_ENABLE_MPI==1
-	: SurfUnstructured(patch_dim, space_dim, MPI_COMM_NULL)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param patch_dim is the dimension of the patch
 	\param space_dim is the dimension of the space
@@ -84,26 +77,25 @@ SurfUnstructured::SurfUnstructured(int patch_dim, int space_dim)
 SurfUnstructured::SurfUnstructured(int patch_dim, int space_dim, MPI_Comm communicator)
 	: SurfaceKernel(PatchManager::AUTOMATIC_ID, patch_dim, space_dim, communicator, 1, true)
 #else
+/*!
+	Creates a patch.
+
+	\param patch_dim is the dimension of the patch
+	\param space_dim is the dimension of the space
+*/
+SurfUnstructured::SurfUnstructured(int patch_dim, int space_dim)
 	: SurfaceKernel(PatchManager::AUTOMATIC_ID, patch_dim, space_dim, true)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch.
-
-	\param id is the id of the patch
-	\param patch_dim is the dimension of the patch
-	\param space_dim is the dimension of the space
-*/
-SurfUnstructured::SurfUnstructured(int id, int patch_dim, int space_dim)
 #if BITPIT_ENABLE_MPI==1
-	: SurfUnstructured(id, patch_dim, space_dim, MPI_COMM_NULL)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param id is the id of the patch
 	\param patch_dim is the dimension of the patch
@@ -114,25 +106,25 @@ SurfUnstructured::SurfUnstructured(int id, int patch_dim, int space_dim)
 SurfUnstructured::SurfUnstructured(int id, int patch_dim, int space_dim, MPI_Comm communicator)
 	: SurfaceKernel(id, patch_dim, space_dim, communicator, 1, true)
 #else
+/*!
+	Creates a patch.
+
+	\param id is the id of the patch
+	\param patch_dim is the dimension of the patch
+	\param space_dim is the dimension of the space
+*/
+SurfUnstructured::SurfUnstructured(int id, int patch_dim, int space_dim)
 	: SurfaceKernel(id, patch_dim, space_dim, true)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch restoring the patch saved in the specified stream.
-
-	\param stream is the stream to read from
-*/
-SurfUnstructured::SurfUnstructured(std::istream &stream)
 #if BITPIT_ENABLE_MPI==1
-	: SurfUnstructured(stream, MPI_COMM_NULL)
-{
-}
-
 /*!
-	Creates a partitioned patch restoring the patch saved in the specified
-	stream.
+	Creates a patch restoring the patch saved in the specified stream.
+
+	The number of processes in the communicator should be equal to the number
+	of processes of the communicator used when dumping the patch.
 
 	\param stream is the stream to read from
 	\param communicator is the communicator to be used for exchanging data
@@ -141,6 +133,12 @@ SurfUnstructured::SurfUnstructured(std::istream &stream)
 SurfUnstructured::SurfUnstructured(std::istream &stream, MPI_Comm communicator)
 	: SurfaceKernel(communicator, 1, false)
 #else
+/*!
+	Creates a patch restoring the patch saved in the specified stream.
+
+	\param stream is the stream to read from
+*/
+SurfUnstructured::SurfUnstructured(std::istream &stream)
 	: SurfaceKernel(false)
 #endif
 {

--- a/src/surfunstructured/surfunstructured.hpp
+++ b/src/surfunstructured/surfunstructured.hpp
@@ -39,15 +39,16 @@ public:
     using PatchKernel::locatePoint;
 
     // Constructors
-    SurfUnstructured();
-    SurfUnstructured(int patch_dim, int space_dim);
-    SurfUnstructured(int id, int patch_dim, int space_dim);
-    SurfUnstructured(std::istream &stream);
 #if BITPIT_ENABLE_MPI==1
     SurfUnstructured(MPI_Comm communicator);
     SurfUnstructured(int patch_dim, int space_dim, MPI_Comm communicator);
     SurfUnstructured(int id, int patch_dim, int space_dim, MPI_Comm communicator);
     SurfUnstructured(std::istream &stream, MPI_Comm communicator);
+#else
+    SurfUnstructured();
+    SurfUnstructured(int patch_dim, int space_dim);
+    SurfUnstructured(int id, int patch_dim, int space_dim);
+    SurfUnstructured(std::istream &stream);
 #endif
 
     // Clone

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -24,6 +24,9 @@
 
 #include <cmath>
 #include <bitset>
+#if BITPIT_ENABLE_MPI==1
+#	include <mpi.h>
+#endif
 
 #include "bitpit_common.hpp"
 
@@ -61,13 +64,17 @@ namespace bitpit {
 	Creates an uninitialized patch.
 */
 VolCartesian::VolCartesian()
+#if BITPIT_ENABLE_MPI==1
+	: VolumeKernel(MPI_COMM_NULL, 0, false)
+#else
 	: VolumeKernel(false)
+#endif
 {
 	initialize();
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param dimension is the dimension of the patch
 	\param origin is the origin of the domain
@@ -83,7 +90,7 @@ VolCartesian::VolCartesian(int dimension,
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param id is the id of the patch
 	\param dimension is the dimension of the patch
@@ -95,7 +102,11 @@ VolCartesian::VolCartesian(int id, int dimension,
                                const std::array<double, 3> &origin,
                                const std::array<double, 3> &lengths,
                                const std::array<int, 3> &nCells)
+#if BITPIT_ENABLE_MPI==1
+	: VolumeKernel(id, dimension, MPI_COMM_NULL, 0, false)
+#else
 	: VolumeKernel(id, dimension, false)
+#endif
 {
 	initialize();
 
@@ -106,7 +117,7 @@ VolCartesian::VolCartesian(int id, int dimension,
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param dimension is the dimension of the patch
 	\param origin is the origin of the domain
@@ -121,7 +132,7 @@ VolCartesian::VolCartesian(int dimension,
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param id is the id of the patch
 	\param dimension is the dimension of the patch
@@ -132,7 +143,11 @@ VolCartesian::VolCartesian(int dimension,
 VolCartesian::VolCartesian(int id, int dimension,
                                const std::array<double, 3> &origin,
                                double length, int nCells)
+#if BITPIT_ENABLE_MPI==1
+	: VolumeKernel(id, dimension, MPI_COMM_NULL, 0, false)
+#else
 	: VolumeKernel(id, dimension, false)
+#endif
 {
 	initialize();
 
@@ -143,7 +158,7 @@ VolCartesian::VolCartesian(int id, int dimension,
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param dimension is the dimension of the patch
 	\param origin is the origin of the domain
@@ -158,7 +173,7 @@ VolCartesian::VolCartesian(int dimension,
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 
 	\param id is the id of the patch
 	\param dimension is the dimension of the patch
@@ -169,7 +184,11 @@ VolCartesian::VolCartesian(int dimension,
 VolCartesian::VolCartesian(int id, int dimension,
                                const std::array<double, 3> &origin,
                                double length, double dh)
+#if BITPIT_ENABLE_MPI==1
+	: VolumeKernel(id, dimension, MPI_COMM_NULL, 0, false)
+#else
 	: VolumeKernel(id, dimension, false)
+#endif
 {
 	initialize();
 
@@ -186,7 +205,11 @@ VolCartesian::VolCartesian(int id, int dimension,
 	\param stream is the stream to read from
 */
 VolCartesian::VolCartesian(std::istream &stream)
+#if BITPIT_ENABLE_MPI==1
+	: VolumeKernel(MPI_COMM_NULL, 0, false)
+#else
 	: VolumeKernel(false)
+#endif
 {
 	initialize();
 	restore(stream);

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -55,29 +55,30 @@ namespace bitpit {
 	OctantInfoHasher allows to generate a hash for the OctantInfo structure.
 */
 
-/*!
-	Creates an uninitialized serial patch.
-*/
-VolOctree::VolOctree()
 #if BITPIT_ENABLE_MPI==1
-	: VolOctree(MPI_COMM_NULL, 0)
-{
-}
-
 /*!
 	Creates an uninitialized partitioned patch.
 
 	Cells will be initialized the cells only on the process identified by the
 	rank zero in the communicator.
 
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 	\param haloSize is the size, expressed in number of layers, of the ghost
 	cells halo
 */
 VolOctree::VolOctree(MPI_Comm communicator, std::size_t haloSize)
 	: VolumeKernel(communicator, haloSize, false)
 #else
+/*!
+	Creates an uninitialized serial patch.
+*/
+VolOctree::VolOctree()
 	: VolumeKernel(false)
 #endif
 {
@@ -106,8 +107,32 @@ VolOctree::VolOctree(MPI_Comm communicator, std::size_t haloSize)
 	__reset(false);
 }
 
+#if BITPIT_ENABLE_MPI==1
 /*!
-	Creates a serial patch.
+	Creates a patch.
+
+	Cells will be initialized the cells only on the process identified by the
+	rank zero in the communicator.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
+	\param dimension is the dimension of the patch
+	\param origin is the origin of the domain
+	\param length is the length of the domain
+	\param dh is the maximum allowed cell size of the initial refinement
+	\param communicator is the communicator to be used for exchanging data
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
+*/
+VolOctree::VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize)
+	: VolOctree(PatchManager::AUTOMATIC_ID, dimension, origin, length, dh, communicator, haloSize)
+#else
+/*!
+	Creates a patch.
 
 	\param dimension is the dimension of the patch
 	\param origin is the origin of the domain
@@ -115,36 +140,38 @@ VolOctree::VolOctree(MPI_Comm communicator, std::size_t haloSize)
 	\param dh is the maximum allowed cell size of the initial refinement
 */
 VolOctree::VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh)
-#if BITPIT_ENABLE_MPI==1
-	: VolOctree(dimension, origin, length, dh, MPI_COMM_NULL, 0)
-{
-}
-
-/*!
-	Creates a partitioned patch.
-
-	Cells will be initialized the cells only on the process identified by the
-	rank zero in the communicator.
-
-	\param dimension is the dimension of the patch
-	\param origin is the origin of the domain
-	\param length is the length of the domain
-	\param dh is the maximum allowed cell size of the initial refinement
-	\param communicator is the communicator to be used for exchanging data
-	among the processes
-	\param haloSize is the size, expressed in number of layers, of the ghost
-	cells halo
-*/
-VolOctree::VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize)
-	: VolOctree(PatchManager::AUTOMATIC_ID, dimension, origin, length, dh, communicator, haloSize)
-#else
 	: VolOctree(PatchManager::AUTOMATIC_ID, dimension, origin, length, dh)
 #endif
 {
 }
 
+#if BITPIT_ENABLE_MPI==1
 /*!
-	Creates a serial patch.
+	Creates a patch.
+
+	Cells will be initialized the cells only on the process identified by the
+	rank zero in the communicator.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
+	\param id is the id that will be assigned to the patch
+	\param dimension is the dimension of the patch
+	\param origin is the origin of the domain
+	\param length is the length of the domain
+	\param dh is the maximum allowed cell size of the initial refinement
+	\param communicator is the communicator to be used for exchanging data
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
+*/
+VolOctree::VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize)
+	: VolumeKernel(id, dimension, communicator, haloSize, false)
+#else
+/*!
+	Creates a patch.
 
 	\param id is the id that will be assigned to the patch
 	\param dimension is the dimension of the patch
@@ -153,30 +180,6 @@ VolOctree::VolOctree(int dimension, const std::array<double, 3> &origin, double 
 	\param dh is the maximum allowed cell size of the initial refinement
 */
 VolOctree::VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh)
-#if BITPIT_ENABLE_MPI==1
-	: VolOctree(id, dimension, origin, length, dh, MPI_COMM_NULL, 0)
-{
-}
-
-/*!
-	Creates a partitioned patch.
-
-	Cells will be initialized the cells only on the process identified by the
-	rank zero in the communicator.
-
-	\param id is the id that will be assigned to the patch
-	\param dimension is the dimension of the patch
-	\param origin is the origin of the domain
-	\param length is the length of the domain
-	\param dh is the maximum allowed cell size of the initial refinement
-	\param communicator is the communicator to be used for exchanging data
-	among the processes
-	\param haloSize is the size, expressed in number of layers, of the ghost
-	cells halo
-*/
-VolOctree::VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize)
-	: VolumeKernel(id, dimension, communicator, haloSize, false)
-#else
 	: VolumeKernel(id, dimension, false)
 #endif
 {
@@ -225,20 +228,12 @@ VolOctree::VolOctree(int id, int dimension, const std::array<double, 3> &origin,
 	}
 }
 
-/*!
-	Creates a serial patch restoring the patch saved in the specified stream.
-
-	\param stream is the stream to read from
-*/
-VolOctree::VolOctree(std::istream &stream)
 #if BITPIT_ENABLE_MPI==1
-	: VolOctree(stream, MPI_COMM_NULL, 0)
-{
-}
-
 /*!
-	Creates a partitioned patch restoring the patch saved in the specified
-	stream.
+	Creates a patch restoring the patch saved in the specified stream.
+
+	The number of processes in the communicator should be equal to the number
+	of processes of the communicator used when dumping the patch.
 
 	\param stream is the stream to read from
 	\param communicator is the communicator to be used for exchanging data
@@ -249,6 +244,12 @@ VolOctree::VolOctree(std::istream &stream)
 VolOctree::VolOctree(std::istream &stream, MPI_Comm communicator, std::size_t haloSize)
 	: VolumeKernel(communicator, haloSize, false)
 #else
+/*!
+	Creates a patch restoring the patch saved in the specified stream.
+
+	\param stream is the stream to read from
+*/
+VolOctree::VolOctree(std::istream &stream)
 	: VolumeKernel(false)
 #endif
 {
@@ -267,7 +268,7 @@ VolOctree::VolOctree(std::istream &stream, MPI_Comm communicator, std::size_t ha
 }
 
 /*!
-	Creates a serial patch.
+	Creates a patch.
 */
 #if BITPIT_ENABLE_MPI==1
 /*!

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -65,15 +65,16 @@ public:
 		}
 	};
 
-	VolOctree();
-	VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh);
-	VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh);
-	VolOctree(std::istream &stream);
 #if BITPIT_ENABLE_MPI==1
 	VolOctree(MPI_Comm communicator, std::size_t haloSize = 1);
 	VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize = 1);
 	VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh, MPI_Comm communicator, std::size_t haloSize = 1);
 	VolOctree(std::istream &stream, MPI_Comm communicator, std::size_t haloSize = 1);
+#else
+	VolOctree();
+	VolOctree(int dimension, const std::array<double, 3> &origin, double length, double dh);
+	VolOctree(int id, int dimension, const std::array<double, 3> &origin, double length, double dh);
+	VolOctree(std::istream &stream);
 #endif
 	VolOctree(std::unique_ptr<PabloUniform> &&tree, std::unique_ptr<PabloUniform> *adopter = nullptr);
 	VolOctree(int id, std::unique_ptr<PabloUniform> &&tree, std::unique_ptr<PabloUniform> *adopter = nullptr);

--- a/src/volunstructured/volunstructured.cpp
+++ b/src/volunstructured/volunstructured.cpp
@@ -39,78 +39,81 @@ namespace bitpit {
 	a dummy interface, the real implementation will come in a future release.
 */
 
-/*!
-	Creates an uninitialized serial patch.
-*/
-VolUnstructured::VolUnstructured()
 #if BITPIT_ENABLE_MPI==1
-	: VolUnstructured(MPI_COMM_NULL)
-{
-}
-
 /*!
 	Creates an uninitialized partitioned patch.
 
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 */
 VolUnstructured::VolUnstructured(MPI_Comm communicator)
 	: VolumeKernel(communicator, 1, true)
 #else
+/*!
+	Creates an uninitialized serial patch.
+*/
+VolUnstructured::VolUnstructured()
 	: VolumeKernel(true)
 #endif
 {
 }
 
-/*!
-	Creates a serial patch.
-
-	\param dimension is the dimension of the patch
-*/
-VolUnstructured::VolUnstructured(int dimension)
 #if BITPIT_ENABLE_MPI==1
-	: VolUnstructured(dimension, MPI_COMM_NULL)
-{
-}
-
 /*!
-	Creates a partitioned patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
 
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
-	among the processes
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
 */
 VolUnstructured::VolUnstructured(int dimension, MPI_Comm communicator)
 	: VolUnstructured(PatchManager::AUTOMATIC_ID, dimension, communicator)
 #else
+/*!
+	Creates a patch.
+
+	\param dimension is the dimension of the patch
+*/
+VolUnstructured::VolUnstructured(int dimension)
 	: VolUnstructured(PatchManager::AUTOMATIC_ID, dimension)
 #endif
 {
 }
 
+#if BITPIT_ENABLE_MPI==1
 /*!
-	Creates a serial patch.
+	Creates a patch.
+
+	If a null comunicator is provided, a serial patch will be created, this
+	means that each processor will be unaware of the existence of the other
+	processes.
+
+	\param id is the id of the patch
+	\param dimension is the dimension of the patch
+	\param communicator is the communicator to be used for exchanging data
+	among the processes. If a null comunicator is provided, a serial patch
+	will be created
+*/
+VolUnstructured::VolUnstructured(int id, int dimension, MPI_Comm communicator)
+	: VolumeKernel(id, dimension, communicator, 1, true)
+#else
+/*!
+	Creates a patch.
 
 	\param id is the id of the patch
 	\param dimension is the dimension of the patch
 */
 VolUnstructured::VolUnstructured(int id, int dimension)
-#if BITPIT_ENABLE_MPI==1
-	: VolUnstructured(id, dimension, MPI_COMM_NULL)
-{
-}
-
-/*!
-	Creates a partitioned patch.
-
-	\param id is the id of the patch
-	\param dimension is the dimension of the patch
-	\param communicator is the communicator to be used for exchanging data
-	among the processes
-*/
-VolUnstructured::VolUnstructured(int id, int dimension, MPI_Comm communicator)
-	: VolumeKernel(id, dimension, communicator, 1, true)
-#else
 	: VolumeKernel(id, dimension, true)
 #endif
 {

--- a/src/volunstructured/volunstructured.hpp
+++ b/src/volunstructured/volunstructured.hpp
@@ -38,13 +38,14 @@ public:
 	using VolumeKernel::isPointInside;
 	using PatchKernel::locatePoint;
 
-	VolUnstructured();
-	VolUnstructured(int dimension);
-	VolUnstructured(int id, int dimension);
 #if BITPIT_ENABLE_MPI==1
 	VolUnstructured(MPI_Comm communicator);
 	VolUnstructured(int dimension, MPI_Comm communicator);
 	VolUnstructured(int id, int dimension, MPI_Comm communicator);
+#else
+	VolUnstructured();
+	VolUnstructured(int dimension);
+	VolUnstructured(int id, int dimension);
 #endif
 
 	~VolUnstructured();

--- a/test/POD/test_POD_00001.cpp
+++ b/test/POD/test_POD_00001.cpp
@@ -50,7 +50,11 @@ int subtest_001(int rank, int nProcs)
     double dh = length/100;
 
     /**<Create the patch.*/ 
+#if BITPIT_ENABLE_MPI
+    VolumeKernel * mesh = new VolOctree(2, origin, length, dh, MPI_COMM_NULL);
+#else
     VolumeKernel * mesh = new VolOctree(2, origin, length, dh);
+#endif
     mesh->initializeAdjacencies();
     mesh->initializeInterfaces();
     mesh->update();

--- a/test/levelset/test_levelset_00001.cpp
+++ b/test/levelset/test_levelset_00001.cpp
@@ -93,7 +93,11 @@ int subtest_001()
     int dimensions(2) ;
 
     // Input geometry
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(0,1,dimensions,MPI_COMM_NULL) );
+#else
     std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(0,1,dimensions) );
+#endif
 
     bitpit::log::cout() << " - Loading dgf geometry" << std::endl;
 

--- a/test/levelset/test_levelset_00002.cpp
+++ b/test/levelset/test_levelset_00002.cpp
@@ -45,7 +45,11 @@ int subtest_001()
     int dimensions(3) ;
 
     // Input geometry
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, 3, MPI_COMM_NULL) );
+#else
     std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, 3) );
+#endif
 
     bitpit::log::cout()<< " - Loading stl geometry" << std::endl;
 

--- a/test/levelset/test_levelset_00003.cpp
+++ b/test/levelset/test_levelset_00003.cpp
@@ -48,7 +48,11 @@ int subtest_001()
     uint8_t dimensions(2);
 
     // First Input geometry
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<bitpit::SurfUnstructured> STL0( new bitpit::SurfUnstructured (0,1,dimensions,MPI_COMM_NULL) );
+#else
     std::unique_ptr<bitpit::SurfUnstructured> STL0( new bitpit::SurfUnstructured (0,1,dimensions) );
+#endif
 
     bitpit::log::cout()<< " - Loading stl geometry" << std::endl;
 
@@ -65,7 +69,11 @@ int subtest_001()
 
 
     // Second Input geometry
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<bitpit::SurfUnstructured> STL1( new bitpit::SurfUnstructured (1,dimensions,MPI_COMM_NULL) );
+#else
     std::unique_ptr<bitpit::SurfUnstructured> STL1( new bitpit::SurfUnstructured (1,dimensions) );
+#endif
 
     bitpit::log::cout()<< " - Loading stl geometry" << std::endl;
 
@@ -81,7 +89,11 @@ int subtest_001()
     bitpit::log::cout()<< "n. simplex: " << STL1->getCellCount() << std::endl;
 
     // Third Input geometry
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<bitpit::SurfUnstructured> STL2( new bitpit::SurfUnstructured (1,dimensions,MPI_COMM_NULL) );
+#else
     std::unique_ptr<bitpit::SurfUnstructured> STL2( new bitpit::SurfUnstructured (1,dimensions) );
+#endif
 
     bitpit::log::cout()<< " - Loading stl geometry" << std::endl;
 
@@ -121,7 +133,11 @@ int subtest_001()
     };
 
     dh = h / 16. ;
+#if BITPIT_ENABLE_MPI
+    bitpit::VolOctree mesh(dimensions, meshMin, h, dh, MPI_COMM_NULL );
+#else
     bitpit::VolOctree mesh(dimensions, meshMin, h, dh );
+#endif
     mesh.initializeAdjacencies();
     mesh.initializeInterfaces();
     mesh.update() ;

--- a/test/levelset/test_levelset_parallel_00001.cpp
+++ b/test/levelset/test_levelset_parallel_00001.cpp
@@ -48,7 +48,7 @@ int subtest_001(int rank)
     int dimensions(3);
 
     // Input geometry
-    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, dimensions) );
+    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, dimensions, MPI_COMM_NULL) );
 
     bitpit::log::cout() << " - Loading stl geometry" << std::endl;
 

--- a/test/levelset/test_levelset_parallel_00002.cpp
+++ b/test/levelset/test_levelset_parallel_00002.cpp
@@ -50,7 +50,7 @@ int subtest_001(int rank)
     uint8_t dimensions(2);
 
     // First Input geometry
-    std::unique_ptr<bitpit::SurfUnstructured> STL0( new bitpit::SurfUnstructured (1,dimensions) );
+    std::unique_ptr<bitpit::SurfUnstructured> STL0( new bitpit::SurfUnstructured (1,dimensions, MPI_COMM_NULL) );
 
     bitpit::log::cout() << " - Loading stl geometry" << std::endl;
 
@@ -69,7 +69,7 @@ int subtest_001(int rank)
 
 
     // Second Input geometry
-    std::unique_ptr<bitpit::SurfUnstructured> STL1( new bitpit::SurfUnstructured (1,dimensions) );
+    std::unique_ptr<bitpit::SurfUnstructured> STL1( new bitpit::SurfUnstructured (1,dimensions,MPI_COMM_NULL) );
 
     bitpit::log::cout() << " - Loading stl geometry" << std::endl;
 

--- a/test/levelset/test_levelset_parallel_00003.cpp
+++ b/test/levelset/test_levelset_parallel_00003.cpp
@@ -48,7 +48,7 @@ int subtest_001(int rank)
     bitpit::log::cout() << "Testing creating a levelset from an existing tree" << std::endl;
 
     // Input geometry
-    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, dimensions) );
+    std::unique_ptr<bitpit::SurfUnstructured> STL( new bitpit::SurfUnstructured(2, dimensions, MPI_COMM_NULL) );
 
     bitpit::log::cout() << " - Loading stl geometry" << std::endl;
 

--- a/test/surfunstructured/test_surfunstructured_00001.cpp
+++ b/test/surfunstructured/test_surfunstructured_00001.cpp
@@ -231,7 +231,11 @@ int subtest_002(
 // ========================================================================== //
 
 // Local variables
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                        mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                        mesh(2, 3);
+#endif
 Cell                                    cell_17, cell_5, cell_7;
 vector<long>                            cell_list;
 
@@ -270,7 +274,11 @@ vector<long>                            cell_list;
 // ========================================================================== //
 {
     // Scope variables ------------------------------------------------------ //
+#if BITPIT_ENABLE_MPI
+    SurfUnstructured                    envelope(2, 3, MPI_COMM_NULL);
+#else
     SurfUnstructured                    envelope(2, 3);
+#endif
     vector<long>                        ring1, ring1_expected{6,7,8,21,22,23,30,31,32};
 
     // Set envelope attributes ---------------------------------------------- //
@@ -341,7 +349,11 @@ vector<long>                            cell_list;
 // ========================================================================== //
 {
     // Scope variables ------------------------------------------------------ //
+#if BITPIT_ENABLE_MPI
+    SurfUnstructured                    envelope(2, 3, MPI_COMM_NULL);
+#else
     SurfUnstructured                    envelope(2, 3);
+#endif
     vector<long>                        ring1, ring1_expected{6,8,21,22,23,30,31,32};
 
     // Set envelope attributes ---------------------------------------------- //
@@ -421,7 +433,11 @@ vector<long>                            cell_list;
 // ========================================================================== //
 {
     // Scope variables ------------------------------------------------------ //
+#if BITPIT_ENABLE_MPI
+    SurfUnstructured                    envelope(2, 3, MPI_COMM_NULL);
+#else
     SurfUnstructured                    envelope(2, 3);
+#endif
     vector<long>                        ring1, ring1_expected{4,6,7,19,20,21};
     SurfUnstructured::CellIterator      it;
 
@@ -542,7 +558,11 @@ int subtest_001(
 // ========================================================================== //
 
 // Local variables
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
+#endif
 vector<long>                    c_connect{0, 1, 2};
 vector<long>                    g_connect{3, 4, 5};
 Cell                            cell(0, ElementType::TRIANGLE, true);

--- a/test/surfunstructured/test_surfunstructured_00002.cpp
+++ b/test/surfunstructured/test_surfunstructured_00002.cpp
@@ -88,7 +88,11 @@ int subtest_001(
 
 // Local variables
 long                            id;
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
+#endif
 
 // Counters
 // none

--- a/test/surfunstructured/test_surfunstructured_00003.cpp
+++ b/test/surfunstructured/test_surfunstructured_00003.cpp
@@ -87,7 +87,11 @@ string                          in_name_bin = "./data/buddha.stl";
 string                          in_name_ASCII = "./data/cube.stl";
 string                          out_name_bin = "./buddha_copy.stl";
 string                          out_name_ASCII = "./buddha_cube_copy.stl";
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
+#endif
 
 // Counters
 // none
@@ -219,8 +223,11 @@ int subtest_002(
 string                          in_name = "./data/NACA0012.dgf";
 string                          out_name = "./NACA0012_copy.dgf";
 string                          out_name_vtu = "./NACA0012_copy";
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
-
+#endif
 // Counters
 // none
 
@@ -284,7 +291,11 @@ SurfUnstructured                mesh(2, 3);
 // ========================================================================== //
 {
     // Scope variables ------------------------------------------------------ //
+#if BITPIT_ENABLE_MPI
+    SurfUnstructured                    mesh_copy(2, 3, MPI_COMM_NULL);
+#else
     SurfUnstructured                    mesh_copy(2, 3);
+#endif
     
     // Import mesh from stl format ------------------------------------------ //
     log::cout() << "** Re-importing mesh from : \"" << out_name << "\"" << endl;

--- a/test/surfunstructured/test_surfunstructured_00004.cpp
+++ b/test/surfunstructured/test_surfunstructured_00004.cpp
@@ -82,7 +82,11 @@ int subtest_001(
 // ========================================================================== //
 
 // Local variables
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL), edges(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3), edges(2, 3);
+#endif
 
 // Counters
 int                             nV, nE;
@@ -316,7 +320,11 @@ int subtest_002(
 // ========================================================================== //
 
 // Local variables
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
+#endif
 
 // Counters
 int                             nV, nS, nE;

--- a/test/surfunstructured/test_surfunstructured_00005.cpp
+++ b/test/surfunstructured/test_surfunstructured_00005.cpp
@@ -84,7 +84,11 @@ int subtest_001(
 // Local variables
 string                          in_name_ASCII = "./data/ahmed.stl";
 string                          out_name_VTU = "ahmed";
+#if BITPIT_ENABLE_MPI
+SurfUnstructured                mesh(2, 3, MPI_COMM_NULL);
+#else
 SurfUnstructured                mesh(2, 3);
+#endif
 
 // Counters
 // none

--- a/test/surfunstructured/test_surfunstructured_00006.cpp
+++ b/test/surfunstructured/test_surfunstructured_00006.cpp
@@ -51,7 +51,11 @@ int subtest_001(SurfUnstructured *patch_2D, SurfUnstructured *patch_2D_restored)
 
 	const std::string fielname_2D = "./data/cube.stl";
 
+#if BITPIT_ENABLE_MPI
+	patch_2D = new SurfUnstructured(2, 2, MPI_COMM_NULL);
+#else
 	patch_2D = new SurfUnstructured(2, 2);
+#endif
 	patch_2D->importSTL(fielname_2D);
 	patch_2D->getVTK().setName("surfunstructured_patch_2D");
 
@@ -74,7 +78,11 @@ int subtest_001(SurfUnstructured *patch_2D, SurfUnstructured *patch_2D_restored)
 	// Restore the patch
 	log::cout() << "Restoring 2D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+	patch_2D_restored = new SurfUnstructured(MPI_COMM_NULL);
+#else
 	patch_2D_restored = new SurfUnstructured();
+#endif
 	IBinaryArchive binaryReader2D("surfunstructured_patch_2D.dat");
 	patch_2D_restored->restore(binaryReader2D.getStream());
 	binaryReader2D.close();

--- a/test/surfunstructured/test_surfunstructured_00007.cpp
+++ b/test/surfunstructured/test_surfunstructured_00007.cpp
@@ -201,7 +201,11 @@ int subtest_001()
 	long counter;
 
 	// Local variables
+#if BITPIT_ENABLE_MPI
+	SurfUnstructured                        mesh(2, 3, MPI_COMM_NULL);
+#else
 	SurfUnstructured                        mesh(2, 3);
+#endif
 	mesh.setExpert(true);
 
 	// Generate a Dummy Triangulation

--- a/test/surfunstructured/test_surfunstructured_00008.cpp
+++ b/test/surfunstructured/test_surfunstructured_00008.cpp
@@ -59,7 +59,11 @@ int subtest_001(
 ) {
 
     // Create the mesh
+#if BITPIT_ENABLE_MPI
+    SurfUnstructured *mesh = new SurfUnstructured(2, 3, MPI_COMM_NULL);
+#else
     SurfUnstructured *mesh = new SurfUnstructured(2, 3);
+#endif
     mesh->setExpert(true);
 
     std::vector<array<double,3>> verts(5);

--- a/test/surfunstructured/test_surfunstructured_00009.cpp
+++ b/test/surfunstructured/test_surfunstructured_00009.cpp
@@ -48,7 +48,11 @@ int subtest_001()
     log::cout() << std::endl;
     log::cout() << "Importing STL..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    std::unique_ptr<SurfUnstructured> surfaceMesh(new SurfUnstructured (2, 3, MPI_COMM_NULL));
+#else
     std::unique_ptr<SurfUnstructured> surfaceMesh(new SurfUnstructured (2, 3));
+#endif
     surfaceMesh->setExpert(true);
     surfaceMesh->importSTL("./data/buddha.stl");
     surfaceMesh->deleteCoincidentVertices();

--- a/test/voloctree/test_voloctree_00001.cpp
+++ b/test/voloctree/test_voloctree_00001.cpp
@@ -49,7 +49,11 @@ int subtest_001()
 
 	log::cout() << "  >> 2D octree patch" << "\n";
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch_2D = new VolOctree(2, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch_2D = new VolOctree(2, origin, length, dh);
+#endif
 	patch_2D->getVTK().setName("octree_uniform_patch_2D");
 	patch_2D->initializeAdjacencies();
 	patch_2D->initializeInterfaces();
@@ -145,7 +149,11 @@ int subtest_002()
 
 	log::cout() << "  >> 3D octree mesh" << "\n";
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch_3D = new VolOctree(3, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch_3D = new VolOctree(3, origin, length, dh);
+#endif
 	patch_3D->getVTK().setName("octree_uniform_patch_3D");
 	patch_3D->initializeAdjacencies();
 	patch_3D->initializeInterfaces();

--- a/test/voloctree/test_voloctree_00002.cpp
+++ b/test/voloctree/test_voloctree_00002.cpp
@@ -163,7 +163,11 @@ int subtest_001(const std::array<double, 3> &origin, double length, double dh)
 	log::cout() << std::endl;
 	log::cout() << ">> Creating the patch" << std::endl;
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch = new VolOctree(2, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch = new VolOctree(2, origin, length, dh);
+#endif
 	patch->getVTK().setName("octree_adapted_patch_2D");
 	patch->initializeAdjacencies();
 	patch->initializeInterfaces();
@@ -244,7 +248,11 @@ int subtest_002(const std::array<double, 3> &origin, double length, double dh)
 	log::cout() << std::endl;
 	log::cout() << ">> Creating patch" << std::endl;
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch = new VolOctree(3, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch = new VolOctree(3, origin, length, dh);
+#endif
 	patch->getVTK().setName("octree_adapted_patch_3D");
 	patch->initializeAdjacencies();
 	patch->initializeInterfaces();

--- a/test/voloctree/test_voloctree_00003.cpp
+++ b/test/voloctree/test_voloctree_00003.cpp
@@ -71,7 +71,11 @@ int subtest_001()
 
 	log::cout() << "  >> 2D octree patch" << "\n";
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch_2D = new VolOctree(2, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch_2D = new VolOctree(2, origin, length, dh);
+#endif
 	patch_2D->getVTK().setName("octree_uniform_patch_2D");
 	patch_2D->initializeAdjacencies();
 	patch_2D->initializeInterfaces();
@@ -147,7 +151,11 @@ int subtest_002()
 
 	log::cout() << "  >> 3D octree patch" << "\n";
 
+#if BITPIT_ENABLE_MPI
+	VolOctree *patch_3D = new VolOctree(3, origin, length, dh, MPI_COMM_NULL);
+#else
 	VolOctree *patch_3D = new VolOctree(3, origin, length, dh);
+#endif
 	patch_3D->getVTK().setName("octree_uniform_patch_3D");
 	patch_3D->initializeAdjacencies();
 	patch_3D->initializeInterfaces();

--- a/test/voloctree/test_voloctree_00004.cpp
+++ b/test/voloctree/test_voloctree_00004.cpp
@@ -53,7 +53,11 @@ int subtest_001(VolOctree *patch_2D, VolOctree *patch_2D_restored)
     // Create the patch
     log::cout() << "Creating 2D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_2D = new VolOctree(2, origin, length, dh, MPI_COMM_NULL);
+#else
     patch_2D = new VolOctree(2, origin, length, dh);
+#endif
     patch_2D->getVTK().setName("octree_uniform_patch_2D");
     patch_2D->initializeAdjacencies();
     patch_2D->initializeInterfaces();
@@ -200,7 +204,11 @@ int subtest_001(VolOctree *patch_2D, VolOctree *patch_2D_restored)
     // Restore the patch
     log::cout() << "Restoring 2D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_2D_restored = new VolOctree(MPI_COMM_NULL);
+#else
     patch_2D_restored = new VolOctree();
+#endif
     IBinaryArchive binaryReader2D("octree_uniform_patch_2D");
     patch_2D_restored->restore(binaryReader2D.getStream());
 
@@ -289,7 +297,11 @@ int subtest_002(VolOctree *patch_3D, VolOctree *patch_3D_restored)
     // Create the patch
     log::cout() << "Creating 3D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_3D = new VolOctree(3, origin, length, dh, MPI_COMM_NULL);
+#else
     patch_3D = new VolOctree(3, origin, length, dh);
+#endif
     patch_3D->getVTK().setName("octree_uniform_patch_3D");
     patch_3D->initializeAdjacencies();
     patch_3D->initializeInterfaces();
@@ -436,7 +448,11 @@ int subtest_002(VolOctree *patch_3D, VolOctree *patch_3D_restored)
     // Restore the patch
     log::cout() << "Restoring 3D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_3D_restored = new VolOctree(MPI_COMM_NULL);
+#else
     patch_3D_restored = new VolOctree();
+#endif
     IBinaryArchive binaryReader3D("octree_uniform_patch_3D");
     patch_3D_restored->restore(binaryReader3D.getStream());
 

--- a/test/volunstructured/test_volunstructured_00001.cpp
+++ b/test/volunstructured/test_volunstructured_00001.cpp
@@ -46,7 +46,11 @@ int subtest_001()
 
     log::cout() << "\n\n:: 2D unstructured patch ::\n";
 
+#if BITPIT_ENABLE_MPI
+    VolUnstructured *patch_2D = new VolUnstructured(0, 2, MPI_COMM_NULL);
+#else
     VolUnstructured *patch_2D = new VolUnstructured(0, 2);
+#endif
     patch_2D->getVTK().setName("unstructured_uniform_patch_2D");
 
     patch_2D->addVertex({{0.00000000, 0.00000000, 0.00000000}},  1);
@@ -188,7 +192,11 @@ int subtest_002()
 
     log::cout() << "\n\n:: 3D unstructured mesh ::\n";
 
+#if BITPIT_ENABLE_MPI
+    VolUnstructured *patch_3D = new VolUnstructured(0, 3, MPI_COMM_NULL);
+#else
     VolUnstructured *patch_3D = new VolUnstructured(0, 3);
+#endif
     patch_3D->getVTK().setName("unstructured_uniform_patch_3D");
 
     patch_3D->addVertex({{0.00000000, 0.00000000,  0.00000000}},  1);

--- a/test/volunstructured/test_volunstructured_00002.cpp
+++ b/test/volunstructured/test_volunstructured_00002.cpp
@@ -47,7 +47,11 @@ int subtest_001(VolUnstructured *patch_2D, VolUnstructured *patch_2D_restored)
     // Create the patch
     log::cout() << "Creating 2D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_2D = new VolUnstructured(2, MPI_COMM_NULL);
+#else
     patch_2D = new VolUnstructured(2);
+#endif
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
     patch_2D->addVertex({{0.00000000, 0.00000000, 0.00000000}},  1);
@@ -170,7 +174,11 @@ int subtest_001(VolUnstructured *patch_2D, VolUnstructured *patch_2D_restored)
     // Restore the patch
     log::cout() << "Restoring 2D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_2D_restored = new VolUnstructured(MPI_COMM_NULL);
+#else
     patch_2D_restored = new VolUnstructured();
+#endif
     IBinaryArchive binaryReader2D("unstructured_patch_2D");
     patch_2D_restored->restore(binaryReader2D.getStream());
 
@@ -255,7 +263,11 @@ int subtest_002(VolUnstructured *patch_3D, VolUnstructured *patch_3D_restored)
     // Create the patch
     log::cout() << "\n\n:: 3D unstructured mesh ::\n";
 
+#if BITPIT_ENABLE_MPI
+    patch_3D = new VolUnstructured(3, MPI_COMM_NULL);
+#else
     patch_3D = new VolUnstructured(3);
+#endif
     patch_3D->getVTK().setName("unstructured_patch_3D");
 
     patch_3D->addVertex({{0.00000000, 0.00000000,  0.00000000}},  1);
@@ -478,7 +490,11 @@ int subtest_002(VolUnstructured *patch_3D, VolUnstructured *patch_3D_restored)
     // Restore the patch
     log::cout() << "Restoring 3D patch..." << std::endl;
 
+#if BITPIT_ENABLE_MPI
+    patch_3D_restored = new VolUnstructured(MPI_COMM_NULL);
+#else
     patch_3D_restored = new VolUnstructured();
+#endif
     IBinaryArchive binaryReader3D("unstructured_patch_3D");
     patch_3D_restored->restore(binaryReader3D.getStream());
 


### PR DESCRIPTION
Some MPI implementations define the communicator data type as an int. This creates ambiguities in constructor resolution that can
be resolved removing the constructors without the communicator argument.