### PR TITLE
levelset: use a tolerance for distance comparisons when evaluating surface intersections

### DIFF
--- a/src/common/commonUtils.hpp
+++ b/src/common/commonUtils.hpp
@@ -119,6 +119,24 @@ void extractWithoutReplacement(                                               //
 unsigned long factorial(unsigned long n);
 
 /*!
+    Base class for defining functors to compare double precision floating point
+    numbers.
+*/
+struct DoubleFloatingComparison
+{
+
+public:
+    virtual ~DoubleFloatingComparison() = default;
+
+protected:
+    constexpr static const double DEFAULT_ABS_TOL = 10 * std::numeric_limits<double>::epsilon();
+    constexpr static const double DEFAULT_REL_TOL = 10 * std::numeric_limits<double>::epsilon();
+
+    DoubleFloatingComparison() = default;
+
+};
+
+/*!
     Functor to compare two double precision floating point numbers.
 
     See chapter 4.2.2 equation 35 of "The art of computer programming (vol II)"
@@ -127,7 +145,7 @@ unsigned long factorial(unsigned long n);
 
     Also see: "https://www.boost.org/doc/libs/1_74_0/libs/test/doc/html/boost_test/testing_tools/extended_comparison/floating_point/floating_points_comparison_theory.html"
 */
-struct DoubleFloatingEqual
+struct DoubleFloatingEqual : public DoubleFloatingComparison
 {
     /*!
         Compares the specified double precision floating point numbers
@@ -164,9 +182,168 @@ struct DoubleFloatingEqual
         return (relativeDifference <= relativeTolerance);
     }
 
-private:
-    constexpr static const double DEFAULT_ABS_TOL = 10 * std::numeric_limits<double>::epsilon();
-    constexpr static const double DEFAULT_REL_TOL = 10 * std::numeric_limits<double>::epsilon();
+};
+
+/*!
+    Functor to check if a floating point value compares less than another.
+*/
+struct DoubleFloatingLess : public DoubleFloatingComparison
+{
+    /*!
+        Compares the specified double precision floating point numbers and
+        returns true if the first value compare less than the second.
+
+        This is equaivalent to:
+
+               (x < y) AND (NOT FloatingEqual(x, y))
+
+        where FloatingEqual is the operator that compares two double precision
+        floating point numbers.
+
+        \param x if the first value to compare
+        \param y if the second value to compare
+        \param relativeTolerance is the relative tolerance that will be used to
+        perform the comparison
+        \param absoluteTolerance is the absolute tolerance that will be used to
+        perform the comparison
+        \result Returns true if the first value compare less than the second,
+        false otherwise.
+    */
+    bool operator()(double x, double y, double relativeTolerance = DEFAULT_REL_TOL, double absoluteTolerance = DEFAULT_ABS_TOL) const
+    {
+        if (x > y) {
+            return false;
+        }
+
+        if (DoubleFloatingEqual()(x, y, relativeTolerance, absoluteTolerance)) {
+            return false;
+        }
+
+        return true;
+    }
+
+};
+
+/*!
+    Functor to check if a floating point value compares less or equal than
+    another.
+*/
+struct DoubleFloatingLessEqual : public DoubleFloatingComparison
+{
+    /*!
+        Compares the specified double precision floating point numbers and
+        returns true if the first value compare less or equal than the second.
+
+        This is equaivalent to:
+
+               (x < y) OR (FloatingEqual(x, y))
+
+        where FloatingEqual is the operator that compares two double precision
+        floating point numbers.
+
+        \param x if the first value to compare
+        \param y if the second value to compare
+        \param relativeTolerance is the relative tolerance that will be used to
+        perform the comparison
+        \param absoluteTolerance is the absolute tolerance that will be used to
+        perform the comparison
+        \result Returns true if the first value compare less or equal than the
+        second, false otherwise.
+    */
+    bool operator()(double x, double y, double relativeTolerance = DEFAULT_REL_TOL, double absoluteTolerance = DEFAULT_ABS_TOL) const
+    {
+        if (x < y) {
+            return true;
+        }
+
+        if (DoubleFloatingEqual()(x, y, relativeTolerance, absoluteTolerance)) {
+            return true;
+        }
+
+        return false;
+    }
+
+};
+
+/*!
+    Functor to check if a floating point value compares greater than another.
+*/
+struct DoubleFloatingGreater : public DoubleFloatingComparison
+{
+    /*!
+        Compares the specified double precision floating point numbers and
+        returns true if the first value compare greater than the second.
+
+        This is equaivalent to:
+
+               (x > y) AND (NOT FloatingEqual(x, y))
+
+        where FloatingEqual is the operator that compares two double precision
+        floating point numbers.
+
+        \param x if the first value to compare
+        \param y if the second value to compare
+        \param relativeTolerance is the relative tolerance that will be used to
+        perform the comparison
+        \param absoluteTolerance is the absolute tolerance that will be used to
+        perform the comparison
+        \result Returns true if the first value compare greater than the second,
+        false otherwise.
+    */
+    bool operator()(double x, double y, double relativeTolerance = DEFAULT_REL_TOL, double absoluteTolerance = DEFAULT_ABS_TOL) const
+    {
+        if (x < y) {
+            return false;
+        }
+
+        if (DoubleFloatingEqual()(x, y, relativeTolerance, absoluteTolerance)) {
+            return false;
+        }
+
+        return true;
+    }
+
+};
+
+/*!
+    Functor to check if a floating point value compares greater or equal than
+    another.
+*/
+struct DoubleFloatingGreaterEqual : public DoubleFloatingComparison
+{
+    /*!
+        Compares the specified double precision floating point numbers and
+        returns true if the first value compare greater or equal than the
+        second.
+
+        This is equaivalent to:
+
+               (x > y) OR (FloatingEqual(x, y))
+
+        where FloatingEqual is the operator that compares two double precision
+        floating point numbers.
+
+        \param x if the first value to compare
+        \param y if the second value to compare
+        \param relativeTolerance is the relative tolerance that will be used to
+        perform the comparison
+        \param absoluteTolerance is the absolute tolerance that will be used to
+        perform the comparison
+        \result Returns true if the first value compare greater or equal than
+        the second, false otherwise.
+    */
+    bool operator()(double x, double y, double relativeTolerance = DEFAULT_REL_TOL, double absoluteTolerance = DEFAULT_ABS_TOL) const
+    {
+        if (x > y) {
+            return true;
+        }
+
+        if (DoubleFloatingEqual()(x, y, relativeTolerance, absoluteTolerance)) {
+            return true;
+        }
+
+        return false;
+    }
 
 };
 

--- a/src/levelset/levelSetCartesian.cpp
+++ b/src/levelset/levelSetCartesian.cpp
@@ -103,9 +103,10 @@ double LevelSetCartesian::computeCellCircumcircle( long id ) {
  * @param[in] id is the index of cell
  * @param[in] root is a point on the plane
  * @param[in] normal is the normal of the plane
+ * @param[in] tolerance is the tolerance used for distance comparisons
  * @return true if intersect
  */
-bool LevelSetCartesian::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal ) {
+bool LevelSetCartesian::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal, double tolerance ) {
 
     std::array<double,3> centroid( computeCellCentroid(id) );
     std::array<double,3> spacing( m_cartesian->getSpacing() );
@@ -113,7 +114,7 @@ bool LevelSetCartesian::intersectCellPlane( long id, const std::array<double,3> 
     std::array<double,3> maxPoint( centroid +0.5*spacing );
 
     int dim = m_cartesian->getDimension();
-    return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim);
+    return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim, tolerance);
 }
 
 }

