### PR TITLE
PABLO: fix identification of last ghost brother in pre-balance algorithm

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -2188,9 +2188,9 @@ namespace bitpit {
                         while(m_octants[idx].buildFather() == father){
                             if (m_octants[idx].getMarker()<0)
                                 nbro++;
-                            idx--;
                             if (idx==0)
                                 break;
+                            idx--;
                         }
                     }
                     last_idx=idx;


### PR DESCRIPTION
Zero-check should be performed before decrementing the index.