### PR TITLE
IO module: add JSON support to configuration package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ if (BITPIT_ENABLE_MPI)
 endif()
 set(OPERATORS_EXTERNAL_DEPS "")
 set(CONTAINERS_EXTERNAL_DEPS "")
-set(IO_EXTERNAL_DEPS "LibXml2")
+set(IO_EXTERNAL_DEPS "LibXml2;RapidJSON")
 set(COMMUNICATIONS_EXTERNAL_DEPS "MPI")
 set(LA_EXTERNAL_DEPS "PETSc")
 set(SA_EXTERNAL_DEPS "")
@@ -689,6 +689,27 @@ if (${_LibXml2_index} GREATER -1)
     list (INSERT BITPIT_EXTERNAL_VARIABLES_INCLUDE_DIRS 0 "LIBXML2_INCLUDE_DIR")
 endif()
 unset(_LibXml2_index)
+
+list(FIND EXTERNAL_DEPS "RapidJSON" _RapidJSON_index)
+if (${_RapidJSON_index} GREATER -1)
+    find_package(RapidJSON 1.1.0 QUIET)
+    mark_as_advanced(RapidJSON_DIR)
+
+    if (RapidJSON_FOUND)
+        # RapidJSON library has been found
+        addPrivateDefinitions("HAS_RAPIDJSON_LIB=1")
+        list (INSERT BITPIT_EXTERNAL_DEPENDENCIES 0 "RapidJSON")
+        list (INSERT BITPIT_EXTERNAL_VARIABLES_INCLUDE_DIRS 0 "RAPIDJSON_INCLUDE_DIRS")
+
+        # Activate std::string RapidJSON compliancy
+        addPrivateDefinitions("RAPIDJSON_HAS_STDSTRING=1")
+    else()
+        # RapidJSON library has not been found
+        addPrivateDefinitions("HAS_RAPIDJSON_LIB=0")
+        message(STATUS "RapidJSON library not found, JSON support will be disabled.")
+    endif()
+endif()
+unset(_RapidJSON_index)
 
 list(FIND EXTERNAL_DEPS "PETSc" _PETSc_index)
 if (${_PETSc_index} GREATER -1)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,9 +12,14 @@ Some additional dependencies are required for building specific modules
 * libxml2 and its development headers are needed when compiling the 'IO'
   module (please note that the 'IO' module is a dependecies for many other
   bitpit modules, the only modules that do not depend on 'IO' are the low
-  level modules like 'operators', 'containers', 'LA', and 'SA');
+  level modules like 'operators', 'containers', 'LA', and 'SA'). Moreover,
+  json support is automatically enabled if RapidJSON (version 1.1.0) libraries  
+  are installed on the system (https://github.com/Tencent/rapidjson): this is
+  a completely optional requirement, IO module will compile and work fine
+  with the only xml support too;   
 * blas, lapack, and lapacke are needed when compiling 'CG', 'RBF', and 'POD'
   modules.
+    
 
 When compiling bitpit, both shared library files and header library files are
 required. Therefore, in addition to the library packages, also the corresponding
@@ -43,7 +48,7 @@ The `BITPIT_ENABLE_MPI` variable can be used to compile the parallel implementat
 
 The `BITPIT_BUILD_EXAMPLES` can be used to compile examples sources in `bitpit/examples`. Note that the tests sources in `bitpit/test`are necessarily compiled and successively available at `bitpit/build/test/` as well as the compiled examples are available at `bitpit/build/examples/`.
 
-The module variables (available in the advanced mode) can be used to compile each module singularly by setting the related varible `ON/OFF` (BITPIT_MODULE_CONTAINERS, BITPIT_MODULE_IO, BITPIT_MODULE_LA, BITPIT_MODULE_SA...). Possible dependencies between bitpit modules are automatically resolved. 
+The module variables (available in the advanced mode) can be used to compile each module singularly by setting the related varible `ON/OFF` (BITPIT_MODULE_CONTAINERS, BITPIT_MODULE_IO, BITPIT_MODULE_LA, BITPIT_MODULE_SA...). Possible dependencies between bitpit modules are automatically resolved.
 
 Finally, you can choose the installation folder setting the cmake variable `CMAKE_INSTALL_PREFIX`. The default installation folder is `/usr/local/`.
 
@@ -69,12 +74,12 @@ In order to build properly the documentation Doxygen (>=1.8.6) and Graphviz (>=2
 
 In the ccmake interface the variable `BITPIT_ENABLE_DOC` can be set to `ON` in order to build the documentation during the library compilation.
 If turned on the new variable `BITPIT_DOC_EXTRACT_PRIVATE` can be used to include all the private class members in the documentation.
-  
-After the `make` or `make install` the doxygen documentation will be built. You can chose to compile only the documentation with command 
+
+After the `make` or `make install` the doxygen documentation will be built. You can chose to compile only the documentation with command
 ```bash
     bitpit/build$ make doc   
 ```
 You can now browse the html documentation with your favorite browser by opening 'html/index.html'.
 
 ## Help
-For any problem, please contact <a href="http://www.optimad.it">Optimad engineering srl</a> at info@optimad.it. 
+For any problem, please contact <a href="http://www.optimad.it">Optimad engineering srl</a> at info@optimad.it.

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -24,7 +24,7 @@ This is a short guide to set a bitpit compliant 64bit Windows environment using 
   - mingw-w64-x86_64-qt5 (optional, but needed to run cmake-gui. Consider 1.22 GB to install it.)
   - mingw-w64-x86_64-doxygen (to generate Doxygen documentation)
   - mingw-w64-x86_64-graphviz (to generate Doxygen documentation)
-
+  - mingw-w64-x86_64-rapidjson (to enable JSON I/O support on IO module)
 
 - <B>Microsoft MPI</B>: MSMpiSetup.exe or msmpisdk.msi (downloadable for free from https://www.microsoft.com/ searching for "MicrosoftMPI v x.x.x". Here the exact version x.x.x must be compliant with the version of MinGW64 package mingw-w64-x86_64-msmpi. See MSMPI section in procedure chapter for details)
 
@@ -202,6 +202,14 @@ Install *libxml2* with:
 ```bash
 user@machine MINGW64 ~
 > pacman -S mingw-w64-x86_64-libxml2
+```
+
+**__RAPIDJSON__**
+
+If JSON support on IO module is required, install *rapidjson* with:
+```bash
+user@machine MINGW64 ~
+> pacman -S mingw-w64-x86_64-rapidjson
 ```
 
 **__PETSc__**

--- a/src/IO/configuration.cpp
+++ b/src/IO/configuration.cpp
@@ -26,6 +26,10 @@
 #include "configuration.hpp"
 #include "configuration_XML.hpp"
 
+#if HAS_RAPIDJSON_LIB
+#include "configuration_JSON.hpp"
+#endif
+
 #include <stringUtils.hpp>
 
 namespace bitpit {
@@ -148,6 +152,9 @@ void ConfigParser::reset(const std::string &root, int version, bool multiSection
 /*!
     Read the specified configuration file.
 
+    Configuration file can be either XML or JSON files (if JSON support was
+    found at compile time).
+
     \param filename is the filename of the configuration file
     \param append controls if the configuration file will be appended to the
     current configuration or if the current configuration will be overwritten
@@ -160,6 +167,7 @@ void ConfigParser::read(const std::string &filename, bool append)
         clear();
     }
 
+    // Read the configuration
     std::string extension = "";
     std::size_t dotPosition = filename.find_last_of(".");
     if (dotPosition != std::string::npos) {
@@ -169,6 +177,10 @@ void ConfigParser::read(const std::string &filename, bool append)
 
     if (extension == "xml" || extension == "XML") {
         config::XML::readConfiguration(filename, m_root, m_checkVersion, m_version, this);
+#if HAS_RAPIDJSON_LIB
+    } else if (extension == "json" || extension == "JSON") {
+        config::JSON::readConfiguration(filename, this);
+#endif
     } else {
         throw std::runtime_error("ConfigParser::read - Unsupported file format");
     }
@@ -177,10 +189,15 @@ void ConfigParser::read(const std::string &filename, bool append)
 /*!
     Write the configuration to the specified file.
 
+    Configuration file can be either XML or JSON files (if JSON support was
+    found at compile time).
+
+
     \param filename is the filename where the configuration will be written to
 */
 void ConfigParser::write(const std::string &filename) const
 {
+    // Write the configuration
     std::string extension = "";
     std::size_t dotPosition = filename.find_last_of(".");
     if (dotPosition != std::string::npos) {
@@ -190,6 +207,11 @@ void ConfigParser::write(const std::string &filename) const
 
     if (extension == "xml" || extension == "XML") {
         config::XML::writeConfiguration(filename, m_root, m_version, this);
+#if HAS_RAPIDJSON_LIB
+    } else if (extension == "json" || extension == "JSON") {
+        bool prettify = true;
+        config::JSON::writeConfiguration(filename, this, prettify);
+#endif
     } else {
         throw std::runtime_error("ConfigParser::write - Unsupported file format");
     }
@@ -310,6 +332,9 @@ namespace config {
     /*!
         Read the specified configuration file.
 
+        Configuration file can be either XML or JSON files (if JSON support was
+        found at compile time).
+
         \param filename is the filename of the configuration file
         \param append controls if the configuration file will be appended to the
         current configuration or if the current configuration will be overwritten
@@ -322,6 +347,9 @@ namespace config {
 
     /*!
         Write the configuration to the specified file.
+
+        Configuration file can be either XML or JSON files (if JSON support was
+        found at compile time).
 
         \param filename is the filename where the configuration will be written to
     */

--- a/src/IO/configuration.hpp
+++ b/src/IO/configuration.hpp
@@ -43,6 +43,7 @@ public:
 
     void reset(const std::string &root);
     void reset(const std::string &root, int version);
+    void reset(const std::string &root, int version, bool multiSections);
 
     void read(const std::string &filename, bool append = true);
     void write(const std::string &filename) const;
@@ -72,6 +73,9 @@ private:
 
     GlobalConfigParser();
     GlobalConfigParser(const std::string &name, int version);
+    GlobalConfigParser(const std::string &name, bool multiSections);
+    GlobalConfigParser(const std::string &name, int version, bool multiSections);
+
 
     GlobalConfigParser(GlobalConfigParser const&) = delete;
     GlobalConfigParser& operator=(GlobalConfigParser const&) = delete;
@@ -91,6 +95,7 @@ namespace config {
     void reset();
     void reset(const std::string &name);
     void reset(const std::string &name, int version);
+    void reset(const std::string &name, int version, bool multiSections);
 
     void read(const std::string &filename, bool append = true);
     void write(const std::string &filename);

--- a/src/IO/configuration_JSON.cpp
+++ b/src/IO/configuration_JSON.cpp
@@ -1,0 +1,423 @@
+/*---------------------------------------------------------------------------*\
+*
+*  bitpit
+*
+*  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+*
+*  -------------------------------------------------------------------------
+*  License
+*  This file is part of bitpit.
+*
+*  bitpit is free software: you can redistribute it and/or modify it
+*  under the terms of the GNU Lesser General Public License v3 (LGPL)
+*  as published by the Free Software Foundation.
+*
+*  bitpit is distributed in the hope that it will be useful, but WITHOUT
+*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+*  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+*  License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+*
+\*---------------------------------------------------------------------------*/
+
+#include "configuration_JSON.hpp"
+
+#if HAS_RAPIDJSON_LIB
+
+#include "rapidjson/encodedstream.h"
+#include <rapidjson/error/en.h>
+#include "rapidjson/filereadstream.h"
+#include <rapidjson/filewritestream.h>
+#include <rapidjson/prettywriter.h>
+
+#include <string>
+#include <cstdio>
+#include <cassert>
+#include <set>
+#include <iomanip>
+
+namespace bitpit {
+
+namespace config {
+
+namespace JSON {
+
+/*!
+    Reading a json dictionary from file and fill a bitpit::Config tree
+    accordingly.
+
+    Inside, the method creates a DOM structure from json file and scan it
+    using readNode method.
+
+    JSON root document object does not have a key name and a version unlike
+    XML.
+
+    Encoding is always of UTF type (8,16,32). Here it is adopted the standard
+    UTF-8 encoding. JSON dictionary can be written in other UTF format, the
+    conversion is automatically handled by rapidjson parsing.
+
+    \param[in] filename is the path of the JSON file
+    \param[in,out] rootConfig is a pointer to Config tree that will be used
+    to store the data read from the document
+*/
+void readConfiguration(const std::string &filename, Config *rootConfig)
+{
+    if (!rootConfig) {
+        throw std::runtime_error("JSON::readDoc Null Config tree structure passed");
+    }
+
+    // Open the file
+    //
+    // To be compatible with Windows platforms, the file is open as a binary
+    // file (this works fine also on Posix platforms).
+    std::FILE *fp = std::fopen(filename.c_str(), "rb");
+
+    if (!fp) {
+        std::string message = "JSON:readDoc impossible to write on file : ";
+        message += filename.c_str();
+        throw std::runtime_error(message.c_str());
+    }
+
+    // Create a buffer for reading stream purposes.
+    std::vector<char> readBuffer(65536);
+    rapidjson::FileReadStream bis(fp, readBuffer.data(), readBuffer.size());
+
+    // Wrap the readstream into an auto encoding handle. This will let
+    // absorb any UTF encoded file into a regular UTF-8 document.
+    rapidjson::AutoUTFInputStream<unsigned, rapidjson::FileReadStream> eis(bis);
+
+    // Parse UTF file into UTF-8 in memory
+    rapidjson::Document jsonRoot;
+    jsonRoot.ParseStream<0, rapidjson::AutoUTF<unsigned> >(eis);
+
+    // Close the file
+    std::fclose(fp);
+
+    // Handle parse errors
+    if (jsonRoot.HasParseError()) {
+        std::string message = "JSON:readDoc error of type : ";
+        message += std::string(rapidjson::GetParseError_En(jsonRoot.GetParseError()));
+        throw std::runtime_error(message.c_str());
+    }
+
+    // Root should be an object, bitpit doens't support root arrays.
+    assert(jsonRoot.isObject() && "JSON:readDoc parsed document root is not an object");
+
+    // Fill the configuration
+    readNode("", jsonRoot, rootConfig);
+}
+
+/*!
+    Read recursively a json object content and fill accordingly the Config tree
+    branch.
+
+    The current method visit internal members of JSON object and parse tehm in
+    Config::Option or if subnested JSON objects or arrays are present in other
+    Config::Section through a recursive call to itself. If arrays are present,
+    MultiSection feature of the bitpit::Config tree must be enabled
+
+    The method can be used directly on the root content of the JSON document,
+    specifying as key an empty string.
+
+    BEWARE: JSON array support is limited to arrays of JSON objects. Each object
+    is converted into a Config::Section and stored with the same key name of the
+    array (using MultiSection property of Config). Pod JSON arrays (bools, numbers,
+    strings) are not supported since Config tree does not support MultiOptions.
+    An attempt to read an array of pod elements will throw an error.
+
+
+    \param[in] key key name associated of the JSON data.
+    \param[in] value JSON data, can be a pod type (bool, number, null,
+    str ing) or another JSON object/JSON array of contents. In that case
+    automatic recursion will occur.
+    \param[in] config pointer to configuration tree to be filled
+*/
+void readNode(const std::string &key, const rapidjson::Value &value, Config *config)
+{
+    if (value.IsObject()) {
+        // Get the section
+        Config::Section *section;
+        if (key.empty()) {
+            // If the key is empty we are reading the root.
+            section = config;
+        } else if (!config->isMultiSectionsEnabled() &&config->hasSection(key)) {
+            // Get the requestd section
+            section = &(config->getSection(key));
+        } else {
+            // Create a new section.
+            //
+            // If the name already exists, it will be handled as a multi-section
+            // in the tree map.
+            section = &(config->addSection(key));
+        }
+
+        // Read the contents of the section
+        for (auto itr = value.MemberBegin(); itr != value.MemberEnd(); ++itr) {
+            readNode(std::string(itr->name.GetString()), itr->value, section);
+        }
+
+    } else if (value.IsArray()) {
+        // Check if multi-section configurations are supported
+        bool multiSectionsEnabled = config->isMultiSectionsEnabled();
+        if (!multiSectionsEnabled) {
+            throw std::runtime_error("JSON:readNode reading array but Config MultiSection disabled");
+        }
+
+        // Read the array contents
+        for (auto itr = value.Begin(); itr != value.End(); ++itr) {
+            if (itr->IsObject()) {
+                readNode(key, *itr, config);
+            } else {
+                throw std::runtime_error("JSON:readNode only arrays of JSON Objects are supported!");
+            }
+        }
+
+    } else {
+        // Read a single JSON POD type (bool, numbers, strings null).
+        config->set(key, decodeValue(value));
+    }
+}
+
+/*!
+    Write a bitpit::Config tree contents to json formatted dictionary.
+
+    NOTE: JSON root document object does not have a key name and a version
+    unlike XML.
+
+    Inside the method creates an empty rapidjson Document, set the root object
+    and fill it recursively from the Config tree using the writeNode method.
+    Then, it writes the Document on file with standard encoding of UTF-8 type.
+
+    Option prettify controls the json dictionary formatting. If false write it
+    in a unique compact string, otherwise write it down in a more readable tree
+    structure.
+
+    \param[in] filename is the path to a valid json file.
+    \param[in] rootConfig pointer to the Config tree to be written on file
+    \param[in] prettify if set to true, a prettyfied human-readable JSON will
+    be written, otherwise a compatc JSON will be written
+*/
+void writeConfiguration(const std::string &filename, const Config *rootConfig, bool prettify)
+{
+    if (!rootConfig) {
+        throw std::runtime_error("JSON::writeConfiguration Null Config tree structure passed");
+    }
+
+    // DOM Document is GenericDocument<UTF8<>>
+    rapidjson::Document jsonRoot;
+
+    // Get the allocator
+    rapidjson::Document::AllocatorType &allocator = jsonRoot.GetAllocator();
+
+    // Create a root node and recursively fill it
+    jsonRoot.SetObject();
+    writeNode(rootConfig, jsonRoot, allocator);
+
+    // Write on file
+    //
+    // To be compatible with Windows platforms, the file is open as a binary
+    // file (this works fine also on Posix platforms).
+    std::FILE *fp = std::fopen(filename.c_str(), "wb");
+    if (!fp) {
+        std::string message = "JSON:writeConfiguration impossible to write on file : ";
+        message += filename.c_str();
+        throw std::runtime_error(message.c_str());
+    }
+
+    // Create a buffer for writing purposes.
+    std::vector<char> writeBuffer(65536);
+    rapidjson::FileWriteStream bos(fp, writeBuffer.data(), writeBuffer.size());
+
+    // Write the file
+    if (prettify) {
+         // Use prettyfied UTF-8 JSON format with default indentantion
+         rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(bos);
+         jsonRoot.Accept(writer);
+
+    } else {
+        // Use single-ultracompact UTF-8 JSON format
+        rapidjson::Writer<rapidjson::FileWriteStream> writer(bos);
+        jsonRoot.Accept(writer);
+    }
+
+    // Close the file.
+    std::fclose(fp);
+}
+
+/*!
+    Write recursively Config tree contents to JSON objects
+
+    The current method visits the config Tree and write Option and nested
+    sections as internal members of JSON object. MultiSections will be
+    treated as array of JSON objects.
+
+    The method can be used directly on the root content of the JSON document,
+    specifying as key an empty string.
+
+    \param[in] config pointer to local Config tree section to be parsed.
+    \param[in] rootJSONdata, reference JSON object value to fill
+    \param[in] allocator  Allocator of reference rapidjson Document
+*/
+void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::Document::AllocatorType &allocator)
+{
+    // Write the options
+    for (auto &entry : config->getOptions()) {
+        const std::string &configKey   = entry.first;
+        const std::string &configValue = entry.second;
+
+        rapidjson::Value jsonKey;
+        jsonKey.SetString(configKey, allocator);
+
+        rapidjson::Value jsonValue = encodeValue(configValue, allocator);
+
+        rootJSONData.AddMember(jsonKey, jsonValue, allocator);
+    }
+
+    // Get list of unique section keys
+    std::set<std::string> listOfSectionsKeys;
+    for (const auto &entry : config->getSections()) {
+        listOfSectionsKeys.insert(entry.first);
+    }
+
+    // Write the sections
+    for (const std::string &configKey : listOfSectionsKeys) {
+        const Config::ConstMultiSection &keySections = config->getSections(configKey);
+        if (keySections.empty()) {
+                continue;
+        }
+
+        std::size_t nEntries = keySections.size();
+
+        rapidjson::Value object(rapidjson::kObjectType);
+        rapidjson::Value arrayOfObjects(rapidjson::kArrayType);
+        if (nEntries > 1) {
+            arrayOfObjects.Reserve(nEntries, allocator);
+        }
+
+        // Process section content
+        for (std::size_t i = 0; i< nEntries; ++i) {
+            writeNode(keySections[i], object, allocator);
+            if (nEntries > 1) {
+                arrayOfObjects.PushBack(object, allocator);
+                rapidjson::Value swapDummy(rapidjson::kObjectType);
+                object.Swap(swapDummy);
+            }
+        }
+
+        rapidjson::Value jsonKey;
+        jsonKey.SetString(configKey, allocator);
+
+        if (nEntries > 1) {
+            rootJSONData.AddMember(jsonKey, arrayOfObjects, allocator);
+        } else {
+            rootJSONData.AddMember(jsonKey, object, allocator);
+        }
+    }
+}
+
+/*!
+    Convert a JSON value into a string.
+
+    Supported JSON values are:
+    - bool
+    - number (int/int64, uint/uint64 or float/double)
+    - string
+    - null
+
+    Objects and array structures are not stringfyied. Unsupported values and
+    null will be converted in an empty string.
+
+    \param[in] value is the JSON value
+    \result The string corresponding to the specified JSON value.
+*/
+std::string decodeValue(const rapidjson::Value &value)
+{
+    if (value.IsBool()) {
+        return std::to_string(int(value.GetBool()));
+    } else if (value.IsString()) {
+        return std::string(value.GetString());
+    } else if (value.IsNumber()) {
+        // To avoid problems, numbers are always casted to the maximum allowed
+        // datatype.
+        std::ostringstream stringStream;
+        if (value.IsUint64()) {
+            // Try uint casting first
+            stringStream << value.GetUint64();
+
+        } else if (value.IsInt64()) {
+            // Then the normal int casting
+            stringStream << value.GetInt64();
+        } else {
+            // Otherwise try it as double
+            stringStream << std::scientific << std::setprecision(8) << value.GetDouble();
+        }
+
+        return stringStream.str();
+    } else {
+        return std::string("");
+    }
+}
+
+/*!
+    Convert a string into a JSON.
+
+    Supported types are:
+    - unsigned long int (e.g., 123456789);
+    - signed long int (e.g. -123456789);
+    - double (+/-123456789.123456789 or in scientific notation);
+    - null (emtpy strings).
+
+    Strings that does't match any know data types are converted to JSON strings.
+
+    \param[in] stringValue is the string that will be converted
+    \param[in] allocator is the JSON allocator
+    \result The JSON value corresponding to the specified string.
+*/
+rapidjson::Value encodeValue(const std::string &stringValue, rapidjson::Document::AllocatorType &allocator)
+{
+    rapidjson::Value value;
+
+    // Empty string are null values
+    if (stringValue.empty()) {
+        return value;
+    }
+
+    // Strings that contains non-numeric charactes are strings
+    std::size_t nonNumericCharacterPos = stringValue.find_first_not_of("Ee+-.0123456789");
+    if (nonNumericCharacterPos != std::string::npos) {
+        value.SetString(stringValue, allocator);
+        return value;
+    }
+
+    // Convert the string into a number
+    std::istringstream stringStream(stringValue);
+    if (stringValue.find_first_of("Ee.") != std::string::npos) {
+        // Convert the string into a double
+        double number;
+        stringStream >> number;
+        value.SetDouble(number);
+    } else if (stringValue.find_first_of("-") != std::string::npos) {
+        // Convert the string into a long
+        int64_t number;
+        stringStream >> number;
+        value.SetInt64(number);
+
+    } else {
+        // Convert the string into an unsigned long
+        uint64_t number;
+        stringStream >> number;
+        value.SetUint64(number);
+    }
+
+    return value;
+}
+
+}
+
+}
+
+}
+
+#endif

--- a/src/IO/configuration_JSON.hpp
+++ b/src/IO/configuration_JSON.hpp
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+#ifndef __BITPIT_CONFIGURATION_JSON_HPP__
+#define __BITPIT_CONFIGURATION_JSON_HPP__
+
+#if HAS_RAPIDJSON_LIB
+#include <rapidjson/document.h>
+
+#include "configuration_config.hpp"
+
+namespace bitpit {
+
+namespace config {
+
+namespace JSON {
+
+void readConfiguration(const std::string &filename, Config *rootConfig);
+void readNode(const std::string &key, const rapidjson::Value &value, Config *config);
+
+void writeConfiguration(const std::string &filename, const Config *rootConfig, bool prettify = true);
+void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::Document::AllocatorType &allocator);
+
+std::string decodeValue(const rapidjson::Value &value);
+rapidjson::Value encodeValue(const std::string &stringValue, rapidjson::Document::AllocatorType &allocator);
+
+}
+
+}
+
+}
+#endif
+
+#endif

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -85,8 +85,8 @@ void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string 
 {
     // Write the options
     for (auto &entry : config->getOptions()) {
-        std::string key   = entry.first;
-        std::string value = entry.second;
+        const std::string &key   = entry.first;
+        const std::string &value = entry.second;
 
         xmlChar *elementName = encodeString(key, encoding);
         xmlChar *elementText = encodeString(value, encoding);
@@ -98,7 +98,7 @@ void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string 
 
     // Write the sections
     for (auto &entry : config->getSections()) {
-        std::string key = entry.first;
+        const std::string &key = entry.first;
         const Config::Section *section = entry.second.get();
 
         // Start the section

--- a/src/IO/configuration_XML.hpp
+++ b/src/IO/configuration_XML.hpp
@@ -37,9 +37,11 @@ namespace XML {
 
 extern const std::string DEFAULT_ENCODING;
 
+void readConfiguration(const std::string &filename, const std::string &rootname, bool checkVersion, int version, Config *rootConfig);
 void readNode(xmlNodePtr root, Config *config);
-void writeNode(xmlTextWriterPtr writer, const Config *config,
-               const std::string &encoding = DEFAULT_ENCODING);
+
+void writeConfiguration(const std::string &filename, const std::string & rootname, int version, const Config *rootConfig);
+void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string &encoding = DEFAULT_ENCODING);
 
 xmlChar * encodeString(const std::string &in, const std::string &encoding);
 

--- a/src/IO/configuration_config.hpp
+++ b/src/IO/configuration_config.hpp
@@ -91,8 +91,10 @@ public:
     template<typename T>
     void set(const std::string &key, const T &value);
 
-private:
+protected:
     bool m_multiSections;
+
+private:
     std::unique_ptr<Options> m_options;
     std::unique_ptr<Sections> m_sections;
 

--- a/test/IO/CMakeLists.txt
+++ b/test/IO/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND TESTS "test_IO_00003")
 list(APPEND TESTS "test_IO_00004")
 list(APPEND TESTS "test_IO_00005")
 list(APPEND TESTS "test_IO_00006")
+list(APPEND TESTS "test_IO_00007")
 
 # Test extra libraries
 set(TEST_EXTRA_LIBRARIES "")
@@ -61,4 +62,9 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/data/cubeAscii.stl" "${CMAKE_CURRENT_BINARY_DIR}/data/cubeAscii.stl"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/data/cubeBinary.stl" "${CMAKE_CURRENT_BINARY_DIR}/data/cubeBinary.stl"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/data/cubeAscii_MultiSolid.stl" "${CMAKE_CURRENT_BINARY_DIR}/data/cubeAscii_MultiSolid.stl"
+)
+
+add_custom_command(
+    TARGET "test_IO_00007" PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/data/configuration.json" "${CMAKE_CURRENT_BINARY_DIR}/data/configuration.json"
 )

--- a/test/IO/data/configuration.json
+++ b/test/IO/data/configuration.json
@@ -1,0 +1,34 @@
+{
+    "first" : {
+        "color"   : "blue",
+        "distance": 11543 ,
+        "exists"  : true,
+        "data" : {
+            "x" : 64.12345679
+        },
+        "dummy" : null
+    },
+
+    "second" : {
+        "color"   : "redButnotreallyREDsomething similar + to red",
+        "distance": -22876587866878888,
+        "exists"  : false,
+        "data" : {
+            "y" : -32.6789E-21
+        }
+    },
+
+    "ObjArray"    : [
+        {
+            "Address" : "Sunset Boulevard 1923",
+            "Nation"  : "California - USA",
+            "ZIPCode" : 42345
+        },
+
+        {
+            "Address" : "Via dei Pini 24",
+            "Nation"  : "Italy",
+            "ZIPCode" : 10129
+        }
+    ]
+}

--- a/test/IO/test_IO_00007.cpp
+++ b/test/IO/test_IO_00007.cpp
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#if BITPIT_ENABLE_MPI==1
+#include <mpi.h>
+#endif
+
+#include "bitpit_IO.hpp"
+
+using namespace bitpit;
+
+/*!
+* Subtest 001
+*
+* Testing json parser.
+* BEWARE: if bitpit has no JSON support (RapidJSON package not installed)
+* this test does nothing and return .
+*/
+int subtest_001()
+{
+    std::cout << "Testing json configuraton parser features" << std::endl;
+
+    // Declare a bitpit config parser with multisections enabled.
+    //
+    config::reset("bitpit", 1, true);
+
+    // Read the configuration file
+    std::cout << std::endl;
+    std::cout << "Read json configuration file..." << std::endl;
+
+    config::read("data/configuration.json");
+
+    bitpit::GlobalConfigParser & root = config::root;
+    // Dump the configuration
+    std::cout << std::endl;
+    std::cout << "Dump configuration..." << std::endl;
+    root.dump(std::cout, 1);
+
+    // Access configuration
+    std::cout << std::endl;
+    std::cout << "Access configuration..." << std::endl;
+    std::cout << "  - Section \"first\" has color..." << root["first"].get("color") << std::endl;
+    std::cout << "  - Section \"second\" has color..." << root["second"].get("color") << std::endl;
+    std::cout << "  - Section \"first\" has distance..." << root.getSection("first").get("distance") << std::endl;
+    std::cout << "  - Section \"second\" has y data..." << root["second"]["data"].get("y") << std::endl;
+    std::cout << "  - Section \"first\" option count..." << root.getSection("first").getOptionCount() << std::endl;
+    std::cout << "  - Section \"first\" sub-section count..." << root.getSection("first").getSectionCount() << std::endl;
+
+    int firstDistanceInt = root["first"].get<int>("distance");
+    std::cout << "  - Section \"first\" has distance (int)..." << firstDistanceInt << std::endl;
+
+    double firstDistanceDouble = root["first"].get<double>("distance");
+    std::cout << "  - Section \"first\" has distance (double)..." << firstDistanceDouble << std::endl;
+
+    double secondDataDouble = root["second"]["data"].get<double>("y");
+    std::cout << "  - Section \"second\" has y data (double)..." << secondDataDouble << std::endl;
+
+    bool firstExistsBool = root["first"].get<bool>("exists");
+    std::cout << "  - Section \"first\" has exists..." << firstExistsBool << std::endl;
+
+    std::cout << "  - Empty dummy option reading ... -" << root.getSection("first").get("dummy")<<" - "<< std::endl;
+
+    std::cout << "  - Non existent option with fallback..." << root.getSection("first").get("none", "111") << std::endl;
+    std::cout << "  - Non existent option with fallback (int)..." << root.getSection("first").get<int>("none", 111) << std::endl;
+    std::cout << "  - Non existent option with fallback (double)..." << root.getSection("first").get<double>("none", 111.111) << std::endl;
+
+
+    Config::MultiSection multisections = root.getSections("ObjArray");
+    for(auto sec : multisections){
+        std::cout<<"  - ObjArray element has address "<< sec->get("Address") <<std::endl;
+    }
+
+    // Write the configuration file in XML and json
+    std::cout << std::endl;
+    std::cout << "Write configuration file..." << std::endl;
+    root.write("config_test00007_updated.xml");
+    root.write("config_test00007_updated.json");
+
+    return 0;
+}
+
+/*!
+* Main program.
+*/
+int main(int argc, char *argv[])
+{
+#if BITPIT_ENABLE_MPI==1
+    MPI_Init(&argc,&argv);
+#else
+    BITPIT_UNUSED(argc);
+    BITPIT_UNUSED(argv);
+#endif
+
+    // Initialize the logger
+    log::manager().initialize(log::COMBINED);
+
+#if HAS_RAPIDJSON_LIB
+    // Run the subtests
+    log::cout() << "Testing json configuration parser" << std::endl;
+
+    int status;
+    try {
+        status = subtest_001();
+        if (status != 0) {
+            return status;
+        }
+    } catch (const std::exception &exception) {
+        log::cout() << exception.what()<<std::endl;
+        exit(1);
+    }
+#else
+    log::cout() << "Skipping test: configuration parser was compiled without JSON support." << std::endl;
+#endif
+
+#if BITPIT_ENABLE_MPI==1
+    MPI_Finalize();
+#endif
+}


### PR DESCRIPTION
The following pull adds into IO::ConfigParser class the possibility to parse/write json formatted dictionaries. 
Data structure and interfaces of the Config/Config parser classes are the same as before, XML parsing/writing functionalities are also preserved and totally independent from the new json add-on.

RapidJSON external library is used. The external dep is handled silently during bitpit compiling, applying the following the scheme:
1) RapidJSON is found quietly on the system
2) if it's found, set to true a bitpit internal-only precomp variable HAS_RAPIDJSON_LIB and compile with json support.
3) otherwise set to false HAS_RAPIDJSON_LIB, and ignore JSON related code.
In any case, XML support is always guaranteed.
Dictionary format conversion is possible too (parse a JSON file and write it in XML and vice-versa).

In order to comply with the IO::Config tree structure, bitpit JSON parsing  is limited only to arrays of JSON objects. Arrays of doubles, integers, booleans, string or null are not supported, and any attempt to parse them trigger an error.  

A test_io_00007 is added to check json parsing and writing. 

Tested on gcc 4.8 Linux  and MinGW Win10 gcc-10  