### PR TITLE
voloctree: optimize update of adjacencies

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5315,7 +5315,7 @@ void PatchKernel::pruneStaleAdjacencies()
 		return;
 	}
 
-	// Update cell adjacencies
+	// Remove stale adjacencies
 	for (const auto &entry : m_alteredCells) {
 		AlterationFlags cellAlterationFlags = entry.second;
 		if (!testAlterationFlags(cellAlterationFlags, FLAG_ADJACENCIES_DIRTY)) {
@@ -5677,7 +5677,7 @@ void PatchKernel::pruneStaleInterfaces()
 		return;
 	}
 
-	// Update cell interfaces
+	// Remove dangling interfaces from cells
 	for (const auto &entry : m_alteredCells) {
 		AlterationFlags cellAlterationFlags = entry.second;
 		if (!testAlterationFlags(cellAlterationFlags, FLAG_INTERFACES_DIRTY)) {

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1966,37 +1966,80 @@ void VolOctree::_updateAdjacencies()
 	}
 
 	// Update the adjacencies
-	FaceInfoSet processedFaces;
-	processedFaces.reserve(nDirtyAdjacenciesCells * getDimension());
-
 	std::vector<uint32_t> neighTreeIds;
 	std::vector<bool> neighGhostFlags;
 	for (int level = 0; level <= maxLevel; ++level) {
 		for (long cellId : hierarchicalCellIds[level]) {
 			Cell &cell = m_cells[cellId];
 			OctantInfo octantInfo = getCellOctant(cellId);
+			Octant *octant = getOctantPointer(octantInfo);
 			for (int face = 0; face < nCellFaces; ++face) {
-				FaceInfo currentFaceInfo(cellId, face);
-				if (processedFaces.count(currentFaceInfo) > 0) {
-					continue;
+				// Check if the face needs to be processed
+				//
+				// If the face has no adjacencies, we need to process it to
+				// figure out if it is a border or it has some neighbours.
+				//
+				// If the face has only one adjacency and the neighbour's level
+				// is smaller or equal than the one of the current cell, all
+				// face adjacencies have already been found.
+				//
+				// If the face has only one adjacency and the neighbour's level
+				// is greater than the one of the current cell, there are still
+				// adjacencies to be found. The adjacency associated with the
+				// face is an adjacency that was not created during this update
+				// (cells are processed in level increasing order, only cells
+				// with a level smaller or equal to the one of the current cell
+				// may already have been processed during this update). Since
+				// the cell is bigger that its neighbour it cannot have only
+				// one adjacency, there are other adjacencies to be found in
+				// the cell marked as dirty.
+				//
+				// If the face has multiple adjacencies, we need to figure out
+				// if all the adjacencies have already been found. Current
+				// adjacencies were not created during this update (since there
+				// are multiple adjacencies, those adjacencies are cells smaller
+				// than the current one, however since cells are processed in
+				// level increasing order, only cells with a level smaller or
+				// equal to the one of the current cell may already have been
+				// processed during this update). To check if all adjacencies
+				// have been found, we check if the area coverd by the current
+				// adjacencies is equal to the face area.
+				int nFaceAdjacencies = cell.getAdjacencyCount(face);
+				if (nFaceAdjacencies > 0) {
+					if (nFaceAdjacencies == 1) {
+						long cellLevel = octant->getLevel();
+						long neighId = cell.getAdjacency(face, 0);
+						long neighLevel = getCellLevel(neighId);
+						if (neighLevel <= cellLevel) {
+							continue;
+						}
+					} else {
+						uint64_t neighsArea = 0;
+						const long *faceAdjacencies = cell.getAdjacencies(face);
+						for (int k = 0; k < nFaceAdjacencies; ++k) {
+							long neighId = faceAdjacencies[k];
+							OctantInfo neighOctantInfo = getCellOctant(neighId);
+							Octant *neighOctant = getOctantPointer(neighOctantInfo);
+							neighsArea += neighOctant->getLogicalArea();
+						}
+
+						uint64_t faceArea = octant->getLogicalArea();
+						if (faceArea == neighsArea) {
+							continue;
+						}
+					}
 				}
 
 				// Find cell neighbours
 				neighTreeIds.clear();
 				neighGhostFlags.clear();
-				if (octantInfo.internal) {
-					m_tree->findNeighbours(octantInfo.id, face, 1, neighTreeIds, neighGhostFlags);
-				} else {
-					m_tree->findGhostNeighbours(octantInfo.id, face, 1, neighTreeIds, neighGhostFlags);
-				}
+				m_tree->findNeighbours(octant, face, 1, neighTreeIds, neighGhostFlags);
 
 				// Set the adjacencies
 				//
-				// Adjacencies will processed twice, once while processing the
-				// current cell, and once while processing the neighbour cell.
-				// However they will be set only once, because the function that
-				// insert the adjacency in the cell will insert only unique
-				// adjacencies.
+				// Some of the neighbours may already be among the adjacencies
+				// of the cell, this is not a problem because the function that
+				// pushs the adjacency will insert only unique adjacencies.
 				int nNeighs = neighTreeIds.size();
 				for (int k = 0; k < nNeighs; ++k) {
 					OctantInfo neighOctantInfo(neighTreeIds[k], !neighGhostFlags[k]);
@@ -2009,9 +2052,6 @@ void VolOctree::_updateAdjacencies()
 					int neighFace = oppositeFace[face];
 					Cell &neigh = m_cells[neighId];
 					neigh.pushAdjacency(neighFace, cellId);
-
-					FaceInfo neighFaceInfo(neighId, neighFace);
-					processedFaces.insert(neighFaceInfo);
 				}
 			}
 		}

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1963,6 +1963,8 @@ void VolOctree::_updateAdjacencies()
 	FaceInfoSet processedFaces;
 	processedFaces.reserve(nDirtyAdjacenciesCells * getDimension());
 
+	std::vector<uint32_t> neighTreeIds;
+	std::vector<bool> neighGhostFlags;
 	for (int level = 0; level <= maxLevel; ++level) {
 		for (long cellId : hierarchicalCellIds[level]) {
 			Cell &cell = m_cells[cellId];
@@ -1974,8 +1976,8 @@ void VolOctree::_updateAdjacencies()
 				}
 
 				// Find cell neighbours
-				std::vector<uint32_t> neighTreeIds;
-				std::vector<bool> neighGhostFlags;
+				neighTreeIds.clear();
+				neighGhostFlags.clear();
 				if (octantInfo.internal) {
 					m_tree->findNeighbours(octantInfo.id, face, 1, neighTreeIds, neighGhostFlags);
 				} else {

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1924,6 +1924,9 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 */
 void VolOctree::_updateAdjacencies()
 {
+	// Tree information
+	int maxLevel = m_tree->getMaxDepth();
+
 	// Face information
 	int nCellFaces = 2 * getDimension();
 	uint8_t oppositeFace[nCellFaces];
@@ -1931,21 +1934,24 @@ void VolOctree::_updateAdjacencies()
 
 	// Count cells with dirty adjacencies
 	long nDirtyAdjacenciesCells = 0;
+	std::vector<std::size_t> nDirtyAdjacenciesCellsByLevel(maxLevel + 1, 0);
 	for (const auto &entry : m_alteredCells) {
 		AlterationFlags cellAlterationFlags = entry.second;
 		if (!testAlterationFlags(cellAlterationFlags, FLAG_ADJACENCIES_DIRTY)) {
 			continue;
 		}
 
+		long cellId = entry.first;
+		int cellLevel = getCellLevel(cellId);
+
 		++nDirtyAdjacenciesCells;
+		++nDirtyAdjacenciesCellsByLevel[cellLevel];
 	}
 
-	// Sort the cells beased on their tree level
-	int maxLevel = m_tree->getMaxDepth();
-	size_t averageSize = nDirtyAdjacenciesCells / (maxLevel + 1);
+	// Group altered cells by their tree level
 	std::vector<std::vector<long>> hierarchicalCellIds(maxLevel + 1);
 	for (int level = 0; level <= maxLevel; ++level) {
-		hierarchicalCellIds[level].reserve(averageSize);
+		hierarchicalCellIds[level].reserve(nDirtyAdjacenciesCellsByLevel[level]);
 	}
 
 	for (const auto &entry : m_alteredCells) {


### PR DESCRIPTION
Moving the declaration of the two vectors outside the for loops we can avoid some allocations.

(The branch "1.7_voloctree.reduce.allocations" contains the same changes for bitpit v1.7.)