### PR TITLE
IO: optimize handling of index trash in the index generator

### DIFF
--- a/src/IO/index_generator.hpp
+++ b/src/IO/index_generator.hpp
@@ -26,7 +26,6 @@
 #define __BITPIT_INDEX_GENERATOR_HPP__
 
 #include <cassert>
-#include <deque>
 #include <iostream>
 #include <limits>
 #include <set>

--- a/src/IO/index_generator.hpp
+++ b/src/IO/index_generator.hpp
@@ -68,7 +68,6 @@ private:
     std::set<id_type> m_trash;
 
     void eraseFromTrash(id_type id);
-    void pushToTrash(id_type id);
 
     int getBinaryArchiveVersion() const;
 


### PR DESCRIPTION
This changes aim to reduce time spent adding ids into the trash.