### PR TITLE
cmake: fix identification of bitpit include directory in CMake configuration file

### DIFF
--- a/cmake/BITPITConfig.cmake.in
+++ b/cmake/BITPITConfig.cmake.in
@@ -45,7 +45,7 @@ if(BITPIT_RECONFIGURE)
     unset(BITPIT_INCLUDE_DIR CACHE)
 endif()
 
-find_path(BITPIT_INCLUDE_DIR "@PROJECT_NAME@_version.hpp"
+find_path(BITPIT_INCLUDE_DIR "@PROJECT_NAME@.hpp"
           HINTS "${BITPIT_INSTALL_PREFIX}/include/bitpit")
 
 mark_as_advanced(BITPIT_INCLUDE_DIR)


### PR DESCRIPTION
The file "bitpit_version.hpp" does not exist anymore, let's use "bitpit.hpp" to identify the include directory.