### PR TITLE
patchkernel: fix evaluation of face vertex ids for polygons and polyhedra

### DIFF
--- a/src/patchkernel/element.cpp
+++ b/src/patchkernel/element.cpp
@@ -761,12 +761,12 @@ ConstProxyVector<int> Element::getFaceLocalConnect(int face) const
 
 	case (ElementType::POLYGON):
 	{
-		int connectSize = getConnectSize();
+		int nVertices = getVertexCount();
 
 		int faceConnectSize = getFaceVertexCount(face);
 		std::vector<int> localFaceConnect(faceConnectSize);
 		for (int i = 0; i < faceConnectSize; ++i) {
-			localFaceConnect[i] = 1 + ((face + i) % (connectSize - 1));
+			localFaceConnect[i] = (face + i) % nVertices;
 		}
 
 		return ConstProxyVector<int>(std::move(localFaceConnect));
@@ -1315,20 +1315,6 @@ ConstProxyVector<int> Element::getFaceLocalVertexIds(int face) const
 {
 	switch (m_type) {
 
-	case (ElementType::POLYGON):
-	{
-		ConstProxyVector<int> faceLocalConnect = getFaceLocalConnect(face);
-		std::size_t faceLocalConnectSize = faceLocalConnect.size();
-
-		std::size_t nFaceVertices = faceLocalConnectSize;
-		std::vector<int> faceLocalVertexIds(nFaceVertices);
-		for (std::size_t i = 0; i < nFaceVertices; ++i) {
-			faceLocalVertexIds[i] = faceLocalConnect[i] - 1;
-		}
-
-		return ConstProxyVector<int>(std::move(faceLocalVertexIds));
-	}
-
 	case (ElementType::POLYHEDRON):
 	{
 		ElementType faceType = getFaceType(face);
@@ -1342,7 +1328,7 @@ ConstProxyVector<int> Element::getFaceLocalVertexIds(int face) const
 		std::size_t nFaceVertices = faceLocalConnectSize - 1;
 		std::vector<int> faceLocalVertexIds(nFaceVertices);
 		for (std::size_t i = 0; i < nFaceVertices; ++i) {
-			faceLocalVertexIds[i] = faceLocalConnect[i + 1] - 1;
+			faceLocalVertexIds[i] = faceLocalConnect[i + 1];
 		}
 
 		return ConstProxyVector<int>(std::move(faceLocalVertexIds));

--- a/test/volunstructured/test_volunstructured_00001.cpp
+++ b/test/volunstructured/test_volunstructured_00001.cpp
@@ -113,7 +113,8 @@ int subtest_001()
 
     double volume_expected_2D = 1.0;
     if (std::abs(volume_2D - volume_expected_2D) > 1e-12) {
-        throw std::runtime_error("Volume of the 2D patch doesn't match the expected value");
+        log::cout() << "Volume of the 2D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -133,7 +134,8 @@ int subtest_001()
 
     double surfaceArea_expected_2D = 4.0;
     if (std::abs(surfaceArea_2D - surfaceArea_expected_2D) > 1e-12) {
-        throw std::runtime_error("Surface area of the 2D patch doesn't match the expected value");
+        log::cout() << "Surface area of the 2D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -359,7 +361,8 @@ int subtest_002()
 
     double volume_expected_3D = 5.0;
     if (std::abs(volume_3D - volume_expected_3D) > 1e-12) {
-        throw std::runtime_error("Volume of the 3D patch doesn't match the expected value");
+        log::cout() << "Volume of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -379,7 +382,8 @@ int subtest_002()
 
     double surfaceArea_expected_3D = 22.0;
     if (std::abs(surfaceArea_3D - surfaceArea_expected_3D) > 1e-12) {
-        throw std::runtime_error("Surface area of the 3D patch doesn't match the expected value");
+        log::cout() << "Surface area of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;
@@ -419,7 +423,8 @@ int subtest_002()
 
     double divergence_expected_3D = 0.0;
     if (std::abs(divergence_3D - divergence_expected_3D) > 1e-12) {
-        throw std::runtime_error("Divergence of the 3D patch doesn't match the expected value");
+        log::cout() << "Divergence of the 3D patch doesn't match the expected value" << std::endl;
+        return 1;
     }
 
     log::cout() << std::endl;


### PR DESCRIPTION
There was a bug in the evaluation of local face vertex list for  for polygons and polyhedra.