### PR TITLE
containers: rework handling of ProxyVector internal storage

### DIFF
--- a/src/containers/piercedKernelIterator.hpp
+++ b/src/containers/piercedKernelIterator.hpp
@@ -45,6 +45,7 @@ class PiercedKernel;
 */
 template<typename id_t = long>
 class PiercedKernelIterator
+    : public std::iterator<std::random_access_iterator_tag, id_t, std::ptrdiff_t, id_t*, id_t&>
 {
 
 template<typename PK_id_t>

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -87,7 +87,7 @@ private:
         static constexpr bool has_restore()
         {
             return std::is_same<decltype(test_restore<class_t>(nullptr)), std::true_type>();
-        };
+        }
 
     public:
         static const bool value = has_restore<T>();
@@ -112,7 +112,7 @@ private:
         static constexpr bool has_dump()
         {
             return std::is_same<decltype(test_dump<class_t>(nullptr)), std::true_type>();
-        };
+        }
 
     public:
         static const bool value = has_dump<T>();
@@ -251,7 +251,7 @@ public:
     static constexpr bool has_initialize()
     {
         return check_initialize<value_t, void, Args...>::value;
-    };
+    }
 
     // Constructors and initialization
     PiercedStorage();

--- a/src/containers/piercedStorageIterator.hpp
+++ b/src/containers/piercedStorageIterator.hpp
@@ -54,7 +54,7 @@ class PiercedStorageIterator
     : protected PiercedKernelIterator<id_t>
 {
 
-friend class PiercedStorageIterator<value_no_cv_t, id_t, value_no_cv_t>;
+friend class PiercedStorageIterator<typename std::add_const<value_t>::type, id_t, value_no_cv_t>;
 
 template<typename PS_value_t, typename PS_id_t>
 friend class PiercedStorage;
@@ -131,6 +131,9 @@ public:
     // Constructors
     PiercedStorageIterator();
 
+    template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type = 0>
+    PiercedStorageIterator(const PiercedStorageIterator<other_value_t, id_t, value_no_cv_t> &other);
+
     // General methods
     void swap(PiercedStorageIterator& other) noexcept;
 
@@ -154,8 +157,8 @@ public:
     __PSI_REFERENCE__ operator*() const;
     __PSI_POINTER__ operator->() const;
 
-    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
-    operator PiercedStorageIterator<const U, id_t>() const;
+    template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type = 0>
+    PiercedStorageIterator & operator=(const PiercedStorageIterator<other_value_t, id_t, value_no_cv_t> &other);
 
     /**
     * Two-way comparison.

--- a/src/containers/piercedStorageIterator.tpp
+++ b/src/containers/piercedStorageIterator.tpp
@@ -36,6 +36,19 @@ PiercedStorageIterator<value_t, id_t, value_no_cv_t>::PiercedStorageIterator()
 {
 }
 
+/*!
+    Creates a new constant iterator pointing to the same position of the
+    specified iterator.
+
+    \param other is the iterator that will be copied
+*/
+template<typename value_t, typename id_t, typename value_no_cv_t>
+template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
+PiercedStorageIterator<value_t, id_t, value_no_cv_t>::PiercedStorageIterator(const PiercedStorageIterator<other_value_t, id_t, value_no_cv_t> &other)
+    : PiercedStorageIterator(other.m_storage, other.getRawIndex())
+{
+}
+
 /**
 * Creates a new iterator and initializes it with the position of the const
 * base iterator recevied in input.
@@ -203,16 +216,20 @@ __PSI_POINTER__ PiercedStorageIterator<value_t, id_t, value_no_cv_t>::operator->
     return m_storage->rawData(rawIndex);
 }
 
-/**
-* Converts the iterator to a const_iterator.
+/*!
+* Copy assignment operator to create a constant iterator from a non-constant
+* one.
+*
+* \param other is the iterator that will be copied
 */
 template<typename value_t, typename id_t, typename value_no_cv_t>
-template<typename U, typename std::enable_if<!std::is_const<U>::value, int>::type>
-PiercedStorageIterator<value_t, id_t, value_no_cv_t>::operator PiercedStorageIterator<const U, id_t>() const
+template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
+PiercedStorageIterator<value_t, id_t, value_no_cv_t> & PiercedStorageIterator<value_t, id_t, value_no_cv_t>::operator=(const PiercedStorageIterator<other_value_t, id_t, value_no_cv_t> &other)
 {
-    std::size_t rawIndex = getRawIndex();
+    PiercedKernelIterator<id_t>::operator=(other);
+    m_storage = other.m_storage;
 
-    return PiercedStorageIterator<const U, id_t>(m_storage, rawIndex);
+    return *this;
 }
 
 }

--- a/src/containers/proxyVector.cpp
+++ b/src/containers/proxyVector.cpp
@@ -31,4 +31,8 @@ template class ProxyVector<int>;
 template class ProxyVector<long>;
 template class ProxyVector<double>;
 
+template class ProxyVector<const int>;
+template class ProxyVector<const long>;
+template class ProxyVector<const double>;
+
 }

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -25,43 +25,43 @@
 #ifndef __BITPIT_PROXY_VECTOR_HPP__
 #define __BITPIT_PROXY_VECTOR_HPP__
 
-#define  __PXI_REFERENCE__ typename ProxyVectorIterator<T, T_no_cv>::reference
-#define  __PXI_POINTER__   typename ProxyVectorIterator<T, T_no_cv>::pointer
+#define  __PXI_REFERENCE__ typename ProxyVectorIterator<value_t, value_no_cv_t>::reference
+#define  __PXI_POINTER__   typename ProxyVectorIterator<value_t, value_no_cv_t>::pointer
 
