### PR TITLE
voloctree: override functions to identify adjacent faces

### DIFF
--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -523,6 +523,16 @@ uint8_t ReconstructionPolynomial::getDimensions() const
 }
 
 /*!
+ * Get the origin of the reconstruction.
+ *
+ * \return The origin of the reconstruction.
+ */
+const std::array<double, 3> & ReconstructionPolynomial::getOrigin() const
+{
+    return m_origin;
+}
+
+/*!
  * Get the number of coefficients of the reconstruction polynomial.
  *
  * \return The number of coefficients of the reconstruction polynomial.

--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -55,6 +55,7 @@ public:
 
     uint8_t getDegree() const;
     uint8_t getDimensions() const;
+    const std::array<double, 3> & getOrigin() const;
 
     uint16_t getCoefficientCount() const;
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5574,7 +5574,7 @@ void PatchKernel::_updateAdjacencies()
 					}
 
 					Cell &neigh = m_cells.at(neighId);
-					int neighFace = findAdjoinNeighFace(matchingCellId, matchingFace, neighId);
+					int neighFace = findAdjoinNeighFace(matchingCell, matchingFace, neigh);
 					matchingAdjacencies.emplace_back(std::make_pair<Cell *, int>(&neigh, std::move(neighFace)));
 				}
 			} else {
@@ -5889,7 +5889,7 @@ void PatchKernel::_updateInterfaces()
 					long neighId = faceAdjacencies[k];
 					Cell *neigh  = &m_cells[neighId];
 
-					int neighFace = findAdjoinNeighFace(cellId, face, neighId);
+					int neighFace = findAdjoinNeighFace(cell, face, *neigh);
 
 					buildCellInterface(&cell, face, neigh, neighFace);
 				}
@@ -6060,14 +6060,17 @@ PatchKernel::InterfaceIterator PatchKernel::buildCellInterface(Cell *cell_1, int
 /*!
 	Finds the face of the supposed neighbour that adjoins the target face.
 
-	\param cellId is the id of the cell
+	\param cell is the cell
 	\param cellFace is the target face of the cell
-	\param neighId is the id of a supposed neighbour of the cell
+	\param neigh is the supposed neighbour of the cell
 	\result The face of the neighbour which adjoins the target face. If the
 	two cells are not neighbours, a negative number is returned.
  */
