### PR TITLE
test/surfunstructured: remove unneeded patch partitioning

### DIFF
--- a/test/surfunstructured/test_surfunstructured_parallel_00008.cpp
+++ b/test/surfunstructured/test_surfunstructured_parallel_00008.cpp
@@ -55,9 +55,6 @@ int subtest_001(int rank)
     // Build the interfaces
     mesh.initializeInterfaces();
 
-    // Partition the patch
-    mesh.partition(false);
-
     // Fill the patch
     if (rank == 0) {
         mesh.addVertex({{0., 0., 0.00000000}},  0);


### PR DESCRIPTION
There is no need to partition an empty patch.