-#define __PXV_REFERENCE__       typename ProxyVector<T>::reference
-#define __PXV_CONST_REFERENCE__ typename ProxyVector<T>::const_reference
-#define __PXV_POINTER__         typename ProxyVector<T>::pointer
-#define __PXV_CONST_POINTER__   typename ProxyVector<T>::const_pointer
-#define __PXV_ITERATOR__        typename ProxyVector<T>::iterator
-#define __PXV_CONST_ITERATOR__  typename ProxyVector<T>::const_iterator
+#define __PXV_REFERENCE__       typename ProxyVector<value_t>::reference
+#define __PXV_CONST_REFERENCE__ typename ProxyVector<value_t>::const_reference
+#define __PXV_POINTER__         typename ProxyVector<value_t>::pointer
+#define __PXV_CONST_POINTER__   typename ProxyVector<value_t>::const_pointer
+#define __PXV_ITERATOR__        typename ProxyVector<value_t>::iterator
+#define __PXV_CONST_ITERATOR__  typename ProxyVector<value_t>::const_iterator
 
 #include <memory>
 #include <vector>
 
 namespace bitpit{
 
-template<typename PXV_T>
+template<typename PXV_value_t>
 class ProxyVector;
 
 /*!
     @ingroup containers
     @brief Iterator for the class ProxyVector
 
-    @tparam T is the type of the objects handled by the ProxyVector
+    @tparam value_t is the type of the objects handled by the ProxyVector
 */
-template<typename T, typename T_no_cv = typename std::remove_cv<T>::type>
+template<typename value_t, typename value_no_cv_t = typename std::remove_cv<value_t>::type>
 class ProxyVectorIterator
-    : public std::iterator<std::random_access_iterator_tag, T_no_cv, std::ptrdiff_t, T*, T&>
+    : public std::iterator<std::random_access_iterator_tag, value_no_cv_t, std::ptrdiff_t, value_t*, value_t&>
 {
 
-template<typename PXV_T>
+template<typename PXV_value_t>
 friend class ProxyVector;
 
 public:
     /*!
         Type of data stored in the container
     */
-    typedef T value_type;
+    typedef value_t value_type;
 
     // Constructors
     ProxyVectorIterator();
@@ -83,35 +83,35 @@ public:
     __PXI_REFERENCE__ operator*() const;
     __PXI_POINTER__ operator->() const;
 
-    template<typename U = T, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
-    operator ProxyVectorIterator<const U>() const;
+    template<typename other_value_t = value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type = 0>
+    operator ProxyVectorIterator<const other_value_t>() const;
 
     /*!
         Two-way comparison.
     */
-    template<typename U = T, typename U_no_cv = typename std::remove_cv<U>::type>
-    bool operator==(const ProxyVectorIterator<U, U_no_cv>& rhs) const
+    template<typename other_value_t = value_t, typename other_value_no_cv_t = typename std::remove_cv<other_value_t>::type>
+    bool operator==(const ProxyVectorIterator<other_value_t, other_value_no_cv_t>& other) const
     {
-        return (m_position == rhs.m_position);
+        return (m_position == other.m_position);
     }
 
     /*!
         Two-way comparison.
     */
-    template<typename U = T, typename U_no_cv = typename std::remove_cv<U>::type>
-    bool operator!=(const ProxyVectorIterator<U, U_no_cv>& rhs) const
+    template<typename other_value_t = value_t, typename other_value_no_cv_t = typename std::remove_cv<other_value_t>::type>
+    bool operator!=(const ProxyVectorIterator<other_value_t, other_value_no_cv_t>& other) const
     {
-        return (m_position != rhs.m_position);
+        return (m_position != other.m_position);
     }
 
 private:
     /*!
         Position inside the container.
     */
-    T *m_position;
+    value_t *m_position;
 
     // Constructors
-    explicit ProxyVectorIterator(T *position);
+    explicit ProxyVectorIterator(value_t *position);
 
 };
 
@@ -122,69 +122,69 @@ private:
     the container itself.
 
     @details
-    Usage: Use <tt>ProxyVector<Type></tt> to declare a list of elements that
+    Usage: Use <tt>ProxyVector<value_t></tt> to declare a list of elements that
     can be either stored in an external vectror or, if the elements are
     constant, inside the container itself. When the ProxyVector is destroyed,
     the elements of the list will be destroyed only if owned by the ProxyVector o
     bject itself.
 
-    @tparam T is the type of the objects handled by the ProxyVector
+    @tparam value_t is the type of the objects handled by the ProxyVector
 */
-template<typename T>
+template<typename value_t>
 class ProxyVector
 {
 
 private:
-    typedef typename std::remove_cv<T>::type T_no_cv;
+    typedef typename std::remove_cv<value_t>::type value_no_cv_t;
 
 public:
     /*!
         Type of data stored in the container
     */
-    typedef T value_type;
+    typedef value_t value_type;
 
     /*!
         Iterator for the pierced array raw container.
     */
-    typedef ProxyVectorIterator<T> iterator;
+    typedef ProxyVectorIterator<value_t> iterator;
 
     /*!
         Constant iterator for the pierced array raw container.
     */
-    typedef ProxyVectorIterator<const T_no_cv> const_iterator;
+    typedef ProxyVectorIterator<const value_no_cv_t> const_iterator;
 
     /*!
         Reference
     */
     typedef
-        typename std::conditional<std::is_const<T>::value,
-            typename std::vector<T_no_cv>::const_reference,
-            typename std::vector<T_no_cv>::reference>::type
+        typename std::conditional<std::is_const<value_t>::value,
+            typename std::vector<value_no_cv_t>::const_reference,
+            typename std::vector<value_no_cv_t>::reference>::type
         reference;
 
     /*!
         Constant reference
     */
-    typedef typename std::vector<T_no_cv>::const_reference const_reference;
+    typedef typename std::vector<value_no_cv_t>::const_reference const_reference;
 
     /*!
         Pointer
     */
     typedef
-        typename std::conditional<std::is_const<T>::value,
-            typename std::vector<T_no_cv>::const_pointer,
-            typename std::vector<T_no_cv>::pointer>::type
+        typename std::conditional<std::is_const<value_t>::value,
+            typename std::vector<value_no_cv_t>::const_pointer,
+            typename std::vector<value_no_cv_t>::pointer>::type
         pointer;
 
     /*!
         Constant pointer
     */
-    typedef typename std::vector<T_no_cv>::const_pointer const_pointer;
+    typedef typename std::vector<value_no_cv_t>::const_pointer const_pointer;
 
     ProxyVector();
-    ProxyVector(T *data, std::size_t size);
-    template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    ProxyVector(std::vector<T_no_cv> &&data);
+    ProxyVector(value_t *data, std::size_t size);
+    template<typename other_value_t = value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type = 0>
+    ProxyVector(std::vector<value_no_cv_t> &&data);
 
     ProxyVector(const ProxyVector &other);
     ProxyVector(ProxyVector &&other) = default;
@@ -199,18 +199,18 @@ public:
 
     ProxyVector & operator=(const ProxyVector &other);
 
-    void set(T *data, std::size_t size);
-    template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    T_no_cv * set(std::vector<T_no_cv> &&storage);
-    template<typename U = T, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    T_no_cv * set(std::size_t size);
+    void set(value_t *data, std::size_t size);
+    template<typename other_value_t = value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type = 0>
+    value_no_cv_t * set(std::vector<value_no_cv_t> &&storage);
+    template<typename other_value_t = value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type = 0>
+    value_no_cv_t * set(std::size_t size);
 
     void clear();
     void swap(ProxyVector &other);
 
     bool empty() const;
     std::size_t size() const;
-    bool operator==(const ProxyVector& rhs) const;
+    bool operator==(const ProxyVector& other) const;
 
     __PXV_CONST_POINTER__ data() const noexcept;
     __PXV_POINTER__ data() noexcept;
@@ -237,16 +237,16 @@ public:
     __PXV_CONST_ITERATOR__ cend();
 
 private:
-    std::unique_ptr<std::vector<T_no_cv>> m_storage;
+    std::unique_ptr<std::vector<value_no_cv_t>> m_storage;
 
-    T *m_data;
+    value_t *m_data;
     std::size_t m_size;
 
 };
 
 // Constant proxy vector
-template<typename T>
-using ConstProxyVector = ProxyVector<const T>;
+template<typename value_t>
+using ConstProxyVector = ProxyVector<const value_t>;
 
 }
 

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -248,25 +248,32 @@ public:
 
     bool operator==(const ProxyVector &other) const;
 
-    __PXV_CONST_POINTER__ data() const noexcept;
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_POINTER__ data() noexcept;
+    __PXV_CONST_POINTER__ data() const noexcept;
 
-    __PXV_CONST_REFERENCE__ operator[](std::size_t n) const;
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_REFERENCE__ operator[](std::size_t n);
+    __PXV_CONST_REFERENCE__ operator[](std::size_t n) const;
 
-    __PXV_CONST_REFERENCE__ at(std::size_t n) const;
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_REFERENCE__ at(std::size_t n);
+    __PXV_CONST_REFERENCE__ at(std::size_t n) const;
 
-    __PXV_CONST_REFERENCE__ front() const;
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_REFERENCE__ front();
+    __PXV_CONST_REFERENCE__ front() const;
 
-    __PXV_CONST_REFERENCE__ back() const;
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_REFERENCE__ back();
+    __PXV_CONST_REFERENCE__ back() const;
 
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_ITERATOR__ begin();
-    __PXV_ITERATOR__ end();
-
     __PXV_CONST_ITERATOR__ begin() const;
+
+    template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
+    __PXV_ITERATOR__ end();
     __PXV_CONST_ITERATOR__ end() const;
 
     __PXV_CONST_ITERATOR__ cbegin();

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -261,7 +261,10 @@ extern template class ProxyVector<int>;
 extern template class ProxyVector<long>;
 extern template class ProxyVector<double>;
 
-}
+extern template class ProxyVector<const int>;
+extern template class ProxyVector<const long>;
+extern template class ProxyVector<const double>;
 
+}
 
 #endif

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -189,20 +189,6 @@ public:
     typedef ProxyVectorIterator<typename std::add_const<value_no_cv_t>::type, value_no_cv_t> const_iterator;
 
     /*!
-        Reference type
-    */
-    typedef
-        typename std::conditional<std::is_const<value_t>::value,
-            typename std::vector<value_no_cv_t>::const_reference,
-            typename std::vector<value_no_cv_t>::reference>::type
-        reference;
-
-    /*!
-        Constant reference
-    */
-    typedef typename std::vector<value_no_cv_t>::const_reference const_reference;
-
-    /*!
         Pointer type
     */
     typedef
@@ -215,6 +201,20 @@ public:
         Constant pointer
     */
     typedef typename std::vector<value_no_cv_t>::const_pointer const_pointer;
+
+    /*!
+        Reference type
+    */
+    typedef
+        typename std::conditional<std::is_const<value_t>::value,
+            typename std::vector<value_no_cv_t>::const_reference,
+            typename std::vector<value_no_cv_t>::reference>::type
+        reference;
+
+    /*!
+        Constant reference
+    */
+    typedef typename std::vector<value_no_cv_t>::const_reference const_reference;
 
     ProxyVector();
     ProxyVector(value_t *data, std::size_t size);

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -38,7 +38,7 @@
 #include <memory>
 #include <vector>
 
