### PR TITLE
levelset: optimizations to levelset computation

### DIFF
--- a/src/PABLO/PabloUniform.cpp
+++ b/src/PABLO/PabloUniform.cpp
@@ -230,7 +230,7 @@ namespace bitpit {
      * \return Size of an octant of input level.
      */
     double
-    PabloUniform::levelToSize(uint8_t & level) {
+    PabloUniform::levelToSize(uint8_t level) {
         double size = ParaTree::levelToSize(level);
         return m_L *size;
     }

--- a/src/PABLO/PabloUniform.hpp
+++ b/src/PABLO/PabloUniform.hpp
@@ -107,7 +107,7 @@ namespace bitpit {
         double		getL() const;
         void		setL(double L);
         void		setOrigin(const darray3 &origin);
-        double		levelToSize( uint8_t& level);
+        double		levelToSize( uint8_t level);
 
         // =================================================================================== //
         // INDEX BASED METHODS																   //

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -4497,7 +4497,7 @@ namespace bitpit {
      * \return Size of an octant of input level.
      */
     double
-    ParaTree::levelToSize(uint8_t & level) {
+    ParaTree::levelToSize(uint8_t level) {
         uint32_t size = uint32_t(1)<<(TreeConstants::MAX_LEVEL-level);
         return m_trans.mapSize(size);
     }

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -545,7 +545,7 @@ namespace bitpit {
         PartitionIntersections evalPartitionIntersections(const uint32_t *schema_A, int rank_A, const uint32_t *schema_B);
 #endif
     public:
-        double		levelToSize(uint8_t & level);
+        double		levelToSize(uint8_t level);
 
         // =================================================================================== //
         // OTHER INTERSECTION BASED METHODS										     		   //

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2811,7 +2811,7 @@ void ReconstructionKernel::display(std::ostream &out, double tolerance) const
 /*!
  * Is the threshold for which a singuler value is considered zero.
  */
-double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-9;
+const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-9;
 
 
 /*!

--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -268,7 +268,7 @@ public:
     void updateKernel(ReconstructionKernel *kernel) const;
 
 private:
-    static double SVD_ZERO_THRESHOLD;
+    static const double SVD_ZERO_THRESHOLD;
 
     uint8_t m_degree;
     uint8_t m_dimensions;

--- a/src/levelset/levelSetCartesian.cpp
+++ b/src/levelset/levelSetCartesian.cpp
@@ -37,13 +37,6 @@ namespace bitpit {
 */
 
 /*!
- * Destructor
- */
-LevelSetCartesian::~LevelSetCartesian( ){
-    m_cartesian = NULL ;
-}
-
-/*!
  * Constructor
  */
 LevelSetCartesian::LevelSetCartesian(VolCartesian &patch ): LevelSetKernel( (static_cast<VolumeKernel*>(&patch)) ){

--- a/src/levelset/levelSetCartesian.cpp
+++ b/src/levelset/levelSetCartesian.cpp
@@ -106,10 +106,9 @@ double LevelSetCartesian::computeCellCircumcircle( long id ) {
  */
 bool LevelSetCartesian::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal, double tolerance ) {
 
-    std::array<double,3> centroid( computeCellCentroid(id) );
-    std::array<double,3> spacing( m_cartesian->getSpacing() );
-    std::array<double,3> minPoint( centroid -0.5*spacing );
-    std::array<double,3> maxPoint( centroid +0.5*spacing );
+    std::array<double,3> minPoint;
+    std::array<double,3> maxPoint;
+    m_cartesian->evalCellBoundingBox(id, &minPoint, &maxPoint);
 
     int dim = m_cartesian->getDimension();
     return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim, tolerance);

--- a/src/levelset/levelSetCartesian.hpp
+++ b/src/levelset/levelSetCartesian.hpp
@@ -37,7 +37,6 @@ class LevelSetCartesian : public LevelSetKernel{
     VolCartesian*                               m_cartesian ;       /**< Pointer to underlying cartesian mesh*/
 
     public:
-    virtual ~LevelSetCartesian();
     LevelSetCartesian( VolCartesian & );
 
     VolCartesian *                              getCartesianMesh() const;

--- a/src/levelset/levelSetCartesian.hpp
+++ b/src/levelset/levelSetCartesian.hpp
@@ -36,15 +36,26 @@ class LevelSetCartesian : public LevelSetKernel{
     private:
     VolCartesian*                               m_cartesian ;       /**< Pointer to underlying cartesian mesh*/
 
+    double                                      m_cellIncircle ;        /**< Cell incircle*/
+    double                                      m_cellCircumcircle ;    /**< Cell circumcircle*/
+
+    void                                        clearCellCirclesCache();
+    void                                        updateCellCirclesCache();
+
     public:
     LevelSetCartesian( VolCartesian & );
 
     VolCartesian *                              getCartesianMesh() const;
 
+    double                                      getCellIncircle();
+    double                                      getCellCircumcircle();
+
     double                                      computeCellIncircle(long) override;
     double                                      computeCellCircumcircle(long) override;
     bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) override;
 
+    void                                        clearGeometryCache() override;
+    void                                        updateGeometryCache(const std::vector<adaption::Info> &) override;
 };
 
 }

--- a/src/levelset/levelSetKernel.cpp
+++ b/src/levelset/levelSetKernel.cpp
@@ -252,17 +252,6 @@ double LevelSetKernel::isCellInsideBoundingBox( long id, const std::array<double
     return CGElem::intersectBoxBox(minPoint, maxPoint, cellMinPoint, cellMaxPoint);
 }
 
-/*!
- * Get the coordinates of vertex
- *
- * @param vertexId the index of the vertex
- * @result its coordinates
- */
-const std::array<double,3> & LevelSetKernel::getVertexCoords(long vertexId)
-{
-    return m_mesh->getVertexCoords(vertexId);
-}
-
 # if BITPIT_ENABLE_MPI
 
 /*!

--- a/src/levelset/levelSetKernel.hpp
+++ b/src/levelset/levelSetKernel.hpp
@@ -73,8 +73,6 @@ class LevelSetKernel{
     const std::array<double,3> &                computeCellCentroid(long);
     double                                      isCellInsideBoundingBox(long, const std::array<double,3> &, const std::array<double,3> & );
 
-    const std::array<double,3> &                getVertexCoords(long);
-
 # if BITPIT_ENABLE_MPI
     void                                        initializeCommunicator();
     MPI_Comm                                    getCommunicator() const;

--- a/src/levelset/levelSetKernel.hpp
+++ b/src/levelset/levelSetKernel.hpp
@@ -67,8 +67,8 @@ class LevelSetKernel{
     virtual bool                                intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) =0;
     bool                                        isPointInCell(long, const std::array<double,3> &);
 
-    void                                        clearGeometryCache();
-    void                                        updateGeometryCache(const std::vector<adaption::Info> &);
+    virtual void                                clearGeometryCache();
+    virtual void                                updateGeometryCache(const std::vector<adaption::Info> &);
 
     const std::array<double,3> &                computeCellCentroid(long);
     double                                      isCellInsideBoundingBox(long, const std::array<double,3> &, const std::array<double,3> & );

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -131,7 +131,7 @@ std::array<double,3> LevelSetObject::computeProjectionPoint(const std::array<dou
  */
 std::array<double,3> LevelSetObject::computeVertexProjectionPoint(long vertexId) const{
 
-    const std::array<double,3> &coords = m_kernelPtr->getVertexCoords(vertexId);
+    const std::array<double,3> &coords = m_kernelPtr->getMesh()->getVertexCoords(vertexId);
     return computeProjectionPoint(coords);
 }
 

--- a/src/levelset/levelSetOctree.cpp
+++ b/src/levelset/levelSetOctree.cpp
@@ -36,13 +36,6 @@ namespace bitpit {
  */
 
 /*!
- * Destructor
- */
-LevelSetOctree::~LevelSetOctree( ){
-    m_octree = NULL ;
-}
-
-/*!
  * Constructor
  */
 LevelSetOctree::LevelSetOctree(VolOctree & patch ): LevelSetKernel( (static_cast<VolumeKernel*>(&patch)) ){

--- a/src/levelset/levelSetOctree.cpp
+++ b/src/levelset/levelSetOctree.cpp
@@ -73,7 +73,7 @@ double LevelSetOctree::computeCellIncircle(long id) {
  */
 double LevelSetOctree::computeCellCircumcircle( long id ) {
     int dim = m_octree->getDimension();
-    return 0.5*sqrt((float) dim)*m_octree->evalCellSize(id);
+    return 0.5*std::sqrt(dim)*m_octree->evalCellSize(id);
 }
 
 /*!

--- a/src/levelset/levelSetOctree.cpp
+++ b/src/levelset/levelSetOctree.cpp
@@ -83,10 +83,9 @@ double LevelSetOctree::computeCellCircumcircle( long id ) {
  */
 bool LevelSetOctree::intersectCellPlane( long id, const std::array<double,3> &root, const std::array<double,3> &normal, double tolerance ) {
 
-    std::array<double,3> centroid( computeCellCentroid(id) );
-    double spacing( m_octree->evalCellSize(id) );
-    std::array<double,3> minPoint( centroid -0.5*spacing );
-    std::array<double,3> maxPoint( centroid +0.5*spacing );
+    std::array<double,3> minPoint;
+    std::array<double,3> maxPoint;
+    m_octree->evalCellBoundingBox(id, &minPoint, &maxPoint);
 
     int dim = m_octree->getDimension();
     return CGElem::intersectPlaneBox( root, normal, minPoint, maxPoint, dim, tolerance);

--- a/src/levelset/levelSetOctree.hpp
+++ b/src/levelset/levelSetOctree.hpp
@@ -36,7 +36,6 @@ class LevelSetOctree : public LevelSetKernel{
     VolOctree*                                  m_octree ;       /**< Pointer to underlying octree mesh*/
 
     public:
-    virtual ~LevelSetOctree();
     LevelSetOctree( VolOctree & );
 
     VolOctree *                                 getOctreeMesh() const;

--- a/src/levelset/levelSetOctree.hpp
+++ b/src/levelset/levelSetOctree.hpp
@@ -35,6 +35,12 @@ class LevelSetOctree : public LevelSetKernel{
     private:
     VolOctree*                                  m_octree ;       /**< Pointer to underlying octree mesh*/
 
+    std::vector<double>                         m_levelToCellIncircle ;        /**< Incircles associated with cell levels*/
+    std::vector<double>                         m_levelToCellCircumcircle ;    /**< Circumcircles associated with cell levels*/
+
+    void                                        clearCellCirclesCache();
+    void                                        updateCellCirclesCache();
+
     public:
     LevelSetOctree( VolOctree & );
 
@@ -42,6 +48,9 @@ class LevelSetOctree : public LevelSetKernel{
     double                                      computeCellIncircle(long) override;
     double                                      computeCellCircumcircle(long) override;
     bool                                        intersectCellPlane(long, const std::array<double,3> &, const std::array<double,3> &, double) override;
+
+    void                                        clearGeometryCache() override;
+    void                                        updateGeometryCache(const std::vector<adaption::Info> &) override;
 };
 
 }

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -781,12 +781,7 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetCartesian *visitee, bo
     const SurfUnstructured &surface = m_segmentation->getSurface();
 
     // Define search radius
-    double searchRadius = m_narrowBand;
-    if (searchRadius < 0.) {
-        for (int d = 0; d < meshDimension; ++d) {
-            searchRadius = std::max(searchRadius, mesh.getSpacing(d));
-        }
-    }
+    double searchRadius = std::max(m_narrowBand, visitee->getCellCircumcircle());
 
     // Define mesh bounding box
     //

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -831,7 +831,6 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetCartesian *visitee, bo
             if (CGElem::intersectBoxPolygon(meshMinPoint, meshMaxPoint, segmentVertexCoords, false, true, true, intersectionPoints, meshDimension)) {
                 for (const std::array<double,3> &intersectionPoint : intersectionPoints){
                     long cellId = mesh.locateClosestCell(intersectionPoint);
-                    assert(cellId >= 0);
                     processList.insert(cellId);
                 }
             }

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -904,8 +904,6 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
 
     VolumeKernel &mesh = *(visitee->getMesh()) ;
 
-    double intersectionFactor = 0.5 * std::sqrt((double) mesh.getDimension());
-
     std::unordered_set<long> intersectedCells;
 
     // Evaluate levelset information
@@ -923,9 +921,9 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
         // If no segment is identified the cell is not processed.
         long cellId = cell.getId();
         std::array<double,3> cellCentroid = visitee->computeCellCentroid(cellId);
+        double cellCircumcircle = visitee->computeCellCircumcircle(cellId);
 
-        double intersectDistance = intersectionFactor * mesh.evalCellSize(cellId);
-        double searchRadius = std::max(m_narrowBand, intersectDistance);
+        double searchRadius = std::max(m_narrowBand, cellCircumcircle);
 
         long segmentId;
         double distance;
@@ -957,7 +955,7 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
         // intersects the surface because only cells that intersect the surface
         // are considered, otherwise we need to check if the absolute distance
         // associated with the cell is lower than the intersection distance.
-        if (m_narrowBand < 0 || intersectDistance < std::abs(lsInfoItr->value)) {
+        if (m_narrowBand < 0 || cellCircumcircle < std::abs(lsInfoItr->value)) {
             intersectedCells.insert(cellId);
         }
 
@@ -1035,8 +1033,6 @@ void LevelSetSegmentation::updateLSInNarrowBand( LevelSetOctree *visitee, const 
 
     VolumeKernel &mesh = *(visitee->getMesh()) ;
 
-    double intersectionFactor = 0.5 * std::sqrt((double) mesh.getDimension());
-
     std::vector<long> cellsOutsideNarrowband;
 
     // Evaluate the levelset of the cells
@@ -1064,8 +1060,7 @@ void LevelSetSegmentation::updateLSInNarrowBand( LevelSetOctree *visitee, const 
             // If no segment is identified the cell is not processed.
             std::array<double,3> centroid = visitee->computeCellCentroid(cellId);
 
-            double intersectDistance = intersectionFactor * mesh.evalCellSize(cellId);
-            double searchRadius = std::max(m_narrowBand, intersectDistance);
+            double searchRadius = std::max(m_narrowBand, visitee->computeCellCircumcircle(cellId));
 
             long segmentId;
             double distance;

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -230,38 +230,63 @@ const std::array<double, 3> & SkdBox::getBoxMax() const
     return m_boxMax;
 }
 
+
 /*!
-* Evaluates the minimum distance among the specified point and the box
+* Evaluates the minimum distance between the specified point and the box.
 *
 * \param point is the point
-* \result The minimum distance among the specified point and the box.
+* \result The minimum distance between the specified point and the box.
 */
 double SkdBox::evalPointMinDistance(const std::array<double, 3> &point) const
 {
-    double distance = 0.;
-    for (int d = 0; d < 3; ++d) {
-        distance += std::pow(std::max({0., m_boxMin[d] - point[d], point[d] - m_boxMax[d]}), 2);
-    }
-    distance = std::sqrt(distance);
-
-    return distance;
+    return std::sqrt(evalPointMinSquareDistance(point));
 }
 
 /*!
-* Evaluates the maximum distance among the specified point and the box
+* Evaluates the maximum distance between the specified point and the box.
 *
 * \param point is the point
-* \result The maximum distance among the specified point and the box
+* \result The maximum distance between the specified point and the box.
 */
 double SkdBox::evalPointMaxDistance(const std::array<double, 3> &point) const
 {
-    double distance = 0.;
-    for (int d = 0; d < 3; ++d) {
-        distance += std::pow(std::max(point[d] - m_boxMin[d], m_boxMax[d] - point[d]), 2);
-    }
-    distance = std::sqrt(distance);
+    return std::sqrt(evalPointMaxSquareDistance(point));
+}
 
-    return distance;
+/*!
+* Evaluates the square of the minimum distance between the specified point and
+* the box.
+*
+* \param point is the point
+* \result The square of the minimum distance between the specified point and
+* the box.
+*/
+double SkdBox::evalPointMinSquareDistance(const std::array<double, 3> &point) const
+{
+    double squareDistance = 0.;
+    for (int d = 0; d < 3; ++d) {
+        squareDistance += std::pow(std::max({0., m_boxMin[d] - point[d], point[d] - m_boxMax[d]}), 2);
+    }
+
+    return squareDistance;
+}
+
+/*!
+* Evaluates the square of the maximum distance between the specified point and
+* the box.
+*
+* \param point is the point
+* \result The square of the maximum distance between the specified point and
+* the box.
+*/
+double SkdBox::evalPointMaxSquareDistance(const std::array<double, 3> &point) const
+{
+    double squareDistance = 0.;
+    for (int d = 0; d < 3; ++d) {
+        squareDistance += std::pow(std::max(point[d] - m_boxMin[d], m_boxMax[d] - point[d]), 2);
+    }
+
+    return squareDistance;
 }
 
 /*!

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -76,6 +76,9 @@ public:
     double evalPointMinDistance(const std::array<double, 3> &point) const;
     double evalPointMaxDistance(const std::array<double, 3> &point) const;
 
+    double evalPointMinSquareDistance(const std::array<double, 3> &point) const;
+    double evalPointMaxSquareDistance(const std::array<double, 3> &point) const;
+
     bool boxContainsPoint(const std::array<double,3> &point, double offset) const;
     bool boxIntersectsSphere(const std::array<double,3> &center, double radius) const;
 

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -332,9 +332,8 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
 }
 
 /*!
-* Given the specified point find the closest cell contained in the
-* three and evaluates the distance between that cell and the given
-* point.
+* Given the specified point find the closest cell contained in the tree and
+* evaluate the distance between that cell and the given point.
 *
 * \param[in] point is the point
 * \param[in] maxDistance all cells whose distance is greater than
@@ -370,8 +369,15 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
 
     // Get a list of candidates nodes
     //
-    // Some temporary data structures are memeber of the class to avoid
+    // Some temporary data structures are member of the class to avoid
     // their reallocation every time the function is called.
+    //
+    // First, we gather all the candidates and then we evaluate the distance
+    // of each candidate. Since distance estimate is constantly updated when
+    // new nodes are processed, the final estimate may be smaller than the
+    // minimum distance of some candidates. Processing the candidates after
+    // scanning all the tree, allows to discard some of them without the need
+    // of evaluating the exact distance.
     m_nodeStack.clear();
     m_candidateIds.clear();
     m_candidateMinDistances.clear();
@@ -395,8 +401,8 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
         double nodeMaxSquareDistance = node.evalPointMaxSquareDistance(point);
         squareDistanceEstimate = std::min(nodeMaxSquareDistance, squareDistanceEstimate);
 
-        // If the node is a leaf add it to the candidates, otherwise
-        // add its children to the stack.
+        // If the node is a leaf add it to the candidates, otherwise add its
+        // children to the stack.
         bool isLeaf = true;
         for (int i = SkdNode::CHILD_BEGIN; i != SkdNode::CHILD_END; ++i) {
             SkdNode::ChildLocation childLocation = static_cast<SkdNode::ChildLocation>(i);
@@ -418,8 +424,8 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
 
     *distance = std::sqrt(squareDistanceEstimate);
     for (std::size_t k = 0; k < m_candidateIds.size(); ++k) {
-        // Do not consider nodes with a minimum distance greater than
-        // the distance estimate
+        // Do not consider nodes with a minimum distance greater than the
+        // distance estimate
         if (utils::DoubleFloatingGreater()(m_candidateMinDistances[k], *distance, tolerance, tolerance)) {
             continue;
         }

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -22,6 +22,8 @@
  *
 \*---------------------------------------------------------------------------*/
 
+#include "bitpit_common.hpp"
+
 #include "surface_skd_tree.hpp"
 
 namespace bitpit {
@@ -352,6 +354,10 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
 long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, double maxDistance,
                                           bool interiorCellsOnly, long *id, double *distance) const
 {
+    // Tolerance for distance evaluations
+    const PatchKernel &patch = getPatch();
+    double tolerance = patch.getTol();
+
     // Initialize the cell id
     *id = Cell::NULL_ID;
 
@@ -379,7 +385,7 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
         // Do not consider nodes with a minimum distance greater than
         // the distance estimate
         double nodeMinDistance = node.evalPointMinDistance(point);
-        if (nodeMinDistance > *distance) {
+        if (utils::DoubleFloatingGreater()(nodeMinDistance, *distance, tolerance, tolerance)) {
             continue;
         }
 
@@ -413,7 +419,7 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
     for (std::size_t k = 0; k < m_candidateIds.size(); ++k) {
         // Do not consider nodes with a minimum distance greater than
         // the distance estimate
-        if (m_candidateMinDistances[k] > *distance) {
+        if (utils::DoubleFloatingGreater()(m_candidateMinDistances[k], *distance, tolerance, tolerance)) {
             continue;
         }
 

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -506,6 +506,14 @@ void VolCartesian::initializeCellVolume()
 }
 
 /*!
+	Initializes cell size
+*/
+void VolCartesian::initializeCellSize()
+{
+	m_cellSize = std::pow(m_cellVolume, 1. / getDimension());
+}
+
+/*!
 	Initializes interface area
 */
 void VolCartesian::initializeInterfaceArea()
@@ -610,6 +618,9 @@ void VolCartesian::setDiscretization(const std::array<int, 3> &nCells)
 
 	// Cell volume
 	initializeCellVolume();
+
+	// Cell size
+	initializeCellSize();
 
 	// Interface area
 	initializeInterfaceArea();
@@ -849,7 +860,7 @@ double VolCartesian::evalCellSize(const std::array<int, 3> &ijk) const
 */
 double VolCartesian::evalCellSize() const
 {
-	return pow(m_cellVolume, 1. / getDimension());
+	return m_cellSize;
 }
 
 /*!
@@ -1920,6 +1931,8 @@ void VolCartesian::scale(const std::array<double, 3> &scaling, const std::array<
 	}
 
 	initializeCellVolume();
+
+	initializeCellSize();
 
 	initializeInterfaceArea();
 

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -864,6 +864,22 @@ double VolCartesian::evalCellSize() const
 }
 
 /*!
+	Evaluates the bounding box of the specified cell.
+
+	\param id is the id of the cell
+	\param[out] minPoint is the minimum point of the bounding box
+	\param[out] maxPoint is the maximum point of the bounding box
+*/
+void VolCartesian::evalCellBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const
+{
+	std::array<double,3> cellCentroid = evalCellCentroid(id);
+	for (int d = 0; d < 3; ++d) {
+		(*minPoint)[d] = cellCentroid[d] - 0.5 * m_cellSpacings[d];
+		(*maxPoint)[d] = cellCentroid[d] + 0.5 * m_cellSpacings[d];
+	}
+}
+
+/*!
 	Evaluates the area of the specified interface.
 
 	\param id is the id of the interface

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -182,6 +182,7 @@ private:
 	long m_nInterfaces;
 
 	double m_cellVolume;
+	double m_cellSize;
 	std::array<double, 3> m_interfaceArea;
 	std::array<std::array<double, 3>, 6> m_normals;
 
@@ -192,6 +193,7 @@ private:
 	void initialize();
 	void initializeInterfaceArea();
 	void initializeCellVolume();
+	void initializeCellSize();
 
 	void setDiscretization(const std::array<int, 3> &nCells);
 

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -93,6 +93,8 @@ public:
 	std::array<double, 3> evalCellCentroid(const std::array<int, 3> &ijk) const;
 	const std::vector<double> & getCellCentroids(int direction) const;
 
+	void evalCellBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const override;
+
 	double evalInterfaceArea(long id) const override;
 	std::array<double, 3> evalInterfaceNormal(long id) const override;
 


### PR DESCRIPTION
The main optimizations are:
 - usage square distance for skd-tree comparisons;
 - cache evaluation of cell incircles/circumcircles