-int PatchKernel::findAdjoinNeighFace(long cellId, int cellFace, long neighId) const
+int PatchKernel::findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const
 {
+	long cellId  = cell.getId();
+	long neighId = neigh.getId();
+
 	// Evaluate list of candidate faces
 	//
 	// The cells may be neighbours through multiple faces. Identify which face
@@ -6076,7 +6079,6 @@ int PatchKernel::findAdjoinNeighFace(long cellId, int cellFace, long neighId) co
 	// is not needed at all. Therefore, first we identify all the faces through
 	// which the two cells are neighbours and then, if and only if there are
 	// multiple candidates, we identify the face that matches the target one.
-	const Cell &neigh = getCell(neighId);
 	const int nNeighFaces = neigh.getFaceCount();
 
 	int nCandidates = 0;

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5109,16 +5109,14 @@ long PatchKernel::locatePoint(double x, double y, double z) const
  * Check whether the face "face_A" on cell "cell_A" is the same as the face
  * "face_B" on cell "cell_B".
  * 
- * \param[in] cellId_A is the index of the first cell
+ * \param[in] cell_A is the first cell
  * \param[in] face_A is the face on the first cell
- * \param[in] cellId_B is the index of the second cell
+ * \param[in] cell_B is the the second cell
  * \param[in] face_B is the face on the second cell
  * \result Returns true if the two faces are the same.
 */
-bool PatchKernel::isSameFace(long cellId_A, int face_A, long cellId_B, int face_B) const
+bool PatchKernel::isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const
 {
-	const Cell &cell_A = m_cells[cellId_A];
-	const Cell &cell_B = m_cells[cellId_B];
 	if (cell_A.getFaceType(face_A) != cell_B.getFaceType(face_B)) {
 		return false;
 	}
@@ -6068,9 +6066,6 @@ PatchKernel::InterfaceIterator PatchKernel::buildCellInterface(Cell *cell_1, int
  */
 int PatchKernel::findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const
 {
-	long cellId  = cell.getId();
-	long neighId = neigh.getId();
-
 	// Evaluate list of candidate faces
 	//
 	// The cells may be neighbours through multiple faces. Identify which face
@@ -6079,6 +6074,7 @@ int PatchKernel::findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell 
 	// is not needed at all. Therefore, first we identify all the faces through
 	// which the two cells are neighbours and then, if and only if there are
 	// multiple candidates, we identify the face that matches the target one.
+	long cellId = cell.getId();
 	const int nNeighFaces = neigh.getFaceCount();
 
 	int nCandidates = 0;
@@ -6102,7 +6098,7 @@ int PatchKernel::findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell 
 	} else {
 		for (int i = 0; i < nCandidates; ++i) {
 			int candidateFace = (*candidates)[i];
-			if (isSameFace(cellId, cellFace, neighId, candidateFace)) {
+			if (isSameFace(cell, cellFace, neigh, candidateFace)) {
 				return candidateFace;
 			}
 		}

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -873,7 +873,7 @@ protected:
 	void mappedItemRenumbering(PiercedVector<item_t, id_t> &container, const std::unordered_map<id_t, id_t> &renumberMap);
 
 	int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const;
-	bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
+	virtual bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 private:
 	std::unique_ptr<IndexGenerator<long>> m_vertexIdGenerator;

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -873,7 +873,7 @@ protected:
 	void mappedItemRenumbering(PiercedVector<item_t, id_t> &container, const std::unordered_map<id_t, id_t> &renumberMap);
 
 	int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const;
-	bool isSameFace(long cellId_A, int face_A, long cellId_B, int face_B) const;
+	bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 private:
 	std::unique_ptr<IndexGenerator<long>> m_vertexIdGenerator;

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -872,7 +872,7 @@ protected:
 	template<typename item_t, typename id_t = long>
 	void mappedItemRenumbering(PiercedVector<item_t, id_t> &container, const std::unordered_map<id_t, id_t> &renumberMap);
 
-	int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const;
+	virtual int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const;
 	virtual bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 private:

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -872,7 +872,7 @@ protected:
 	template<typename item_t, typename id_t = long>
 	void mappedItemRenumbering(PiercedVector<item_t, id_t> &container, const std::unordered_map<id_t, id_t> &renumberMap);
 
-	int findAdjoinNeighFace(long cellId, int cellFace, long neighId) const;
+	int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const;
 	bool isSameFace(long cellId_A, int face_A, long cellId_B, int face_B) const;
 
 private:

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -587,8 +587,6 @@ public:
 	long locatePoint(double x, double y, double z) const;
 	virtual long locatePoint(const std::array<double, 3> &point) const = 0;
 
-	bool isSameFace(long cellId_A, int face_A, long cellId_B, int face_B) const;
-
 	AdjacenciesBuildStrategy getAdjacenciesBuildStrategy() const;
 	bool areAdjacenciesDirty(bool global = false) const;
 	BITPIT_DEPRECATED(void buildAdjacencies());
@@ -875,6 +873,7 @@ protected:
 	void mappedItemRenumbering(PiercedVector<item_t, id_t> &container, const std::unordered_map<id_t, id_t> &renumberMap);
 
 	int findAdjoinNeighFace(long cellId, int cellFace, long neighId) const;
+	bool isSameFace(long cellId_A, int face_A, long cellId_B, int face_B) const;
 
 private:
 	std::unique_ptr<IndexGenerator<long>> m_vertexIdGenerator;

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2129,9 +2129,11 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                             frontierFace = face;
                             frontierCell = &cell;
                         } else {
+                            Cell &neigh = getCell(neighId);
+
                             frontierCellId = neighId;
-                            frontierFace = findAdjoinNeighFace(cellId, face, neighId);
-                            frontierCell = &(m_cells.at(neighId));
+                            frontierFace = findAdjoinNeighFace(cell, face, neigh);
+                            frontierCell = &neigh;
 
                             assert(frontierFace >= 0);
                         }

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2029,7 +2029,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
     std::unordered_set<long> frontierNeighs;
     std::unordered_set<long> frontierVertices;
     std::unordered_set<long> frontierFaceVertices;
-    std::unordered_set<CellHalfEdge, CellHalfEdge::Hasher> frontierEdges;
+    std::unordered_set<ConstCellHalfEdge, ConstCellHalfEdge::Hasher> frontierEdges;
 
     std::unordered_set<long> outgoingCells;
     std::unordered_set<long> frameCells;
@@ -2123,13 +2123,13 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                         // Select the cell with only one adjacency
                         long frontierCellId;
                         long frontierFace;
-                        Cell *frontierCell;
+                        const Cell *frontierCell;
                         if (nFaceAdjacencies == 1) {
                             frontierCellId = cellId;
                             frontierFace = face;
                             frontierCell = &cell;
                         } else {
-                            Cell &neigh = getCell(neighId);
+                            const Cell &neigh = getCell(neighId);
 
                             frontierCellId = neighId;
                             frontierFace = findAdjoinNeighFace(cell, face, neigh);
@@ -2224,7 +2224,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                                 // Edge information
                                 int nEdgeVertices = frontierCell->getEdgeVertexCount(edge);
 
-                                CellHalfEdge frontierEdge = CellHalfEdge(*frontierCell, edge, CellHalfEdge::WINDING_NATURAL);
+                                ConstCellHalfEdge frontierEdge = ConstCellHalfEdge(*frontierCell, edge, ConstCellHalfEdge::WINDING_NATURAL);
 
                                 // Discard edges that do not belong to the
                                 // current frontier face
@@ -2244,12 +2244,12 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                                 }
 
                                 // Avoid adding duplicate edges
-                                frontierEdge.setWinding(CellHalfEdge::WINDING_REVERSE);
+                                frontierEdge.setWinding(ConstCellHalfEdge::WINDING_REVERSE);
                                 auto frontierEdgeItr = frontierEdges.find(frontierEdge);
                                 if (frontierEdgeItr != frontierEdges.end()) {
                                     continue;
                                 } else {
-                                    frontierEdge.setWinding(CellHalfEdge::WINDING_NATURAL);
+                                    frontierEdge.setWinding(ConstCellHalfEdge::WINDING_NATURAL);
                                     frontierEdgeItr = frontierEdges.find(frontierEdge);
                                     if (frontierEdgeItr != frontierEdges.end()) {
                                         continue;

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -999,16 +999,16 @@ bool SurfaceKernel::adjustCellOrientation(long seed, bool invert)
                 const long *faceAdjacencies = cell.getAdjacencies(face);
                 for (int i = 0; i < nFaceAdjacencies; ++i) {
                     long neighId = faceAdjacencies[i];
+                    const Cell &neigh = getCell(neighId);
 #if BITPIT_ENABLE_MPI==1
                     if (ghostExchangeNeeded) {
-                        const auto &neigh = getCell(neighId);
                         if (!neigh.isInterior()) {
                             continue;
                         }
                     }
 #endif
 
-                    int neighFace = findAdjoinNeighFace(cellId, face, neighId);
+                    int neighFace = findAdjoinNeighFace(cell, face, neigh);
 
                     bool isNeighOriented = haveSameOrientation(cellId, face, neighId, neighFace);
                     if (visited.count(neighId) == 0) {

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -1010,7 +1010,7 @@ bool SurfaceKernel::adjustCellOrientation(long seed, bool invert)
 
                     int neighFace = findAdjoinNeighFace(cell, face, neigh);
 
-                    bool isNeighOriented = haveSameOrientation(cellId, face, neighId, neighFace);
+                    bool isNeighOriented = haveSameOrientation(cell, face, neigh, neighFace);
                     if (visited.count(neighId) == 0) {
                         if (!isNeighOriented) {
                             flipCellOrientation(neighId);
@@ -1114,23 +1114,23 @@ bool SurfaceKernel::adjustCellOrientation(long seed, bool invert)
  * relative orientation only checking the order of the vertices, otherwise
  * is is necessary to evaluate the normals.
  *
- * \param[in] cellId_A is the index of the first cell
- * \param[in] cellFace_A is the face on the first cell
- * \param[in] cellId_B is the index of the second cell
- * \param[in] cellFace_B is the face on the second cell
+ * \param[in] cell_A is the first cell
+ * \param[in] face_A is the face on the first cell
+ * \param[in] cell_B is the second cell
+ * \param[in] face_B is the face on the second cell
  * \result Returns true if the two facets have the same orientation, false
  * otherwise.
 */
-bool SurfaceKernel::haveSameOrientation(long cellId_A, int cellFace_A, long cellId_B, int cellFace_B) const
+bool SurfaceKernel::haveSameOrientation(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const
 {
     //
     // Cell information
     //
-    const Cell &cell_A = getCell(cellId_A);
+    long cellId_A = cell_A.getId();
     ConstProxyVector<long> cellVertexIds_A = cell_A.getVertexIds();
     std::size_t nCellVertices_A = cellVertexIds_A.size();
 
-    const Cell &cell_B = getCell(cellId_B);
+    long cellId_B = cell_B.getId();
     ConstProxyVector<long> cellVertexIds_B = cell_B.getVertexIds();
     std::size_t nCellVertices_B = cellVertexIds_B.size();
 
@@ -1199,8 +1199,8 @@ bool SurfaceKernel::haveSameOrientation(long cellId_A, int cellFace_A, long cell
     std::size_t nMaxCellVertices = std::max(nCellVertices_A, nCellVertices_B);
     BITPIT_CREATE_WORKSPACE(vertexCoordinates, std::array<double BITPIT_COMMA 3>, nMaxCellVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
 
-    ConstProxyVector<int> faceLocalVertexIds_A = cell_A.getFaceLocalVertexIds(cellFace_A);
-    ConstProxyVector<int> faceLocalVertexIds_B = cell_B.getFaceLocalVertexIds(cellFace_B);
+    ConstProxyVector<int> faceLocalVertexIds_A = cell_A.getFaceLocalVertexIds(face_A);
+    ConstProxyVector<int> faceLocalVertexIds_B = cell_B.getFaceLocalVertexIds(face_B);
 
     std::array<double, 3> pseudoNormal_A;
     std::array<double, 3> pseudoNormal_B;

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -76,7 +76,7 @@ private:
         bool compareSelectedTypes(unsigned short, ElementType) const;
         void displayHistogram(long, const std::vector<double>&, const std::vector<double>&, const std::string&, std::ostream&, unsigned int padding = 0) const;
 
-        bool haveSameOrientation(long cellId_A, int face_A, long cellId_B, int face_B) const;
+        bool haveSameOrientation(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 protected:
         int                     m_spaceDim;

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2745,6 +2745,34 @@ void VolOctree::findOctantCodimensionNeighs(const OctantInfo &octantInfo, int in
 }
 
 /*!
+	Finds the face of the supposed neighbour that adjoins the target face.
+
+	\param cellId is the id of the cell
+	\param cellFace is the target face of the cell
+	\param neighId is the id of a supposed neighbour of the cell
+	\result The face of the neighbour which adjoins the target face. If the
+	two cells are not neighbours, a negative number is returned.
+ */
+int VolOctree::findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const
+{
+	long cellId = cell.getId();
+
+	// Get the neighbour face
+	int neighFace = m_tree->getOppface()[cellFace];
+
+	// Check if the two cells are neighbours
+	int nNeighFaceAdjacencies = neigh.getAdjacencyCount(neighFace);
+	const long *neighFaceAdjacencies = neigh.getAdjacencies(neighFace);
+	for (int k = 0; k < nNeighFaceAdjacencies; ++k) {
+		if (neighFaceAdjacencies[k] == cellId) {
+			return neighFace;
+		}
+	}
+
+	return -1;
+}
+
+/*!
  * Check whether the face "face_A" on cell "cell_A" is the same as the face
  * "face_B" on cell "cell_B".
  *

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2744,4 +2744,35 @@ void VolOctree::findOctantCodimensionNeighs(const OctantInfo &octantInfo, int in
 	}
 }
 
+/*!
+ * Check whether the face "face_A" on cell "cell_A" is the same as the face
+ * "face_B" on cell "cell_B".
+ *
+ * \param[in] cell_A is the first cell
+ * \param[in] face_A is the face on the first cell
+ * \param[in] cell_B is the the second cell
+ * \param[in] face_B is the face on the second cell
+ * \result Returns true if the two faces are the same.
+*/
+bool VolOctree::isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const
+{
+	// Check if the face matches
+	if (m_tree->getOppface()[face_A] != face_B) {
+		return false;
+	}
+
+	// Check if the two cells are neighbours
+	long cellId_A = cell_A.getId();
+
+	int nNeighFaceAdjacencies_B = cell_B.getAdjacencyCount(face_B);
+	const long *neighFaceAdjacencies_B = cell_B.getAdjacencies(face_B);
+	for (int k = 0; k < nNeighFaceAdjacencies_B; ++k) {
+		if (neighFaceAdjacencies_B[k] == cellId_A) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 }

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1719,7 +1719,7 @@ VolOctree::StitchInfo VolOctree::deleteCells(const std::vector<DeleteInfo> &dele
 				}
 
 				const Cell &neigh = m_cells[neighId];
-				int neighFace = findAdjoinNeighFace(cellId, face, neighId);
+				int neighFace = findAdjoinNeighFace(cell, face, neigh);
 				const int *localNeighFaceConnect = m_cellTypeInfo->faceConnectStorage[neighFace].data();
 				ConstProxyVector<long> faceVertexIds = neigh.getFaceVertexIds(neighFace);
 				std::size_t nFaceVertexIds = faceVertexIds.size();

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -169,6 +169,7 @@ protected:
 	std::vector<long> _findGhostCellExchangeSources(int rank) override;
 #endif
 
+	int findAdjoinNeighFace(const Cell &cell, int cellFace, const Cell &neigh) const override;
 	bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const override;
 
 private:

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -169,6 +169,8 @@ protected:
 	std::vector<long> _findGhostCellExchangeSources(int rank) override;
 #endif
 
+	bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const override;
+
 private:
 	using PatchKernel::setBoundingBox;
 


### PR DESCRIPTION
Voloctree patch now overrides the functions used to identify adjacent faces, this allows to support trees with periodic boundary conditions.