### PR TITLE
patchkernel: fixes to vertex ordering

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -6950,7 +6950,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 	} else if (name == "connectivity") {
 		for (const Cell &cell : getVTKCellWriteRange()) {
 			ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
-			const int nCellVertices = cell.getVertexCount();
+			const int nCellVertices = cellVertexIds.size();
 			for (int k = 0; k < nCellVertices; ++k) {
 				long vertexId = cellVertexIds[k];
 				long vtkVertexId = m_vtkVertexMap.at(vertexId);

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -76,8 +76,8 @@ void SkdPatchInfo::buildCache(const PatchKernel::CellConstRange &cellRange)
 
         // Cell info
         const Cell &cell = *itr;
-        int nCellVertices = cell.getVertexCount();
         ConstProxyVector<long> cellConnect = cell.getVertexIds();
+        int nCellVertices = cellConnect.size();
 
         // Bounding box
         std::array<double, 3> &cellBoxMin   = m_cellBoxes->rawAt(rawCellId, 0);

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -265,7 +265,7 @@ double SurfaceKernel::evalCellArea(long id) const
         return (0.5*norm2(crossProduct(d1, d2)));
     }
     else {
-        int                     nvert = cell_->getVertexCount();
+        int                     nvert = cellVertexIds.size();
         double                  coeff = 0.25;
         double                  area = 0.0;
         for (int i = 0; i < nvert; ++i) {
@@ -639,7 +639,7 @@ std::array<double, 3> SurfaceKernel::evalFacetNormal(long id) const
     }
     else {
         std::array<double, 3>           d1, d2;
-        int                             i, nvert = cell_->getVertexCount();
+        int                             i, nvert = cellVertexIds.size();
         double                          coeff = 1.0/double(nvert);
         for (i = 0; i < nvert; ++i) {
             int prevVertex = getOrderedLocalVertexIds(*cell_, (nvert + i - 1) % nvert);

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -1270,10 +1270,16 @@ void SurfaceKernel::flipCellOrientation(long id)
     //  Flipped vertices     4     3     2     1     0
     //
     //  This means we have to invert the connectivity of the cell.
+    long *connectivity = cell.getConnect();
+
+    int connectBegin = 0;
+    if (cell.getType() == ElementType::POLYGON) {
+        ++connectBegin;
+    }
+
     int nCellVertices = cell.getVertexCount();
-    long *cellConnect = cell.getConnect();
     for (int i = 0; i < (int) std::floor(nCellVertices / 2); ++i) {
-        std::swap(cellConnect[i], cellConnect[nCellVertices - i - 1]);
+        std::swap(connectivity[connectBegin + i], connectivity[connectBegin + nCellVertices - i - 1]);
     }
 
     //

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -91,6 +91,8 @@ protected:
         SurfaceKernel(int id, int patch_dim, int space_dim, bool expert);
 #endif
 
+        int getOrderedLocalVertexIds(const Cell &cell, long n) const;
+
 };
 
 }


### PR DESCRIPTION
This fixes two kind of errors in vertex ordering:
 - connectivity of surface polygons was not reversed correctly;
 - vertex of pixel element are not stored in anti-clockwise order but they follow a z-curve order; algorithms of SurfaceKernel that relay on the anti-clockwise ordering need to properly reorder the vertices.

The branch starts from "levelset.normal.evaluation".