### PR TITLE
Add missing includes

### DIFF
--- a/src/PABLO/Map.hpp
+++ b/src/PABLO/Map.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <iostream>
 #include <array>
+#include <limits>
 
 namespace bitpit {
 

--- a/src/common/commonUtils.hpp
+++ b/src/common/commonUtils.hpp
@@ -32,6 +32,7 @@
 #include <cfloat>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <iomanip>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Some includes were missing (see #194).

(The branch "1.7_bitpit.add.missing.includes" contains the same changes for bitpit v1.7.)