### PR TITLE
patchkernel: allow to disable automatic cell/vertex/interface auto indexing

### DIFF
--- a/src/patchkernel/element.cpp
+++ b/src/patchkernel/element.cpp
@@ -761,12 +761,12 @@ ConstProxyVector<int> Element::getFaceLocalConnect(int face) const
 
 	case (ElementType::POLYGON):
 	{
-		int connectSize = getConnectSize();
+		int nVertices = getVertexCount();
 
 		int faceConnectSize = getFaceVertexCount(face);
 		std::vector<int> localFaceConnect(faceConnectSize);
 		for (int i = 0; i < faceConnectSize; ++i) {
-			localFaceConnect[i] = 1 + ((face + i) % (connectSize - 1));
+			localFaceConnect[i] = (face + i) % nVertices;
 		}
 
 		return ConstProxyVector<int>(std::move(localFaceConnect));
@@ -1315,20 +1315,6 @@ ConstProxyVector<int> Element::getFaceLocalVertexIds(int face) const
 {
 	switch (m_type) {
 
-	case (ElementType::POLYGON):
-	{
-		ConstProxyVector<int> faceLocalConnect = getFaceLocalConnect(face);
-		std::size_t faceLocalConnectSize = faceLocalConnect.size();
-
-		std::size_t nFaceVertices = faceLocalConnectSize;
-		std::vector<int> faceLocalVertexIds(nFaceVertices);
-		for (std::size_t i = 0; i < nFaceVertices; ++i) {
-			faceLocalVertexIds[i] = faceLocalConnect[i] - 1;
-		}
-
-		return ConstProxyVector<int>(std::move(faceLocalVertexIds));
-	}
-
 	case (ElementType::POLYHEDRON):
 	{
 		ElementType faceType = getFaceType(face);
@@ -1342,7 +1328,7 @@ ConstProxyVector<int> Element::getFaceLocalVertexIds(int face) const
 		std::size_t nFaceVertices = faceLocalConnectSize - 1;
 		std::vector<int> faceLocalVertexIds(nFaceVertices);
 		for (std::size_t i = 0; i < nFaceVertices; ++i) {
-			faceLocalVertexIds[i] = faceLocalConnect[i + 1] - 1;
+			faceLocalVertexIds[i] = faceLocalConnect[i + 1];
 		}
 
 		return ConstProxyVector<int>(std::move(faceLocalVertexIds));

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -382,6 +382,9 @@ public:
 
 	bool empty() const;
 
+	bool isVertexAutoIndexingEnabled() const;
+	void setVertexAutoIndexing(bool enabled);
+
 	virtual long getVertexCount() const;
 	long getInternalVertexCount() const;
 #if BITPIT_ENABLE_MPI==1
@@ -429,6 +432,9 @@ public:
 	VertexConstIterator ghostVertexConstBegin() const;
 	VertexConstIterator ghostVertexConstEnd() const;
 #endif
+
+	bool isCellAutoIndexingEnabled() const;
+	void setCellAutoIndexing(bool enabled);
 
 	virtual long getCellCount() const;
 	long getInternalCellCount() const;
@@ -529,6 +535,9 @@ public:
 	CellConstIterator ghostCellConstEnd() const;
 	BITPIT_DEPRECATED(CellConstIterator ghostConstEnd() const);
 #endif
+
+	bool isInterfaceAutoIndexingEnabled() const;
+	void setInterfaceAutoIndexing(bool enabled);
 
 	virtual long getInterfaceCount() const;
 	PiercedVector<Interface> &getInterfaces();
@@ -868,9 +877,9 @@ protected:
 	int findAdjoinNeighFace(long cellId, int cellFace, long neighId) const;
 
 private:
-	IndexGenerator<long> m_vertexIdGenerator;
-	IndexGenerator<long> m_interfaceIdGenerator;
-	IndexGenerator<long> m_cellIdGenerator;
+	std::unique_ptr<IndexGenerator<long>> m_vertexIdGenerator;
+	std::unique_ptr<IndexGenerator<long>> m_interfaceIdGenerator;
+	std::unique_ptr<IndexGenerator<long>> m_cellIdGenerator;
 
 	long m_nInternalVertices;
 #if BITPIT_ENABLE_MPI==1

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -836,11 +836,16 @@ PatchKernel::CellIterator PatchKernel::addCell(ElementType type, std::unique_ptr
 		return cellEnd();
 	}
 
-	if (id < 0) {
-		id = m_cellIdGenerator.generate();
-	} else {
-		m_cellIdGenerator.setAssigned(id);
+	if (m_cellIdGenerator) {
+		if (id < 0) {
+			id = m_cellIdGenerator->generate();
+		} else {
+			m_cellIdGenerator->setAssigned(id);
+		}
+	} else if (id < 0) {
+		throw std::runtime_error("No valid id has been provided for the cell.");
 	}
+
 
 	if (Cell::getDimension(type) > getDimension()) {
 		return cellEnd();
@@ -2975,8 +2980,12 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
             // patch generate a new id. Otherwise, keep the id of the received
             // vertex.
             if (!isDuplicate) {
-                if (m_vertexIdGenerator.isAssigned(originalVertexId)) {
-                    vertex.setId(Vertex::NULL_ID);
+                if (m_vertexIdGenerator) {
+                    if (m_vertexIdGenerator->isAssigned(originalVertexId)) {
+                        vertex.setId(Vertex::NULL_ID);
+                    }
+                } else if (m_vertices.exists(originalVertexId)) {
+                    throw std::runtime_error("A vertex with the same id of the received vertex already exists.");
                 }
 
                 VertexIterator vertexIterator = addVertex(std::move(vertex));
@@ -3092,8 +3101,13 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
                 // If the id of the received cell is already assigned, let the
                 // patch generate a new id. Otherwise, keep the id of the received
                 // cell.
-                if (m_cellIdGenerator.isAssigned(cellOriginalId)){
-                    cell.setId(Cell::NULL_ID);
+
+                if (m_cellIdGenerator) {
+                    if (m_cellIdGenerator->isAssigned(cellOriginalId)) {
+                        cell.setId(Cell::NULL_ID);
+                    }
+                } else if (m_cells.exists(cellOriginalId)) {
+                    throw std::runtime_error("A cell with the same id of the received cell already exists.");
                 }
 
                 CellIterator cellIterator = addCell(std::move(cell), cellOwner);

--- a/test/volunstructured/test_volunstructured_00001.cpp
+++ b/test/volunstructured/test_volunstructured_00001.cpp
@@ -53,6 +53,8 @@ int subtest_001()
 #endif
     patch_2D->getVTK().setName("unstructured_uniform_patch_2D");
 
+    patch_2D->setVertexAutoIndexing(false);
+
     patch_2D->addVertex({{0.00000000, 0.00000000, 0.00000000}},  1);
     patch_2D->addVertex({{0.00000000, 1.00000000, 0.00000000}},  2);
     patch_2D->addVertex({{1.00000000, 1.00000000, 0.00000000}},  3);
@@ -200,6 +202,8 @@ int subtest_002()
     VolUnstructured *patch_3D = new VolUnstructured(0, 3);
 #endif
     patch_3D->getVTK().setName("unstructured_uniform_patch_3D");
+
+    patch_3D->setVertexAutoIndexing(false);
 
     patch_3D->addVertex({{0.00000000, 0.00000000,  0.00000000}},  1);
     patch_3D->addVertex({{1.00000000, 0.00000000,  0.00000000}},  2);

--- a/test/volunstructured/test_volunstructured_00001.cpp
+++ b/test/volunstructured/test_volunstructured_00001.cpp
@@ -113,7 +113,8 @@ int subtest_001()
 
     double volume_expected_2D = 1.0;
     if (std::abs(volume_2D - volume_expected_2D) > 1e-12) {
-        throw std::runtime_error("Volume of the 2D patch doesn't match the expected value");
+        log::cout() << "Volume of the 2D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -133,7 +134,8 @@ int subtest_001()
 
     double surfaceArea_expected_2D = 4.0;
     if (std::abs(surfaceArea_2D - surfaceArea_expected_2D) > 1e-12) {
-        throw std::runtime_error("Surface area of the 2D patch doesn't match the expected value");
+        log::cout() << "Surface area of the 2D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -359,7 +361,8 @@ int subtest_002()
 
     double volume_expected_3D = 5.0;
     if (std::abs(volume_3D - volume_expected_3D) > 1e-12) {
-        throw std::runtime_error("Volume of the 3D patch doesn't match the expected value");
+        log::cout() << "Volume of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -379,7 +382,8 @@ int subtest_002()
 
     double surfaceArea_expected_3D = 22.0;
     if (std::abs(surfaceArea_3D - surfaceArea_expected_3D) > 1e-12) {
-        throw std::runtime_error("Surface area of the 3D patch doesn't match the expected value");
+        log::cout() << "Surface area of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -419,7 +423,8 @@ int subtest_002()
 
     double divergence_expected_3D = 0.0;
     if (std::abs(divergence_3D - divergence_expected_3D) > 1e-12) {
-        throw std::runtime_error("Divergence of the 3D patch doesn't match the expected value");
+        log::cout() << "Divergence of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;

--- a/test/volunstructured/test_volunstructured_00002.cpp
+++ b/test/volunstructured/test_volunstructured_00002.cpp
@@ -54,6 +54,8 @@ int subtest_001(VolUnstructured *patch_2D, VolUnstructured *patch_2D_restored)
 #endif
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
+    patch_2D->setVertexAutoIndexing(false);
+
     patch_2D->addVertex({{0.00000000, 0.00000000, 0.00000000}},  1);
     patch_2D->addVertex({{0.00000000, 1.00000000, 0.00000000}},  2);
     patch_2D->addVertex({{1.00000000, 1.00000000, 0.00000000}},  3);
@@ -269,6 +271,8 @@ int subtest_002(VolUnstructured *patch_3D, VolUnstructured *patch_3D_restored)
     patch_3D = new VolUnstructured(3);
 #endif
     patch_3D->getVTK().setName("unstructured_patch_3D");
+
+    patch_3D->setVertexAutoIndexing(false);
 
     patch_3D->addVertex({{0.00000000, 0.00000000,  0.00000000}},  1);
     patch_3D->addVertex({{1.00000000, 0.00000000,  0.00000000}},  2);

--- a/test/volunstructured/test_volunstructured_parallel_00001.cpp
+++ b/test/volunstructured/test_volunstructured_parallel_00001.cpp
@@ -49,6 +49,8 @@ int subtest_001(int rank, VolUnstructured *patch_2D, VolUnstructured *patch_2D_r
     patch_2D = new VolUnstructured(2, MPI_COMM_WORLD);
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
+    patch_2D->setVertexAutoIndexing(false);
+
     // Fill the patch
     if (rank == 0) {
         patch_2D->addVertex({{0.00000000, 0.00000000, 0.00000000}},  1);
@@ -323,6 +325,8 @@ int subtest_002(int rank, VolUnstructured *patch_3D, VolUnstructured *patch_3D_r
 
     patch_3D = new VolUnstructured(3, MPI_COMM_WORLD);
     patch_3D->getVTK().setName("unstructured_patch_3D");
+
+    patch_3D->setVertexAutoIndexing(false);
 
     // Fill the patch
     if (rank == 0) {

--- a/test/volunstructured/test_volunstructured_parallel_00003.cpp
+++ b/test/volunstructured/test_volunstructured_parallel_00003.cpp
@@ -42,6 +42,7 @@ int subtest_001(int rank)
     // Create the patch
     std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD));
     patch->getVTK().setName("test_00003_partitioned_mesh");
+    patch->setVertexAutoIndexing(false);
     if (rank == 0) {
         patch->addVertex({{0.00000000, 0.00000000,  0.00000000}},  1);
         patch->addVertex({{1.00000000, 0.00000000,  0.00000000}},  2);


### PR DESCRIPTION
When automatic indexing is disabled, all ids for newly added cells/vertices/interfaces need to be provided manually. 

Interface auto-indexing cannot be disabled if interfaces build strategy is set to "automatic".