--- a/src/levelset/levelSetCartesian.hpp
+++ b/src/levelset/levelSetCartesian.hpp
@@ -44,7 +44,7 @@ class LevelSetCartesian : public LevelSetKernel{
 
     double                                      computeCellIncircle(long) override;
     double                                      computeCellCircumcircle(long) override;
-    bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &) override;
+    bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) override;
 
 };
 

--- a/src/levelset/levelSetKernel.hpp
+++ b/src/levelset/levelSetKernel.hpp
@@ -64,7 +64,7 @@ class LevelSetKernel{
 
     virtual double                              computeCellIncircle(long);
     virtual double                              computeCellCircumcircle(long);
-    virtual bool                                intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &) =0;
+    virtual bool                                intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) =0;
     bool                                        isPointInCell(long, const std::array<double,3> &);
 
     void                                        clearGeometryCache();

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -234,11 +234,13 @@ LevelSetIntersectionStatus LevelSetObject::intersectSurface(long i, LevelSetInte
 
     double incircle, circumcircle;
 
+    double distanceTolerance = m_kernelPtr->getMesh()->getTol();
+
     switch(mode){
         case LevelSetIntersectionMode::FAST_GUARANTEE_TRUE:
         {
             incircle = m_kernelPtr->computeCellIncircle(i) ;
-            if(std::abs(getLS(i)) <= incircle){
+            if(utils::DoubleFloatingLessEqual()(std::abs(getLS(i)), incircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::TRUE;
             } else {
                 return LevelSetIntersectionStatus::FALSE;
@@ -250,7 +252,7 @@ LevelSetIntersectionStatus LevelSetObject::intersectSurface(long i, LevelSetInte
         case LevelSetIntersectionMode::FAST_GUARANTEE_FALSE:
         {
             circumcircle = m_kernelPtr->computeCellCircumcircle(i) ;
-            if(std::abs(getLS(i)) > circumcircle){
+            if(utils::DoubleFloatingGreater()(std::abs(getLS(i)), circumcircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::FALSE;
             } else {
                 return LevelSetIntersectionStatus::TRUE;
@@ -262,12 +264,12 @@ LevelSetIntersectionStatus LevelSetObject::intersectSurface(long i, LevelSetInte
         case LevelSetIntersectionMode::FAST_FUZZY:
         {
             circumcircle = m_kernelPtr->computeCellCircumcircle(i) ;
-            if(std::abs(getLS(i)) > circumcircle){
+            if(utils::DoubleFloatingGreater()(std::abs(getLS(i)), circumcircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::FALSE;
             }
 
             incircle = m_kernelPtr->computeCellIncircle(i) ;
-            if(std::abs(getLS(i)) <= incircle){
+            if(utils::DoubleFloatingLessEqual()(std::abs(getLS(i)), incircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::TRUE;
             }
 
@@ -279,18 +281,18 @@ LevelSetIntersectionStatus LevelSetObject::intersectSurface(long i, LevelSetInte
         case LevelSetIntersectionMode::ACCURATE:
         {
             circumcircle = m_kernelPtr->computeCellCircumcircle(i) ;
-            if(std::abs(getLS(i)) > circumcircle){
+            if(utils::DoubleFloatingGreater()(std::abs(getLS(i)), circumcircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::FALSE;
             }
 
             incircle = m_kernelPtr->computeCellIncircle(i) ;
-            if(std::abs(getLS(i)) <= incircle){
+            if(utils::DoubleFloatingLessEqual()(std::abs(getLS(i)), incircle, distanceTolerance, distanceTolerance)){
                 return LevelSetIntersectionStatus::TRUE;
             }
 
             std::array<double,3> root = computeProjectionPoint(i);
             std::array<double,3> normal = getGradient(i);
-            if( m_kernelPtr->intersectCellPlane(i,root,normal) ){
+            if( m_kernelPtr->intersectCellPlane(i,root,normal, distanceTolerance) ){
                 return LevelSetIntersectionStatus::TRUE;
             } else {
                 return LevelSetIntersectionStatus::FALSE;

--- a/src/levelset/levelSetOctree.cpp
+++ b/src/levelset/levelSetOctree.cpp
@@ -81,9 +81,10 @@ double LevelSetOctree::computeCellCircumcircle( long id ) {
  * @param[in] id is the index of cell
  * @param[in] root is a point on the plane
  * @param[in] normal is the normal of the plane
+ * @param[in] tolerance is the tolerance used for distance comparisons
  * @return true if intersect
  */
-bool LevelSetOctree::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal ) {
+bool LevelSetOctree::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal, double tolerance ) {
 
     std::array<double,3> centroid( computeCellCentroid(id) );
     double spacing( m_octree->evalCellSize(id) );
@@ -91,6 +92,6 @@ bool LevelSetOctree::intersectCellPlane( long id, const std::array<double,3> &ro
     std::array<double,3> maxPoint( centroid +0.5*spacing );
 
     int dim = m_octree->getDimension();
-    return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim);
+    return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim, tolerance);
 }
 }

--- a/src/levelset/levelSetOctree.hpp
+++ b/src/levelset/levelSetOctree.hpp
@@ -42,7 +42,7 @@ class LevelSetOctree : public LevelSetKernel{
     VolOctree *                                 getOctreeMesh() const;
     double                                      computeCellIncircle(long) override;
     double                                      computeCellCircumcircle(long) override;
-    bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &) override;
+    bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) override;
 };
 
 }


### PR DESCRIPTION
This change allows to get correct results when a cell has a face that lies exactly on an STL border.