### PR TITLE
Updating guide for MinGW-Win bitpit porting

### DIFF
--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1,16 +1,16 @@
 #  bitpit on Microsoft Windows
 
-This is a short guide to set a bitpit compliant 64bit Windows environment using MSYS2/MingGW64.
+This is a short guide to set a bitpit compliant 64bit Windows environment using MSYS2/MinGW64.
 
 ## Requirements:
 - <B>Windows 8/10</B> (8.1 pro/10 tested)
 
-- <B>MSYS2</B> (64bit) https://www.msys2.org/
+- <B>MSYS2</B> (64bit) https://www.msys2.org/ (tested version msys2-x86_64-20210419.exe)
 
 - <B>MSYS2 packages</B>:
   - base-devel
   - binutils
-  - python2
+  - python
   - git (optional)
 
 
@@ -26,14 +26,15 @@ This is a short guide to set a bitpit compliant 64bit Windows environment using 
   - mingw-w64-x86_64-graphviz (to generate Doxygen documentation)
 
 
-- <B>Microsoft MPI</B>: MSMpiSetup.exe or msmpisdk.msi (dowloadable for free from https://www.microsoft.com/ searching for "MicrosoftMPI v x.x.x". Here the exact version x.x.x must be compliant with the version of MinGW64 package mingw-w64-x86_64-msmpi. See MSMPI section in          procedure chapter for details)
+- <B>Microsoft MPI</B>: MSMpiSetup.exe or msmpisdk.msi (downloadable for free from https://www.microsoft.com/ searching for "MicrosoftMPI v x.x.x". Here the exact version x.x.x must be compliant with the version of MinGW64 package mingw-w64-x86_64-msmpi. See MSMPI section in procedure chapter for details)
 
-- <B>PETSc library</B> https://www.mcs.anl.gov/petsc/download/index.html. Version 3.12.5 tested (older version 3.8.4 tested too).
+- <B>PETSc library</B> https://www.mcs.anl.gov/petsc/download/index.html. Version 3.15.0 tested
 
 ## Procedure
 #### Install MSYS2 (64 bit)/ MinGW64
 
-1. Download MSYS2 from https://www.msys2.org/ and install it following the instructions on the site to update and get the environment ready to be used. A more detailed install guide can be found also here: https://www.msys2.org/wiki/MSYS2-installation/. This will install 2 subsystems in particular:
+1. Download MSYS2 from https://www.msys2.org/ and install it following the instructions on the site to update and get the environment ready to be used. A more detailed install guide can be found also here: https://www.msys2.org/wiki/MSYS2-installation/. This will install a bunch of subsystems,
+two in particular are of interest in this context:
     - *msys2*: general POSIX compliant emulating environment
     - *mingw64*: environment, based on *msys2* and specifically tuned to provide better interoperability with native 64bit Windows software, using MingGW.
 
@@ -44,12 +45,12 @@ This is a short guide to set a bitpit compliant 64bit Windows environment using 
     >C:\msys64\msys2_shell.cmd -mingw64 (for mingw64 shell)
     ```
 
-3. Open a *msys2* shell and install base *msys2* packages base-devel, binutils, python2, git. On usage of *pacman* please refer to https://www.msys2.org/wiki/Using-packages/ :
+3. Open a *msys2* shell and install base *msys2* packages base-devel, binutils, python, git. On usage of *pacman* please refer to https://www.msys2.org/docs/package-management/ :
     ```bash
     user@machine MSYS2 ~
-    > pacman -S base-devel binutils python2 git
+    > pacman -S base-devel binutils python git
     ```
-    As in a Linux system, libs and binaries installed can be found navigating C:/msys64/usr/lib or C:/msys64/usr/bin
+    As in a Linux system, libraries and binaries installed can be found navigating C:/msys64/usr/lib or C:/msys64/usr/bin
 
 4. Open a *mingw64* shell and install the base development toolchain for *mingw64*. This will include C,C++, Fortran compilers and libraries :
     ```bash
@@ -65,11 +66,13 @@ This is a short guide to set a bitpit compliant 64bit Windows environment using 
     ```
     Using built-in specs.
     COLLECT_GCC=C:\msys64\mingw64\bin\gcc.exe
-    COLLECT_LTO_WRAPPER=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.3.0/lto-wrapper.exe
+    COLLECT_LTO_WRAPPER=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/lto-wrapper.exe
     Target: x86_64-w64-mingw32
-    Configured with: ../gcc-9.3.0/configure --prefix=/mingw64 --with-local-prefix=/mingw64/local --build=x86_64-w64-mingw32 --  host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/mingw64/x86_64-w64-mingw32/include --libexecdir=/mingw64/lib --enable-bootstrap --with-arch=x86-64 --with-tune=generic --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++ --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable- libstdcxx-filesystem-ts=yes --enable-libstdcxx-time=yes --disable-libstdcxx-pch --disable-libstdcxx-debug --disable-isl-version-check --enable-lto --enable-libgomp --disable-multilib --enable-checking=release --disable-rpath --disable-win32-registry --disable-nls --  disable-werror --disable-symvers --enable-plugin --with-libiconv --with-system-zlib --with-gmp=/mingw64 --with-mpfr=/mingw64 --with- mpc=/mingw64 --with-isl=/mingw64 --with-pkgversion='Rev2, Built by MSYS2 project' --with-bugurl=https://sourceforge.net/projects/msys2 - -with-gnu-as --with-gnu-ld
+    Configured with: ../gcc-10.3.0/configure --prefix=/mingw64 --with-local-prefix=/mingw64/local --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/mingw64/x86_64-w64-mingw32/include --libexecdir=/mingw64/lib --enable-bootstrap --enable-checking=release --with-arch=x86-64 --with-tune=generic --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++,jit --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-filesystem-ts=yes --enable-libstdcxx-time=yes --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-lto --enable-libgomp --disable-multilib --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-libiconv --with-system-zlib --with-gmp=/mingw64 --with-mpfr=/mingw64 --with-mpc=/mingw64 --with-isl=/mingw64 --with-pkgversion='Rev2, Built by MSYS2 project' --with-bugurl=https://github.com/msys2/MINGW-packages/issues --with-gnu-as --with-gnu-ld --with-boot-ldflags='-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high -Wl,--disable-dynamicbase -static-libstdc++ -static-libgcc' 'LDFLAGS_FOR_TARGET=-pipe -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high' --enable-linker-plugin-flags='LDFLAGS=-static-libstdc++\ -static-libgcc\ -pipe\ -Wl,--dynamicbase,--high-entropy-va,--nxcompat,--default-image-base-high\ -Wl,--stack,12582912'
     Thread model: posix
-    gcc version 9.3.0 (Rev2, Built by MSYS2 project)
+    Supported LTO compression algorithms: zlib zstd
+    gcc version 10.3.0 (Rev2, Built by MSYS2 project)
+
     ```
 
 5. In order to make your Windows OS *see* the *mingw64* shell binaries, modify the Windows  *PATH* environment variable by adding `C:\msys64\mingw64\bin`. The same output of 4) should appear launching from a Windows PowerShell or a Windows prompt the command:
@@ -93,7 +96,7 @@ This section will install MPI on your machine, both libraries and compiler wrapp
     ```
     It should return something like:
     ```bash
-    mingw64/mingw-w64-x86_64-msmpi 10.1.1-1
+    mingw64/mingw-w64-x86_64-msmpi 10.1.1-4
     Microsoft MPI SDK (mingw-w64)
     ```
     Please take note of the MSMPIVersion number, in the specific case 10.1.1, but it can vary according to the update status of your MSYS2 package repository. Install the msmpi from *mingw64*:
@@ -105,7 +108,7 @@ This section will install MPI on your machine, both libraries and compiler wrapp
 
 2. Download Microsoft MPI from https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi. If on site version does not match the MSMPIVersion noted earlier, a simple browser search of "MSMPI" and target version number will redirect you to the correct version download page on the official Microsoft site. Then install **both** *MSMpiSetup.exe* and *msmpisdk.msi*.
 
-3. Reopen the *mingw64* shell (to load the new env variables introduced in 2.) and locate the environment variable MSMPI_BIN typing:
+3. Reopen the *mingw64* shell (to load the new enviroment variables introduced in 2.) and locate the environment variable MSMPI_BIN typing:
     ```bash
     user@machine MINGW64 ~
     > printenv | grep "WIN\|MSMPI"
@@ -135,11 +138,11 @@ This section will install MPI on your machine, both libraries and compiler wrapp
     > cygpath -u 'C:/PROGRA~1/MICROS~2/Bin/'
     result will be: /c/PROGRA~1/MICROS~2/Bin/
     ```
-    The last result can be safely exported in the local *mingw64* shell PATH environment	variable with:
+    The last result can be safely exported in the local *mingw64* shell PATH environment variable with:
     ```bash
     export PATH=$PATH:/c/PROGRA~1/MICROS~2/Bin/
     ```
-    and make *mpiexec.exe* available in the shell. It is recommended to add it permanently to the *~/.bashrc* conf file of the shell.
+    and make *mpiexec.exe* available in the shell. It is recommended to add it permanently to the *~/.bashrc* configuration file of the shell.
 
 5. Before moving on, test MSMPI with a simple MPI Hello World code. Here an example in c++:
     ```c++
@@ -174,7 +177,7 @@ This section will install MPI on your machine, both libraries and compiler wrapp
 #### bitpit dependencies
 For the following subsections, open a *mingw64* shell.
 
-_**Beware**_: some of these deps can be available also as native Windows applications/libraries. Anyway we choose to use those provided by msys2/mingw64 repositories to ensure the maximum coherence during the installation flow. If you choose to use different versions/distributions, let us know your experience. We will be glad to use your tips to enrich the current guide.
+_**Beware**_: some of these dependencies can be available also as native Windows applications/libraries. Anyway we choose to use those provided by msys2/mingw64 repositories to ensure the maximum coherence during the installation flow. If you choose to use different versions/distributions, let us know your experience. We will be glad to use your tips to enrich the current guide.
 
 **__CMAKE__**
 
@@ -203,15 +206,15 @@ user@machine MINGW64 ~
 
 **__PETSc__**
 
-First, __*PETSc* sources__ are needed. Download *PETSc v3.12.5* from https://www.mcs.anl.gov/petsc/download/index.html. This is the most recent version of PETSc tested with bitpit. If you want to have a try with different versions, please let us know your experience.
+First, __*PETSc* sources__ are needed. Download *PETSc v3.15.0* from https://www.mcs.anl.gov/petsc/download/index.html. This is the most recent version of PETSc tested with bitpit. If you want to have a try with different versions, please let us know your experience.
 
 - Untar the downloaded *PETSc* archive and enter the *PETSc* sources folder from the *mingw64* shell.
 
-- Get track of *msys2* python2.exe and ar.exe binaries, both available in '/usr/bin/' inside the *mingw64* shell (if not check subsection 3 of **Install MSYS2(64bit) and MINGW64** chapter of the guide). These ones are the only that work properly with *PETSc* configure scripts. *mingw64* python and ar versions create problems.
+- Get track of *msys2* python.exe and ar.exe binaries, both available in '/usr/bin/' inside the *mingw64* shell (if not check subsection 3 of **Install MSYS2(64bit) and MINGW64** chapter of the guide). These ones are the only that work properly with *PETSc* configure scripts. *mingw64* python and ar versions create problems.
 
-- Check if *mpiexec.exe* is available in the shell (type "mpiex" and complete with tab). If not please check again  the section 4 of **MS-MPI** chapter.
+- Check if *mpiexec.exe* is available in the shell (type "mpiex" and complete with tab). If not please check again the section 4 of **MS-MPI** chapter.
 
-- We configure *PETSc* using a *Python2* script. Edit a new *Python* file, e.g. __*myConf.py*__, and add these lines:
+- We configure *PETSc* using a *Python* script (3.x version namely). Edit a new *Python* file, e.g. __*myConf.py*__, and add these lines:
     ```python
      configure_options = [
      '--with-ar=/usr/bin/ar' ,
@@ -239,7 +242,7 @@ First, __*PETSc* sources__ are needed. Download *PETSc v3.12.5* from https://www
     ```
     and follow the PETSc instructions to complete the installation ( copy and paste exactly the command lines PETSc suggests, up to the 'make...test' part).
 
-- Finally, export __*PETSC_DIR*__ and __*PETSC_ARCH*__ environment variables on    *mingw64* local shell by adding  to *~/.bashrc* file : `export PETSC_DIR=#prefix# PETSC_ARCH=""`, where #prefix# is the path specified with --prefix in the python configuration script.
+- Finally, export __*PETSC_DIR*__ and __*PETSC_ARCH*__ environment variables on *mingw64* local shell by adding  to *~/.bashrc* file : `export PETSC_DIR=#prefix# PETSC_ARCH=""`, where #prefix# is the path specified with --prefix in the python configuration script.
 
 
 #### bitpit


### PR DESCRIPTION
Simple guide review for README_WINDOWS.md file:
- new msys2/mingw64 core version - 20210419 : lots of changes, since msys guys moved the project to new servers, and compliancy with older versions was a little bit messed up.
- tested bitpit compliancy with the latest petsc version (3.15.0)