-namespace bitpit{
+namespace bitpit {
 
 template<typename PXV_value_t>
 class ProxyVector;
@@ -210,7 +210,8 @@ public:
 
     bool empty() const;
     std::size_t size() const;
-    bool operator==(const ProxyVector& other) const;
+
+    bool operator==(const ProxyVector &other) const;
 
     __PXV_CONST_POINTER__ data() const noexcept;
     __PXV_POINTER__ data() noexcept;
@@ -253,9 +254,9 @@ using ConstProxyVector = ProxyVector<const value_t>;
 // Include the implementation
 #include "proxyVector.tpp"
 
-// Some commonly used ProxyVectors are instantiated explicitly
 namespace bitpit{
 
+// Some commonly used ProxyVectors are instantiated explicitly
 extern template class ProxyVector<int>;
 extern template class ProxyVector<long>;
 extern template class ProxyVector<double>;

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -154,7 +154,7 @@ public:
     typedef ProxyVectorIterator<const value_no_cv_t> const_iterator;
 
     /*!
-        Reference
+        Reference type
     */
     typedef
         typename std::conditional<std::is_const<value_t>::value,
@@ -168,7 +168,7 @@ public:
     typedef typename std::vector<value_no_cv_t>::const_reference const_reference;
 
     /*!
-        Pointer
+        Pointer type
     */
     typedef
         typename std::conditional<std::is_const<value_t>::value,

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -25,7 +25,7 @@
 #ifndef __BITPIT_PROXY_VECTOR_TPP__
 #define __BITPIT_PROXY_VECTOR_TPP__
 
-namespace bitpit{
+namespace bitpit {
 
 /*!
     Creates a new uninitialized iterator

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -37,10 +37,25 @@ ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator()
 }
 
 /*!
+    Constructor
+
+    This constructor allows to generate a constant iterator from a non
+    constnat iterator.
+
+    \param other is the iterator that will be copied
+*/
+template<typename value_t, typename value_no_cv_t>
+template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
+ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(const ProxyVectorIterator<other_value_t> &other)
+    : m_position(other.m_position)
+{
+}
+
+/*!
     Exchanges the values of the current iterator and
     the iterator recevied as argument.
 
-    \param other the iterator to exchange values with
+    \param other is the iterator to exchange values with
 */
 template<typename value_t, typename value_no_cv_t>
 void ProxyVectorIterator<value_t, value_no_cv_t>::swap(ProxyVectorIterator& other) noexcept
@@ -132,13 +147,18 @@ __PXI_POINTER__ ProxyVectorIterator<value_t, value_no_cv_t>::operator->() const
 }
 
 /*!
-    Converts the iterator to a const_iterator.
+* Copy assignment operator to create a constant iterator from a non-constant
+* one.
+*
+* \param other is the iterator that will be copied
 */
 template<typename value_t, typename value_no_cv_t>
-template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
-ProxyVectorIterator<value_t, value_no_cv_t>::operator ProxyVectorIterator<const other_value_t>() const
+template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
+ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator=(const ProxyVectorIterator<other_value_t> &other)
 {
-    return ProxyVectorIterator<const other_value_t>(m_position);
+    m_position = other.m_position;
+
+    return *this;
 }
 
 /*!
@@ -146,7 +166,7 @@ ProxyVectorIterator<value_t, value_no_cv_t>::operator ProxyVectorIterator<const 
     the const base iterator recevied in input.
 */
 template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(value_t *position)
+ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(__PXI_POINTER__ position)
     : m_position(position)
 {
 }

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -30,8 +30,8 @@ namespace bitpit{
 /*!
     Creates a new uninitialized iterator
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv>::ProxyVectorIterator()
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator()
     : m_position(nullptr)
 {
 }
@@ -42,8 +42,8 @@ ProxyVectorIterator<T, T_no_cv>::ProxyVectorIterator()
 
     \param other the iterator to exchange values with
 */
-template<typename T, typename T_no_cv>
-void ProxyVectorIterator<T, T_no_cv>::swap(ProxyVectorIterator& other) noexcept
+template<typename value_t, typename value_no_cv_t>
+void ProxyVectorIterator<value_t, value_no_cv_t>::swap(ProxyVectorIterator& other) noexcept
 {
     std::swap(m_position, other.m_position);
 }
@@ -51,8 +51,8 @@ void ProxyVectorIterator<T, T_no_cv>::swap(ProxyVectorIterator& other) noexcept
 /*!
     Pre-increment operator.
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv> & ProxyVectorIterator<T, T_no_cv>::operator++()
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator++()
 {
     m_position++;
 
@@ -62,8 +62,8 @@ ProxyVectorIterator<T, T_no_cv> & ProxyVectorIterator<T, T_no_cv>::operator++()
 /*!
     Post-increment operator.
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv> ProxyVectorIterator<T, T_no_cv>::operator++(int)
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_no_cv_t>::operator++(int)
 {
     ProxyVectorIterator tmp(m_position);
 
@@ -75,8 +75,8 @@ ProxyVectorIterator<T, T_no_cv> ProxyVectorIterator<T, T_no_cv>::operator++(int)
 /*!
     Pre-decrement operator.
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv> & ProxyVectorIterator<T, T_no_cv>::operator--()
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator--()
 {
     m_position--;
 
@@ -86,8 +86,8 @@ ProxyVectorIterator<T, T_no_cv> & ProxyVectorIterator<T, T_no_cv>::operator--()
 /*!
     Post-decrement operator.
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv> ProxyVectorIterator<T, T_no_cv>::operator--(int)
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_no_cv_t>::operator--(int)
 {
     ProxyVectorIterator tmp(m_position);
 
@@ -101,8 +101,8 @@ ProxyVectorIterator<T, T_no_cv> ProxyVectorIterator<T, T_no_cv>::operator--(int)
 
     \param increment is the increment
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv>& ProxyVectorIterator<T, T_no_cv>::operator+=(int increment)
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t>& ProxyVectorIterator<value_t, value_no_cv_t>::operator+=(int increment)
 {
     m_position += increment;
 
@@ -115,8 +115,8 @@ ProxyVectorIterator<T, T_no_cv>& ProxyVectorIterator<T, T_no_cv>::operator+=(int
     \result A reference to the element currently pointed to by the
             iterator.
 */
-template<typename T, typename T_no_cv>
-__PXI_REFERENCE__ ProxyVectorIterator<T, T_no_cv>::operator*() const
+template<typename value_t, typename value_no_cv_t>
+__PXI_REFERENCE__ ProxyVectorIterator<value_t, value_no_cv_t>::operator*() const
 {
     return *m_position;
 }
@@ -127,8 +127,8 @@ __PXI_REFERENCE__ ProxyVectorIterator<T, T_no_cv>::operator*() const
     \result A reference to the element currently pointed to by the
             iterator.
 */
-template<typename T, typename T_no_cv>
-__PXI_POINTER__ ProxyVectorIterator<T, T_no_cv>::operator->() const
+template<typename value_t, typename value_no_cv_t>
+__PXI_POINTER__ ProxyVectorIterator<value_t, value_no_cv_t>::operator->() const
 {
     return m_position;
 }
@@ -136,19 +136,19 @@ __PXI_POINTER__ ProxyVectorIterator<T, T_no_cv>::operator->() const
 /*!
     Converts the iterator to a const_iterator.
 */
-template<typename T, typename T_no_cv>
-template<typename U, typename std::enable_if<!std::is_const<U>::value, int>::type>
-ProxyVectorIterator<T, T_no_cv>::operator ProxyVectorIterator<const U>() const
+template<typename value_t, typename value_no_cv_t>
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+ProxyVectorIterator<value_t, value_no_cv_t>::operator ProxyVectorIterator<const other_value_t>() const
 {
-    return ProxyVectorIterator<const U>(m_position);
+    return ProxyVectorIterator<const other_value_t>(m_position);
 }
 
 /*!
     Creates a new iterator and initializes it with the position of
     the const base iterator recevied in input.
 */
-template<typename T, typename T_no_cv>
-ProxyVectorIterator<T, T_no_cv>::ProxyVectorIterator(T *position)
+template<typename value_t, typename value_no_cv_t>
+ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(value_t *position)
     : m_position(position)
 {
 }
@@ -159,8 +159,8 @@ ProxyVectorIterator<T, T_no_cv>::ProxyVectorIterator(T *position)
     \param other is the iterator from which the distance will be evaluated
     \result The distance between the specified iterator.
 */
-template<typename T, typename T_no_cv>
-std::size_t ProxyVectorIterator<T, T_no_cv>::operator-(const ProxyVectorIterator &other)
+template<typename value_t, typename value_no_cv_t>
+std::size_t ProxyVectorIterator<value_t, value_no_cv_t>::operator-(const ProxyVectorIterator &other)
 {
     return (m_position - other.m_position);
 }
@@ -168,8 +168,8 @@ std::size_t ProxyVectorIterator<T, T_no_cv>::operator-(const ProxyVectorIterator
 /*!
     Constructor
 */
-template<typename T>
-ProxyVector<T>::ProxyVector()
+template<typename value_t>
+ProxyVector<value_t>::ProxyVector()
     : m_data(nullptr), m_size(0)
 {
 }
@@ -180,8 +180,8 @@ ProxyVector<T>::ProxyVector()
     \param size is the number elements contained in the data
     \param data a pointer to the data
 */
-template<typename T>
-ProxyVector<T>::ProxyVector(T *data, std::size_t size)
+template<typename value_t>
+ProxyVector<value_t>::ProxyVector(value_t *data, std::size_t size)
     : m_data(data), m_size(size)
 {
 }
@@ -191,10 +191,10 @@ ProxyVector<T>::ProxyVector(T *data, std::size_t size)
 
     \param storage is the storage that contains the data
 */
-template<typename T>
-template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
-ProxyVector<T>::ProxyVector(std::vector<T_no_cv> &&storage)
-    : m_storage(std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(std::move(storage)))),
+template<typename value_t>
+template<typename other_value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type>
+ProxyVector<value_t>::ProxyVector(std::vector<value_no_cv_t> &&storage)
+    : m_storage(std::unique_ptr<std::vector<value_no_cv_t>>(new std::vector<value_no_cv_t>(std::move(storage)))),
       m_data(m_storage->data()), m_size(m_storage->size())
 {
 }
@@ -202,15 +202,15 @@ ProxyVector<T>::ProxyVector(std::vector<T_no_cv> &&storage)
 /*!
     Copy constructor.
 */
-template<typename T>
-ProxyVector<T>::ProxyVector(const ProxyVector &other)
+template<typename value_t>
+ProxyVector<value_t>::ProxyVector(const ProxyVector &other)
     : m_size(other.m_size)
 {
     if (other.m_storage) {
         if (m_storage) {
             m_storage->assign(other.m_storage->begin(), other.m_storage->end());
         } else {
-            m_storage = std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(*(other.m_storage)));
+            m_storage = std::unique_ptr<std::vector<value_no_cv_t>>(new std::vector<value_no_cv_t>(*(other.m_storage)));
         }
 
         if (other.m_data == other.m_storage->data()) {
@@ -231,8 +231,8 @@ ProxyVector<T>::ProxyVector(const ProxyVector &other)
     Assigns new contents to the container, replacing its current contents,
     and modifying its size accordingly.
 */
-template<typename T>
-ProxyVector<T> & ProxyVector<T>::operator=(const ProxyVector &other)
+template<typename value_t>
+ProxyVector<value_t> & ProxyVector<value_t>::operator=(const ProxyVector &other)
 {
     if (this != &other) {
         ProxyVector temporary(other);
@@ -248,8 +248,8 @@ ProxyVector<T> & ProxyVector<T>::operator=(const ProxyVector &other)
     \param data a pointer to the data
     \param size is the number elements contained in the data
 */
-template<typename T>
-void ProxyVector<T>::set(T *data, std::size_t size)
+template<typename value_t>
+void ProxyVector<value_t>::set(value_t *data, std::size_t size)
 {
     m_data = data;
     m_size = size;
@@ -260,11 +260,11 @@ void ProxyVector<T>::set(T *data, std::size_t size)
 
     \param storage is the storage that contains the data
 */
-template<typename T>
-template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
-typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::vector<T_no_cv> &&storage)
+template<typename value_t>
+template<typename other_value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type>
+typename ProxyVector<value_t>::value_no_cv_t * ProxyVector<value_t>::set(std::vector<value_no_cv_t> &&storage)
 {
-    m_storage = std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(std::move(storage)));
+    m_storage = std::unique_ptr<std::vector<value_no_cv_t>>(new std::vector<value_no_cv_t>(std::move(storage)));
     m_data    = m_storage->data();
     m_size    = m_storage->size();
 
@@ -277,12 +277,12 @@ typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::vector<T_no_cv> &&st
     \param size is the number of elements the storage should be able to
     contain
 */
-template<typename T>
-template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
-typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::size_t size)
+template<typename value_t>
+template<typename other_value_t, typename std::enable_if<std::is_const<other_value_t>::value, int>::type>
+typename ProxyVector<value_t>::value_no_cv_t * ProxyVector<value_t>::set(std::size_t size)
 {
     if (!m_storage) {
-        m_storage = std::unique_ptr<std::vector<T_no_cv>>(new std::vector<T_no_cv>(size));
+        m_storage = std::unique_ptr<std::vector<value_no_cv_t>>(new std::vector<value_no_cv_t>(size));
     } else {
         m_storage->resize(size);
     }
@@ -295,8 +295,8 @@ typename ProxyVector<T>::T_no_cv * ProxyVector<T>::set(std::size_t size)
 /*!
     Clear content.
 */
-template<typename T>
-void ProxyVector<T>::clear()
+template<typename value_t>
+void ProxyVector<value_t>::clear()
 {
     m_data = nullptr;
     m_size = 0;
@@ -309,8 +309,8 @@ void ProxyVector<T>::clear()
 
     \param other is another container of the same type
 */
-template<typename T>
-void ProxyVector<T>::swap(ProxyVector &other)
+template<typename value_t>
+void ProxyVector<value_t>::swap(ProxyVector &other)
 {
     std::swap(m_data, other.m_data);
     std::swap(m_size, other.m_size);
@@ -323,10 +323,10 @@ void ProxyVector<T>::swap(ProxyVector &other)
 
     \result true if the containers are equal, false otherwise.
 */
-template<typename T>
-bool ProxyVector<T>::operator==(const ProxyVector& rhs) const
+template<typename value_t>
+bool ProxyVector<value_t>::operator==(const ProxyVector& other) const
 {
-    return m_size == rhs.m_size && m_data == rhs.m_data && m_storage == rhs.m_storage;
+    return m_size == other.m_size && m_data == other.m_data && m_storage == other.m_storage;
 }
 
 /*!
@@ -334,8 +334,8 @@ bool ProxyVector<T>::operator==(const ProxyVector& rhs) const
 
     \result true if the container size is 0, false otherwise.
 */
-template<typename T>
-bool ProxyVector<T>::empty() const
+template<typename value_t>
+bool ProxyVector<value_t>::empty() const
 {
     return size() == 0;
 }
@@ -345,8 +345,8 @@ bool ProxyVector<T>::empty() const
 
     \result The number of elements in the container.
 */
-template<typename T>
-std::size_t ProxyVector<T>::size() const
+template<typename value_t>
+std::size_t ProxyVector<value_t>::size() const
 {
     return m_size;
 }
@@ -358,8 +358,8 @@ std::size_t ProxyVector<T>::size() const
     \result A direct constant pointer to the memory where the elments are
     stored.
 */
-template<typename T>
-__PXV_CONST_POINTER__ ProxyVector<T>::data() const noexcept
+template<typename value_t>
+__PXV_CONST_POINTER__ ProxyVector<value_t>::data() const noexcept
 {
     return m_data;
 }
@@ -369,8 +369,8 @@ __PXV_CONST_POINTER__ ProxyVector<T>::data() const noexcept
 
     \result A direct pointer to the memory where the elments are stored.
 */
-template<typename T>
-__PXV_POINTER__ ProxyVector<T>::data() noexcept
+template<typename value_t>
+__PXV_POINTER__ ProxyVector<value_t>::data() noexcept
 {
     return m_data;
 }
@@ -381,8 +381,8 @@ __PXV_POINTER__ ProxyVector<T>::data() noexcept
     \param n is the position of the requested element
     \result A constant reference to the specified element.
 */
-template<typename T>
-__PXV_CONST_REFERENCE__ ProxyVector<T>::operator[](std::size_t n) const
+template<typename value_t>
+__PXV_CONST_REFERENCE__ ProxyVector<value_t>::operator[](std::size_t n) const
 {
     return m_data[n];
 }
@@ -393,8 +393,8 @@ __PXV_CONST_REFERENCE__ ProxyVector<T>::operator[](std::size_t n) const
     \param n is the position of the requested element
     \result A reference to the specified element.
 */
-template<typename T>
-__PXV_REFERENCE__ ProxyVector<T>::operator[](std::size_t n)
+template<typename value_t>
+__PXV_REFERENCE__ ProxyVector<value_t>::operator[](std::size_t n)
 {
     return m_data[n];
 }
@@ -405,8 +405,8 @@ __PXV_REFERENCE__ ProxyVector<T>::operator[](std::size_t n)
     \param n is the position of the requested element
     \result A constant reference to the specified element.
 */
-template<typename T>
-__PXV_CONST_REFERENCE__ ProxyVector<T>::at(std::size_t n) const
+template<typename value_t>
+__PXV_CONST_REFERENCE__ ProxyVector<value_t>::at(std::size_t n) const
 {
     return m_data[n];
 }
@@ -417,8 +417,8 @@ __PXV_CONST_REFERENCE__ ProxyVector<T>::at(std::size_t n) const
     \param n is the position of the requested element
     \result A reference to the specified element.
 */
-template<typename T>
-__PXV_REFERENCE__ ProxyVector<T>::at(std::size_t n)
+template<typename value_t>
+__PXV_REFERENCE__ ProxyVector<value_t>::at(std::size_t n)
 {
     return m_data[n];
 }
@@ -428,8 +428,8 @@ __PXV_REFERENCE__ ProxyVector<T>::at(std::size_t n)
 
     \result A constant reference to the first element in the container.
 */
-template<typename T>
-__PXV_CONST_REFERENCE__ ProxyVector<T>::front() const
+template<typename value_t>
+__PXV_CONST_REFERENCE__ ProxyVector<value_t>::front() const
 {
     return m_data[0];
 }
@@ -439,8 +439,8 @@ __PXV_CONST_REFERENCE__ ProxyVector<T>::front() const
 
     \result A reference to the first element in the container.
 */
-template<typename T>
-__PXV_REFERENCE__ ProxyVector<T>::front()
+template<typename value_t>
+__PXV_REFERENCE__ ProxyVector<value_t>::front()
 {
     return m_data[0];
 }
@@ -450,8 +450,8 @@ __PXV_REFERENCE__ ProxyVector<T>::front()
 
     \result A constant reference to the last element in the container.
 */
-template<typename T>
-__PXV_CONST_REFERENCE__ ProxyVector<T>::back() const
+template<typename value_t>
+__PXV_CONST_REFERENCE__ ProxyVector<value_t>::back() const
 {
     return m_data[m_size - 1];
 }
@@ -461,8 +461,8 @@ __PXV_CONST_REFERENCE__ ProxyVector<T>::back() const
 
     \result A reference to the last element in the container.
 */
-template<typename T>
-__PXV_REFERENCE__ ProxyVector<T>::back()
+template<typename value_t>
+__PXV_REFERENCE__ ProxyVector<value_t>::back()
 {
     return m_data[m_size - 1];
 }
@@ -472,8 +472,8 @@ __PXV_REFERENCE__ ProxyVector<T>::back()
 
     \result An iterator pointing to the first element in the container.
 */
-template<typename T>
-__PXV_ITERATOR__ ProxyVector<T>::begin()
+template<typename value_t>
+__PXV_ITERATOR__ ProxyVector<value_t>::begin()
 {
     return iterator(m_data);
 }
@@ -483,8 +483,8 @@ __PXV_ITERATOR__ ProxyVector<T>::begin()
 
     \result An iterator referring to the past-the-end element in the container.
 */
-template<typename T>
-__PXV_ITERATOR__ ProxyVector<T>::end()
+template<typename value_t>
+__PXV_ITERATOR__ ProxyVector<value_t>::end()
 {
     return iterator(m_data + m_size);
 }
@@ -494,8 +494,8 @@ __PXV_ITERATOR__ ProxyVector<T>::end()
 
     \result A constant iterator pointing to the first element in the container.
 */
-template<typename T>
-__PXV_CONST_ITERATOR__ ProxyVector<T>::begin() const
+template<typename value_t>
+__PXV_CONST_ITERATOR__ ProxyVector<value_t>::begin() const
 {
     return const_iterator(m_data);
 }
@@ -507,8 +507,8 @@ __PXV_CONST_ITERATOR__ ProxyVector<T>::begin() const
     \result A constant iterator referring to the past-the-end element in the
     container.
 */
-template<typename T>
-__PXV_CONST_ITERATOR__ ProxyVector<T>::end() const
+template<typename value_t>
+__PXV_CONST_ITERATOR__ ProxyVector<value_t>::end() const
 {
     return const_iterator(m_data + m_size);
 }
@@ -518,8 +518,8 @@ __PXV_CONST_ITERATOR__ ProxyVector<T>::end() const
 
     \result A constant iterator pointing to the first element in the container.
 */
-template<typename T>
-__PXV_CONST_ITERATOR__ ProxyVector<T>::cbegin()
+template<typename value_t>
+__PXV_CONST_ITERATOR__ ProxyVector<value_t>::cbegin()
 {
     return const_iterator(m_data);
 }
@@ -531,8 +531,8 @@ __PXV_CONST_ITERATOR__ ProxyVector<T>::cbegin()
     \result A constant iterator referring to the past-the-end element in the
     container.
 */
-template<typename T>
-__PXV_CONST_ITERATOR__ ProxyVector<T>::cend()
+template<typename value_t>
+__PXV_CONST_ITERATOR__ ProxyVector<value_t>::cend()
 {
     return const_iterator(m_data + m_size);
 }

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -28,7 +28,7 @@
 namespace bitpit {
 
 /*!
-    Creates a new uninitialized iterator
+    Constructor
 */
 template<typename value_t, typename value_no_cv_t>
 ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator()
@@ -112,8 +112,7 @@ ProxyVectorIterator<value_t, value_no_cv_t>& ProxyVectorIterator<value_t, value_
 /*!
     Deference operator.
 
-    \result A reference to the element currently pointed to by the
-            iterator.
+    \result A reference to the element currently pointed to by the iterator.
 */
 template<typename value_t, typename value_no_cv_t>
 __PXI_REFERENCE__ ProxyVectorIterator<value_t, value_no_cv_t>::operator*() const
@@ -124,8 +123,7 @@ __PXI_REFERENCE__ ProxyVectorIterator<value_t, value_no_cv_t>::operator*() const
 /*!
     Deference operator.
 
-    \result A reference to the element currently pointed to by the
-            iterator.
+    \result A reference to the element currently pointed to by the iterator.
 */
 template<typename value_t, typename value_no_cv_t>
 __PXI_POINTER__ ProxyVectorIterator<value_t, value_no_cv_t>::operator->() const
@@ -305,7 +303,7 @@ void ProxyVector<value_t>::clear()
 }
 
 /*!
-    Swaps the contents.
+    Swaps the content.
 
     \param other is another container of the same type
 */

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -370,6 +370,18 @@ std::size_t ProxyVector<value_t>::size() const
 }
 
 /*!
+    Returns a direct pointer to the memory where the elments are stored.
+
+    \result A direct pointer to the memory where the elments are stored.
+*/
+template<typename value_t>
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_POINTER__ ProxyVector<value_t>::data() noexcept
+{
+    return m_data;
+}
+
+/*!
     Returns a direct constant pointer to the memory where the elments are
     stored.
 
@@ -383,14 +395,16 @@ __PXV_CONST_POINTER__ ProxyVector<value_t>::data() const noexcept
 }
 
 /*!
-    Returns a direct pointer to the memory where the elments are stored.
+    Returns a reference to the specified element.
 
-    \result A direct pointer to the memory where the elments are stored.
+    \param n is the position of the requested element
+    \result A reference to the specified element.
 */
 template<typename value_t>
-__PXV_POINTER__ ProxyVector<value_t>::data() noexcept
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_REFERENCE__ ProxyVector<value_t>::operator[](std::size_t n)
 {
-    return m_data;
+    return m_data[n];
 }
 
 /*!
@@ -412,7 +426,8 @@ __PXV_CONST_REFERENCE__ ProxyVector<value_t>::operator[](std::size_t n) const
     \result A reference to the specified element.
 */
 template<typename value_t>
-__PXV_REFERENCE__ ProxyVector<value_t>::operator[](std::size_t n)
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_REFERENCE__ ProxyVector<value_t>::at(std::size_t n)
 {
     return m_data[n];
 }
@@ -430,15 +445,15 @@ __PXV_CONST_REFERENCE__ ProxyVector<value_t>::at(std::size_t n) const
 }
 
 /*!
-    Returns a reference to the specified element.
+    Gets a reference to the first element in the container.
 
-    \param n is the position of the requested element
-    \result A reference to the specified element.
+    \result A reference to the first element in the container.
 */
 template<typename value_t>
-__PXV_REFERENCE__ ProxyVector<value_t>::at(std::size_t n)
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_REFERENCE__ ProxyVector<value_t>::front()
 {
-    return m_data[n];
+    return m_data[0];
 }
 
 /*!
@@ -453,14 +468,15 @@ __PXV_CONST_REFERENCE__ ProxyVector<value_t>::front() const
 }
 
 /*!
-    Gets a reference to the first element in the container.
+    Gets a reference to the last element in the container.
 
-    \result A reference to the first element in the container.
+    \result A reference to the last element in the container.
 */
 template<typename value_t>
-__PXV_REFERENCE__ ProxyVector<value_t>::front()
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_REFERENCE__ ProxyVector<value_t>::back()
 {
-    return m_data[0];
+    return m_data[m_size - 1];
 }
 
 /*!
@@ -475,36 +491,15 @@ __PXV_CONST_REFERENCE__ ProxyVector<value_t>::back() const
 }
 
 /*!
-    Gets a reference to the last element in the container.
-
-    \result A reference to the last element in the container.
-*/
-template<typename value_t>
-__PXV_REFERENCE__ ProxyVector<value_t>::back()
-{
-    return m_data[m_size - 1];
-}
-
-/*!
     Returns an iterator pointing to the first element in the container.
 
     \result An iterator pointing to the first element in the container.
 */
 template<typename value_t>
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
 __PXV_ITERATOR__ ProxyVector<value_t>::begin()
 {
     return iterator(m_data);
-}
-
-/*!
-    Returns an iterator referring to the past-the-end element in the container.
-
-    \result An iterator referring to the past-the-end element in the container.
-*/
-template<typename value_t>
-__PXV_ITERATOR__ ProxyVector<value_t>::end()
-{
-    return iterator(m_data + m_size);
 }
 
 /*!
@@ -516,6 +511,18 @@ template<typename value_t>
 __PXV_CONST_ITERATOR__ ProxyVector<value_t>::begin() const
 {
     return const_iterator(m_data);
+}
+
+/*!
+    Returns an iterator referring to the past-the-end element in the container.
+
+    \result An iterator referring to the past-the-end element in the container.
+*/
+template<typename value_t>
+template<typename other_value_t, typename std::enable_if<!std::is_const<other_value_t>::value, int>::type>
+__PXV_ITERATOR__ ProxyVector<value_t>::end()
+{
+    return iterator(m_data + m_size);
 }
 
 /*!

--- a/src/discretization/stencil_solver.tpp
+++ b/src/discretization/stencil_solver.tpp
@@ -229,7 +229,8 @@ void DiscretizationStencilSolverAssembler<stencil_t>::getRowPattern(long rowInde
         pattern->set(patternData, stencilSize);
     } else {
         std::size_t expandedPatternSize = m_blockSize * stencilSize;
-        long *expandedPatternStorage = pattern->set(expandedPatternSize);
+        pattern->set(ConstProxyVector<long>::INTERNAL_STORAGE, expandedPatternSize);
+        ConstProxyVector<long>::storage_pointer expandedPatternStorage = pattern->storedData();
 
         std::size_t expandedPatternIdx = 0;
         for (std::size_t k = 0; k < stencilSize; ++k) {
@@ -288,7 +289,8 @@ void DiscretizationStencilSolverAssembler<stencil_t>::_getRowValues(long rowInde
     const typename stencil_t::weight_type *weightData = stencil.weightData();
 
     std::size_t expandedValuesSize = m_blockSize * stencilSize;
-    double *expandedValuesStorage = values->set(expandedValuesSize);
+    values->set(ConstProxyVector<double>::INTERNAL_STORAGE, expandedValuesSize);
+    ConstProxyVector<double>::storage_pointer expandedValuesStorage = values->storedData();
 
     std::size_t expandedValuesIdx = 0;
     for (std::size_t k = 0; k < stencilSize; ++k) {

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -115,7 +115,8 @@ void SegmentationKernel::setSurface( const SurfUnstructured *surface, double fea
     m_featureAngle = featureAngle;
 
     // Check if segment is supported
-    for( SurfUnstructured::CellConstIterator segmentItr = m_surface->cellConstBegin(); segmentItr != m_surface->cellConstEnd(); ++segmentItr ){
+    SurfUnstructured::CellConstIterator endItr = m_surface->cellConstEnd();
+    for( SurfUnstructured::CellConstIterator segmentItr = m_surface->cellConstBegin(); segmentItr != endItr; ++segmentItr ){
         switch (segmentItr->getType()) {
 
         case ElementType::VERTEX :

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -214,9 +214,12 @@ void PatchNumberingInfo::_extract()
 
 	// Evalaute the consecutive id of the internal cells
 	if (m_patch->getInternalCellCount() > 0) {
+		PatchKernel::CellConstIterator beginItr = m_patch->internalCellConstBegin();
+		PatchKernel::CellConstIterator endItr   = m_patch->internalCellConstEnd();
+
 		std::size_t index = 0;
 		std::vector<std::pair<long, long>> nativeIds(m_patch->getInternalCellCount());
-		for (auto itr = m_patch->internalCellConstBegin(); itr != m_patch->internalCellConstEnd(); ++itr) {
+		for (PatchKernel::CellConstIterator itr = beginItr; itr != endItr; ++itr) {
 			long id = itr.getId();
 			long nativeId = m_patch->_getCellNativeIndex(id);
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -6103,7 +6103,7 @@ void PatchKernel::resetInterfaceAlterationFlags(long id, AlterationFlags flags)
 */
 void PatchKernel::setInterfaceAlterationFlags(AlterationFlags flags)
 {
-	for (CellIterator itr = cellBegin(); itr != cellEnd(); ++itr) {
+	for (InterfaceIterator itr = interfaceBegin(); itr != interfaceEnd(); ++itr) {
 		setInterfaceAlterationFlags(itr.getId(), flags);
 	}
 }

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1079,7 +1079,8 @@ void PatchKernel::write(VTKWriteMode mode)
 	int vtkVertexCount = 0;
 	m_vtkVertexMap.unsetKernel(true);
 	m_vtkVertexMap.setStaticKernel(&m_vertices);
-	for (VertexConstIterator itr = vertexConstBegin(); itr != vertexConstEnd(); ++itr) {
+	VertexConstIterator endItr = vertexConstEnd();
+	for (VertexConstIterator itr = vertexConstBegin(); itr != endItr; ++itr) {
 		std::size_t vertexRawId = itr.getRawIndex();
 		if (vertexWriteFlag.rawAt(vertexRawId)) {
 			m_vtkVertexMap.rawAt(vertexRawId) = vtkVertexCount++;
@@ -1352,8 +1353,11 @@ void PatchKernel::setVertexAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		VertexConstIterator beginItr = m_vertices.cbegin();
+		VertexConstIterator endItr   = m_vertices.cend();
+
 		m_vertexIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
-		for (auto itr = m_vertices.begin(); itr != m_vertices.end(); ++itr) {
+		for (VertexConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_vertexIdGenerator->setAssigned(itr.getId());
 		}
 	} else {
@@ -1860,6 +1864,9 @@ long PatchKernel::countOrphanVertices() const
 */
 std::vector<long> PatchKernel::findOrphanVertices()
 {
+	VertexConstIterator beginItr = m_vertices.cbegin();
+	VertexConstIterator endItr   = m_vertices.cend();
+
 	// Detect used vertices
 	PiercedStorage<bool, long> vertexUsedFlag(1, &m_vertices);
 	vertexUsedFlag.fill(false);
@@ -1874,7 +1881,7 @@ std::vector<long> PatchKernel::findOrphanVertices()
 
 	// Count the orphan vertices
 	std::size_t nOrhpanVertices = 0;
-	for (auto itr = m_vertices.begin(); itr != m_vertices.end(); ++itr) {
+	for (VertexConstIterator itr = beginItr; itr != endItr; ++itr) {
 		std::size_t vertexRawIndex = itr.getRawIndex();
 		if (!vertexUsedFlag.rawAt(vertexRawIndex)) {
 			++nOrhpanVertices;
@@ -1885,7 +1892,7 @@ std::vector<long> PatchKernel::findOrphanVertices()
 	std::vector<long> orhpanVertices(nOrhpanVertices);
 
 	std::size_t orphanVertexIndex = 0;
-	for (auto itr = m_vertices.begin(); itr != m_vertices.end(); ++itr) {
+	for (VertexConstIterator itr = beginItr; itr != endItr; ++itr) {
 		std::size_t vertexRawIndex = itr.getRawIndex();
 		if (!vertexUsedFlag.rawAt(vertexRawIndex)) {
 			orhpanVertices[orphanVertexIndex] = itr.getId();
@@ -2099,8 +2106,11 @@ void PatchKernel::setCellAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		CellConstIterator beginItr = m_cells.cbegin();
+		CellConstIterator endItr   = m_cells.cend();
+
 		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
-		for (auto itr = m_cells.begin(); itr != m_cells.end(); ++itr) {
+		for (CellConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_cellIdGenerator->setAssigned(itr.getId());
 		}
 	} else {
@@ -3689,8 +3699,11 @@ void PatchKernel::setInterfaceAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		InterfaceConstIterator beginItr = m_interfaces.cbegin();
+		InterfaceConstIterator endItr   = m_interfaces.cend();
+
 		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
-		for (auto itr = m_interfaces.begin(); itr != m_interfaces.end(); ++itr) {
+		for (InterfaceConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_interfaceIdGenerator->setAssigned(itr.getId());
 		}
 	} else {
@@ -4148,7 +4161,8 @@ long PatchKernel::countFreeInterfaces() const
 long PatchKernel::countOrphanInterfaces() const
 {
 	long nOrphanInterfaces = 0;
-	for (InterfaceConstIterator itr = interfaceConstBegin(); itr != interfaceConstEnd(); ++itr) {
+	InterfaceConstIterator endItr = interfaceConstEnd();
+	for (InterfaceConstIterator itr = interfaceConstBegin(); itr != endItr; ++itr) {
 		const long interfaceId = itr.getId();
 		if (isInterfaceOrphan(interfaceId)) {
 			++nOrphanInterfaces;
@@ -4169,7 +4183,8 @@ long PatchKernel::countOrphanInterfaces() const
 std::vector<long> PatchKernel::findOrphanInterfaces() const
 {
 	std::vector<long> orphanInterfaces;
-	for (InterfaceConstIterator itr = interfaceConstBegin(); itr != interfaceConstEnd(); ++itr) {
+	InterfaceConstIterator endItr = interfaceConstEnd();
+	for (InterfaceConstIterator itr = interfaceConstBegin(); itr != endItr; ++itr) {
 		const long interfaceId = itr.getId();
 		if (isInterfaceOrphan(interfaceId)) {
 			orphanInterfaces.push_back(interfaceId);
@@ -6025,7 +6040,8 @@ void PatchKernel::resetCellAlterationFlags(long id, AlterationFlags flags)
 */
 void PatchKernel::setCellAlterationFlags(AlterationFlags flags)
 {
-	for (CellIterator itr = cellBegin(); itr != cellEnd(); ++itr) {
+	CellConstIterator endItr = cellConstEnd();
+	for (CellConstIterator itr = cellConstBegin(); itr != endItr; ++itr) {
 		setCellAlterationFlags(itr.getId(), flags);
 	}
 }
@@ -6103,7 +6119,8 @@ void PatchKernel::resetInterfaceAlterationFlags(long id, AlterationFlags flags)
 */
 void PatchKernel::setInterfaceAlterationFlags(AlterationFlags flags)
 {
-	for (InterfaceIterator itr = interfaceBegin(); itr != interfaceEnd(); ++itr) {
+	InterfaceConstIterator endItr = interfaceConstEnd();
+	for (InterfaceConstIterator itr = interfaceConstBegin(); itr != endItr; ++itr) {
 		setInterfaceAlterationFlags(itr.getId(), flags);
 	}
 }
@@ -6990,7 +7007,8 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 	BITPIT_UNUSED(format);
 
 	if (name == "Points") {
-		for (VertexConstIterator itr = vertexConstBegin(); itr != vertexConstEnd(); ++itr) {
+		VertexConstIterator endItr = vertexConstEnd();
+		for (VertexConstIterator itr = vertexConstBegin(); itr != endItr; ++itr) {
 			std::size_t vertexRawId = itr.getRawIndex();
 			long vertexVTKId = m_vtkVertexMap.rawAt(vertexRawId);
 			if (vertexVTKId != Vertex::NULL_ID) {
@@ -7108,7 +7126,8 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			genericIO::flushBINARY(stream, cell.getPID());
 		}
 	} else if (name == "vertexIndex") {
-		for (VertexConstIterator itr = vertexConstBegin(); itr != vertexConstEnd(); ++itr) {
+		VertexConstIterator endItr = vertexConstEnd();
+		for (VertexConstIterator itr = vertexConstBegin(); itr != endItr; ++itr) {
 			std::size_t vertexRawId = itr.getRawIndex();
 			long vertexVTKId = m_vtkVertexMap.rawAt(vertexRawId);
 			if (vertexVTKId != Vertex::NULL_ID) {
@@ -7127,7 +7146,8 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			genericIO::flushBINARY(stream, getCellRank(cell.getId()));
 		}
 	} else if (name == "vertexRank") {
-		for (VertexConstIterator itr = vertexConstBegin(); itr != vertexConstEnd(); ++itr) {
+		VertexConstIterator endItr = vertexConstEnd();
+		for (VertexConstIterator itr = vertexConstBegin(); itr != endItr; ++itr) {
 			std::size_t vertexRawId = itr.getRawIndex();
 			long vertexVTKId = m_vtkVertexMap.rawAt(vertexRawId);
 			if (vertexVTKId != Vertex::NULL_ID) {

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -4924,13 +4924,10 @@ ConstProxyVector<std::array<double, 3>> PatchKernel::getCellVertexCoordinates(lo
 	ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
 	const int nCellVertices = cellVertexIds.size();
 
-	// Store coordinates in storage
-	std::vector<std::array<double, 3>> storage(nCellVertices);
-	getVertexCoords(cellVertexIds.size(), cellVertexIds.data(), storage.data());
-
 	// Build the proxy vector with the coordinates
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates;
-	vertexCoordinates.set(std::move(storage));
+	ConstProxyVector<std::array<double, 3>> vertexCoordinates(ConstProxyVector<std::array<double, 3>>::INTERNAL_STORAGE, nCellVertices);
+	ConstProxyVector<std::array<double, 3>>::storage_pointer storage = vertexCoordinates.storedData();
+	getVertexCoords(cellVertexIds.size(), cellVertexIds.data(), storage);
 
 	return vertexCoordinates;
 }
@@ -5003,13 +5000,10 @@ ConstProxyVector<std::array<double, 3>> PatchKernel::getInterfaceVertexCoordinat
 	ConstProxyVector<long> interfaceVertexIds = interface.getVertexIds();
 	const int nInterfaceVertices = interfaceVertexIds.size();
 
-	// Store coordinates in storage
-	std::vector<std::array<double, 3>> storage(nInterfaceVertices);
-	getVertexCoords(interfaceVertexIds.size(), interfaceVertexIds.data(), storage.data());
-
 	// Build the proxy vector with the coordinates
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates;
-	vertexCoordinates.set(std::move(storage));
+	ConstProxyVector<std::array<double, 3>> vertexCoordinates(ConstProxyVector<std::array<double, 3>>::INTERNAL_STORAGE, nInterfaceVertices);
+	ConstProxyVector<std::array<double, 3>>::storage_pointer storage = vertexCoordinates.storedData();
+	getVertexCoords(interfaceVertexIds.size(), interfaceVertexIds.data(), storage);
 
 	return vertexCoordinates;
 }
@@ -6535,13 +6529,10 @@ ConstProxyVector<std::array<double, 3>> PatchKernel::getElementVertexCoordinates
 	ConstProxyVector<long> elementVertexIds = element.getVertexIds();
 	const int nElementVertices = elementVertexIds.size();
 
-	// Store coordinates in storage
-	std::vector<std::array<double, 3>> storage(nElementVertices);
-	getVertexCoords(elementVertexIds.size(), elementVertexIds.data(), storage.data());
-
 	// Build the proxy vector with the coordinates
-	ConstProxyVector<std::array<double, 3>> vertexCoordinates;
-	vertexCoordinates.set(std::move(storage));
+	ConstProxyVector<std::array<double, 3>> vertexCoordinates(ConstProxyVector<std::array<double, 3>>::INTERNAL_STORAGE, nElementVertices);
+	ConstProxyVector<std::array<double, 3>>::storage_pointer storage = vertexCoordinates.storedData();
+	getVertexCoords(elementVertexIds.size(), elementVertexIds.data(), storage);
 
 	return vertexCoordinates;
 }

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -1673,8 +1673,11 @@ double PatchKernel::evalPartitioningUnbalance(const std::unordered_map<long, dou
 	// Evaluate partition weight
 	double partitionWeight;
 	if (!cellWeights.empty()) {
+		CellConstIterator beginItr = internalCellConstBegin();
+		CellConstIterator endItr   = internalCellConstEnd();
+
 		partitionWeight = 0.;
-		for (auto cellItr = internalCellConstBegin(); cellItr != internalCellConstEnd(); ++cellItr) {
+		for (CellConstIterator cellItr = beginItr; cellItr != endItr; ++cellItr) {
 			long cellId = cellItr.getId();
 
 			double cellWeight;
@@ -2759,7 +2762,8 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
     // We may received cells that connect to the existing mesh through one
     // of the faces that are now borders. Marking those border interfaces as
     // dangling allows to delete them and create new internal interfaces.
-    for (auto itr = ghostCellConstBegin(); itr != ghostCellConstEnd(); ++itr) {
+    CellConstIterator endItr = ghostCellConstEnd();
+    for (CellConstIterator itr = ghostCellConstBegin(); itr != endItr; ++itr) {
         const Cell &cell = *itr;
         const long *interfaces = cell.getInterfaces();
         const int nCellInterfaces = cell.getInterfaceCount();
@@ -3846,9 +3850,12 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 	// List of vertices that are no more ghosts.
 	//
 	// Previous ghost vertices will be converted to internal vertices.
+	VertexConstIterator previousBeginItr = ghostVertexConstBegin();
+	VertexConstIterator previousEndItr   = ghostVertexConstEnd();
+
 	std::vector<long> previousGhosts;
 	previousGhosts.reserve(getGhostVertexCount());
-	for (VertexConstIterator vertexItr = ghostVertexBegin(); vertexItr != ghostVertexEnd(); ++vertexItr) {
+	for (VertexConstIterator vertexItr = previousBeginItr; vertexItr != previousEndItr; ++vertexItr) {
 		long vertexId = vertexItr.getId();
 		if (exchangeVertexOwners.count(vertexId) != 0) {
 			continue;
@@ -3886,7 +3893,10 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 	}
 
 	// Set the owner of the existing ghosts
-	for (VertexConstIterator vertexItr = ghostVertexBegin(); vertexItr != ghostVertexEnd(); ++vertexItr) {
+	VertexConstIterator beginItr = ghostVertexConstEnd();
+	VertexConstIterator endItr   = ghostVertexConstEnd();
+
+	for (VertexConstIterator vertexItr = beginItr; vertexItr != endItr; ++vertexItr) {
 		long vertexId = vertexItr->getId();
 		int vertexOwner = exchangeVertexOwners.at(vertexId);
 		setGhostVertexOwner(vertexId, vertexOwner);

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -272,8 +272,11 @@ void VolCartesian::resetInterfaces()
 void VolCartesian::_updateAdjacencies()
 {
 	// Partial updates are not supported
+	CellConstIterator beginItr = cellConstBegin();
+	CellConstIterator endItr   = cellConstEnd();
+
 	bool partialUpdate = false;
-	for (auto cellIterator = cellBegin(); cellIterator != cellEnd(); ++cellIterator) {
+	for (CellConstIterator cellIterator = beginItr; cellIterator != endItr; ++cellIterator) {
 		long cellId = cellIterator.getId();
 		if (!testCellAlterationFlags(cellId, FLAG_ADJACENCIES_DIRTY)) {
 			partialUpdate = true;
@@ -318,8 +321,11 @@ void VolCartesian::_updateAdjacencies()
 void VolCartesian::_updateInterfaces()
 {
 	// Partial updates are not supported
+	CellConstIterator beginItr = cellConstBegin();
+	CellConstIterator endItr   = cellConstEnd();
+
 	bool partialUpdate = false;
-	for (auto cellIterator = cellBegin(); cellIterator != cellEnd(); ++cellIterator) {
+	for (CellConstIterator cellIterator = beginItr; cellIterator != endItr; ++cellIterator) {
 		long cellId = cellIterator.getId();
 		if (!testCellAlterationFlags(cellId, FLAG_INTERFACES_DIRTY)) {
 			partialUpdate = true;

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -588,7 +588,8 @@ void VolOctree::setBoundingBox()
 #if BITPIT_ENABLE_MPI==1
 	// The tree is only evaluating the bounding box of the internal octants,
 	// we need to consider also ghosts cells.
-	for (auto ghostCellItr = ghostCellBegin(); ghostCellItr != ghostCellEnd(); ++ghostCellItr) {
+	CellConstIterator endItr = ghostCellConstEnd();
+	for (CellConstIterator ghostCellItr = ghostCellConstBegin(); ghostCellItr != endItr; ++ghostCellItr) {
 		ConstProxyVector<long> ghostVertexIds = ghostCellItr->getVertexIds();
 		int nGhostCellVertices = ghostVertexIds.size();
 		for (int i = 0; i < nGhostCellVertices; ++i) {
@@ -1021,10 +1022,13 @@ std::vector<adaption::Info> VolOctree::_adaptionPrepare(bool trackAdaption)
 #if BITPIT_ENABLE_MPI==1
 		// Ghost cells will be removed
 		if (isPartitioned() && getGhostCellCount() > 0) {
+			CellConstIterator beginItr = ghostCellConstBegin();
+			CellConstIterator endItr   = ghostCellConstEnd();
+
 			std::size_t adaptionInfoId = adaptionData.create(adaption::TYPE_DELETION, adaption::ENTITY_CELL, currentRank);
 			adaption::Info &adaptionInfo = adaptionData[adaptionInfoId];
 			adaptionInfo.previous.reserve(getGhostCellCount());
-			for (auto itr = ghostCellBegin(); itr != ghostCellEnd(); ++itr) {
+			for (CellConstIterator itr = beginItr; itr != endItr; ++itr) {
 				adaptionInfo.previous.emplace_back();
 				long &deletedGhostCellId = adaptionInfo.previous.back();
 				deletedGhostCellId = itr.getId();

--- a/src/voloctree/voloctree_parallel.cpp
+++ b/src/voloctree/voloctree_parallel.cpp
@@ -259,9 +259,12 @@ void VolOctree::computePartitioningOctantWeights(const std::unordered_map<long, 
 		return;
 	}
 
+	CellConstIterator beginItr = internalCellConstBegin();
+	CellConstIterator endItr   = internalCellConstEnd();
+
 	std::size_t nOctants = m_tree->getNumOctants();
 	m_partitioningOctantWeights = std::unique_ptr<std::vector<double>>(new std::vector<double>(nOctants, defaultWeight));
-	for (auto cellItr = internalCellConstBegin(); cellItr != internalCellConstEnd(); ++cellItr) {
+	for (CellConstIterator cellItr = beginItr; cellItr != endItr; ++cellItr) {
 		long cellId = cellItr.getId();
 		auto weightItr = cellWeights.find(cellId);
 		if (weightItr != cellWeights.end()) {

--- a/test/containers/test_containers_00001.cpp
+++ b/test/containers/test_containers_00001.cpp
@@ -431,6 +431,100 @@ int subtest_001()
 }
 
 /*!
+* Subtest 002
+*
+* Testing basic PiercedVectorIterator features.
+*/
+int subtest_002()
+{
+	// Creating an emtpy PiercedVector
+	std::cout << std::endl << "::: Creating an empty PiercedVector :::" << std::endl;
+	std::cout << std::endl;
+
+	std::cout << "  Pierced vector created" << std::endl;
+
+	PiercedVector<double> container;
+
+	// Filling the PiercedVector
+	std::cout << std::endl << "::: Filling the vector :::" << std::endl;
+
+	int nElements = 10;
+	fillContainer(nElements, container);
+
+	printElements(container);
+
+	// Testing iterator
+	std::cout << std::endl << "::: Testing iterator :::" << std::endl;
+
+	PiercedVector<double>::iterator piercedItr1 = container.begin();
+	if (*piercedItr1 != container.front()) {
+		return 1;
+	}
+	piercedItr1 = container.end();
+
+	PiercedVector<double>::iterator piercedItr2;
+	piercedItr2 = container.begin();
+	if (*piercedItr2 != container.front()) {
+		return 1;
+	}
+	piercedItr2 = container.end();
+
+	// Testing constant iterator
+	std::cout << std::endl << "::: Testing constant iterator :::" << std::endl;
+
+	PiercedVector<double>::const_iterator piercedConstItr1 = container.cbegin();
+	if (*piercedConstItr1 != container.front()) {
+		return 1;
+	}
+	piercedConstItr1++;
+	++piercedConstItr1;
+	if (*piercedConstItr1 != container[2]) {
+		return 1;
+	}
+	piercedConstItr1 = container.cend();
+
+	PiercedVector<double>::const_iterator piercedConstItr2 = container.begin();
+	if (*piercedConstItr2 != container.front()) {
+		return 1;
+	}
+	piercedConstItr2++;
+	++piercedConstItr2;
+	if (*piercedConstItr2 != container[2]) {
+		return 1;
+	}
+	piercedConstItr2 = container.end();
+
+	PiercedVector<double>::const_iterator piercedConstItr3;
+	piercedConstItr3 = container.begin();
+	if (*piercedConstItr3 != container.front()) {
+		return 1;
+	}
+	piercedConstItr3++;
+	++piercedConstItr3;
+	if (*piercedConstItr3 != container[2]) {
+		return 1;
+	}
+	piercedConstItr3 = container.end();
+
+	PiercedVector<double>::const_iterator piercedConstItr4;
+	piercedConstItr4 = container.cbegin();
+	if (*piercedConstItr4 != container.front()) {
+		return 1;
+	}
+	piercedConstItr4++;
+	++piercedConstItr4;
+	if (*piercedConstItr4 != container[2]) {
+		return 1;
+	}
+	piercedConstItr4 = container.cend();
+
+	// Done
+	std::cout << std::endl << "::: Done :::" << std::endl;
+	std::cout << std::endl;
+
+	return 0;
+}
+/*!
 * Main program.
 */
 int main(int argc, char *argv[])
@@ -451,6 +545,11 @@ int main(int argc, char *argv[])
 	int status;
 	try {
 		status = subtest_001();
+		if (status != 0) {
+			return status;
+		}
+
+		status = subtest_002();
 		if (status != 0) {
 			return status;
 		}


### PR DESCRIPTION
I've added a very simple "pool allocator" to the ProxyVector container, in order to reduce memory allocations when ProxyVector needs an internal storage. I'm using quotes because what I'm doing is not really a pool allocator, I just save the last 10 internal storages and I re-used those storages when a new ProxyVector is created.