### PR TITLE
surfunstructured: fix duplicate vertex check

### DIFF
--- a/src/patchkernel/vertex.hpp
+++ b/src/patchkernel/vertex.hpp
@@ -66,17 +66,22 @@ public:
 
 		bool operator()(const Vertex &vertex_1, const Vertex &vertex_2) const
 		{
-			return operator()(&vertex_1, &vertex_2);
+			return operator()(vertex_1.getCoords(), vertex_2.getCoords());
 		}
 
 		bool operator()(const Vertex *vertex_1, const Vertex *vertex_2) const
 		{
+			return operator()(vertex_1->getCoords(), vertex_2->getCoords());
+		}
+
+		bool operator()(const std::array<double, 3> &coords_1, const std::array<double, 3> &coords_2) const
+		{
 			for (int d = 0; d < 3; ++d) {
-				if (utils::DoubleFloatingEqual()((*vertex_1)[d], (*vertex_2)[d], m_tolerance)) {
+				if (utils::DoubleFloatingEqual()(coords_1[d], coords_2[d], m_tolerance)) {
 					continue;
 				}
 
-				return (*vertex_1)[d] < (*vertex_2)[d];
+				return coords_1[d] < coords_2[d];
 			}
 
 			return false;


### PR DESCRIPTION
The algorithm to join the facets was storing the pointers to the vertices of the patch. When new vertices are added, these pointers may get invalidated. Since the container that stores the vertices (PiercedStorage) is based on a std::vector, it is possible to guarantee that the pointers remain valid performing a reserve to the right capacity before starting vertex insertion (this reserve was missing in DGF import). However, there is no official guarantee that the pointers of a PiercedStorage remain valid after adding new elements to the container. The algorithm to identify duplicate vertices is then reworkd and now is not using the pointers to the vertices anymore.