### PR TITLE
patchkernel: optimize transfer of vertices/cells/interfaces into the patch

### DIFF
--- a/src/patchkernel/cell.cpp
+++ b/src/patchkernel/cell.cpp
@@ -260,19 +260,6 @@ void Cell::_initialize(bool interior, bool initializeNeighbourhood, bool storeNe
 
 	// Neighbourhood
 	if (initializeNeighbourhood) {
-		// To reduce memory fragmentation, destroy both interfaces/adjacencies
-		// before resetting the interfaces/adjacencies
-		int reallocateInterfaces = (static_cast<int>(m_interfaces.getItemCount()) != getFaceCount());
-		if (reallocateInterfaces) {
-			m_interfaces.destroy();
-		}
-
-		int reallocateAdjacencies = (static_cast<int>(m_adjacencies.getItemCount()) != getFaceCount());
-		if (reallocateAdjacencies) {
-			m_adjacencies.destroy();
-		}
-
-		// Reset the interfaces/adjacencies
 		resetInterfaces(storeNeighbourhood);
 		resetAdjacencies(storeNeighbourhood);
 	}
@@ -325,7 +312,22 @@ void Cell::deleteInterfaces()
 */
 void Cell::resetInterfaces(bool storeInterfaces)
 {
-	m_interfaces = createNeighbourhoodStorage(storeInterfaces);
+	// Early return if no interfaces should be stored
+	ElementType type = getType();
+	if (!storeInterfaces || type == ElementType::UNDEFINED) {
+		m_interfaces.destroy();
+		return;
+	}
+
+	// Early return if not element defines no faces
+	int nFaces = getFaceCount();
+	if (nFaces <= 0) {
+		m_interfaces.destroy();
+		return;
+	}
+
+	// Initialize the interface storage
+	m_interfaces.initialize(nFaces, 0);
 }
 
 /*!
@@ -580,7 +582,22 @@ void Cell::deleteAdjacencies()
 */
 void Cell::resetAdjacencies(bool storeAdjacencies)
 {
-	m_adjacencies = createNeighbourhoodStorage(storeAdjacencies);
+	// Early return if no adjacencies should be stored
+	ElementType type = getType();
+	if (!storeAdjacencies || type == ElementType::UNDEFINED) {
+		m_adjacencies.destroy();
+		return;
+	}
+
+	// Early return if not element defines no faces
+	int nFaces = getFaceCount();
+	if (nFaces <= 0) {
+		m_adjacencies.destroy();
+		return;
+	}
+
+	// Initialize the interface storage
+	m_adjacencies.initialize(nFaces, 0);
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1550,13 +1550,26 @@ PatchKernel::VertexIterator PatchKernel::addVertex(Vertex &&source, long id)
 		id = source.getId();
 	}
 
-	VertexIterator iterator = addVertex(source.getCoords(), id);
+	// Add a dummy vertex
+	//
+	// It is not possible to directly add the source into the storage. First a
+	// dummy vertex is created and then that vertex is replaced with the source.
+	//
+	// The corrdinates of the dummy vertex shuold match the coordinates of the
+	// source, because the bounding box of the patch is updated every time a
+	// new vertex is added.
+	VertexIterator iterator = _addInternalVertex(source.getCoords(), id);
+
+	// Replace the newly created vertex with the source
+	//
+	// Before replacing the newly created vertex we need to set the id
+	// of the source to the id that has been assigned to the newly created
+	// vertex, we also need to mark the vertex as internal.
+	source.setId(iterator->getId());
+	source.setInterior(true);
 
 	Vertex &vertex = (*iterator);
-	id = vertex.getId();
 	vertex = std::move(source);
-	vertex.setId(id);
-	vertex.setInterior(true);
 
 	return iterator;
 }
@@ -1585,16 +1598,6 @@ PatchKernel::VertexIterator PatchKernel::addVertex(const std::array<double, 3> &
 		return vertexEnd();
 	}
 
-	if (m_vertexIdGenerator) {
-		if (id < 0) {
-			id = m_vertexIdGenerator->generate();
-		} else {
-			m_vertexIdGenerator->setAssigned(id);
-		}
-	} else if (id < 0) {
-		throw std::runtime_error("No valid id has been provided for the vertex.");
-	}
-
 	// Add the vertex
 	VertexIterator iterator = _addInternalVertex(coords, id);
 
@@ -1617,6 +1620,17 @@ PatchKernel::VertexIterator PatchKernel::addVertex(const std::array<double, 3> &
 */
 PatchKernel::VertexIterator PatchKernel::_addInternalVertex(const std::array<double, 3> &coords, long id)
 {
+	// Get id
+	if (m_vertexIdGenerator) {
+		if (id < 0) {
+			id = m_vertexIdGenerator->generate();
+		} else {
+			m_vertexIdGenerator->setAssigned(id);
+		}
+	} else if (id < 0) {
+		throw std::runtime_error("No valid id has been provided for the vertex.");
+	}
+
 	// Get the id of the vertex before which the new vertex should be inserted
 #if BITPIT_ENABLE_MPI==1
 	//
@@ -1727,11 +1741,6 @@ bool PatchKernel::deleteVertex(long id)
 	_deleteInternalVertex(id);
 #endif
 
-	// Vertex id is no longer used
-	if (m_vertexIdGenerator) {
-		m_vertexIdGenerator->trash(id);
-	}
-
 	return true;
 }
 
@@ -1803,6 +1812,11 @@ void PatchKernel::_deleteInternalVertex(long id)
 	m_nInternalVertices--;
 	if (id == m_lastInternalVertexId) {
 		updateLastInternalVertexId();
+	}
+
+	// Vertex id is no longer used
+	if (m_vertexIdGenerator) {
+		m_vertexIdGenerator->trash(id);
 	}
 }
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2428,18 +2428,22 @@ PatchKernel::CellIterator PatchKernel::addCell(Cell &&source, long id)
 		id = source.getId();
 	}
 
-	int connectSize = source.getConnectSize();
-	std::unique_ptr<long[]> connectStorage = std::unique_ptr<long[]>(new long[connectSize]);
-	if (!source.hasInfo()){
-		std::copy(source.getConnect(), source.getConnect() + connectSize, connectStorage.get());
-	}
+	// Add a dummy cell
+	//
+	// It is not possible to directly add the source into the storage. First a
+	// dummy cell is created and then that cell is replaced with the source.
+	std::unique_ptr<long[]> dummyConnectStorage = std::unique_ptr<long[]>(nullptr);
 
-	CellIterator iterator = addCell(source.getType(), std::move(connectStorage), id);
+	CellIterator iterator = _addInternalCell(ElementType::UNDEFINED, std::move(dummyConnectStorage), id);
+
+	// Replace the newly created cell with the source
+	//
+	// Before replacing the newly created cell we need to set the id of the
+	// source to the id that has been assigned to the newly created cell.
+	source.setId(iterator->getId());
 
 	Cell &cell = (*iterator);
-	id = cell.getId();
 	cell = std::move(source);
-	cell.setId(id);
 
 	return iterator;
 }
@@ -2522,16 +2526,6 @@ PatchKernel::CellIterator PatchKernel::addCell(ElementType type, std::unique_ptr
 		return cellEnd();
 	}
 
-	if (m_cellIdGenerator) {
-		if (id < 0) {
-			id = m_cellIdGenerator->generate();
-		} else {
-			m_cellIdGenerator->setAssigned(id);
-		}
-	} else if (id < 0) {
-		throw std::runtime_error("No valid id has been provided for the cell.");
-	}
-
 	if (Cell::getDimension(type) > getDimension()) {
 		return cellEnd();
 	}
@@ -2560,6 +2554,17 @@ PatchKernel::CellIterator PatchKernel::addCell(ElementType type, std::unique_ptr
 PatchKernel::CellIterator PatchKernel::_addInternalCell(ElementType type, std::unique_ptr<long[]> &&connectStorage,
 													long id)
 {
+	// Get the id of the cell
+	if (m_cellIdGenerator) {
+		if (id < 0) {
+			id = m_cellIdGenerator->generate();
+		} else {
+			m_cellIdGenerator->setAssigned(id);
+		}
+	} else if (id < 0) {
+		throw std::runtime_error("No valid id has been provided for the cell.");
+	}
+
 	// Get the id of the cell before which the new cell should be inserted
 #if BITPIT_ENABLE_MPI==1
 	//
@@ -2704,9 +2709,6 @@ bool PatchKernel::deleteCell(long id)
 	_deleteInternalCell(id);
 #endif
 
-	// Cell id is no longer used
-	m_cellIdGenerator->trash(id);
-
 	return true;
 }
 
@@ -2777,6 +2779,11 @@ void PatchKernel::_deleteInternalCell(long id)
 	m_nInternalCells--;
 	if (id == m_lastInternalCellId) {
 		updateLastInternalCellId();
+	}
+
+	// Cell id is no longer used
+	if (m_cellIdGenerator) {
+		m_cellIdGenerator->trash(id);
 	}
 }
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1546,6 +1546,7 @@ PatchKernel::VertexIterator PatchKernel::addVertex(const Vertex &source, long id
 */
 PatchKernel::VertexIterator PatchKernel::addVertex(Vertex &&source, long id)
 {
+	// Get the id
 	if (id < 0) {
 		id = source.getId();
 	}
@@ -1620,7 +1621,7 @@ PatchKernel::VertexIterator PatchKernel::addVertex(const std::array<double, 3> &
 */
 PatchKernel::VertexIterator PatchKernel::_addInternalVertex(const std::array<double, 3> &coords, long id)
 {
-	// Get id
+	// Get the id
 	if (m_vertexIdGenerator) {
 		if (id < 0) {
 			id = m_vertexIdGenerator->generate();
@@ -1707,7 +1708,9 @@ PatchKernel::VertexIterator PatchKernel::restoreVertex(const std::array<double, 
 */
 void PatchKernel::_restoreInternalVertex(const VertexIterator &iterator, const std::array<double, 3> &coords)
 {
-	// There is not need to set the id of the vertex as assigned, because
+	// Restore the vertex
+	//
+	// There is no need to set the id of the vertex as assigned, because
 	// also the index generator will be restored.
 	Vertex &vertex = *iterator;
 	vertex.initialize(iterator.getId(), coords, true);
@@ -2424,6 +2427,7 @@ PatchKernel::CellIterator PatchKernel::addCell(const Cell &source, long id)
 */
 PatchKernel::CellIterator PatchKernel::addCell(Cell &&source, long id)
 {
+	// Get the id
 	if (id < 0) {
 		id = source.getId();
 	}
@@ -2664,7 +2668,9 @@ PatchKernel::CellIterator PatchKernel::restoreCell(ElementType type, std::unique
 void PatchKernel::_restoreInternalCell(const CellIterator &iterator, ElementType type,
 								   std::unique_ptr<long[]> &&connectStorage)
 {
-	// There is not need to set the id of the cell as assigned, because
+	// Restore the cell
+	//
+	// There is no need to set the id of the cell as assigned, because
 	// also the index generator will be restored.
 	long cellId = iterator.getId();
 	Cell &cell = *iterator;
@@ -3899,6 +3905,7 @@ PatchKernel::InterfaceIterator PatchKernel::addInterface(const Interface &source
 */
 PatchKernel::InterfaceIterator PatchKernel::addInterface(Interface &&source, long id)
 {
+	// Get the id
 	if (id < 0) {
 		id = source.getId();
 	}
@@ -4027,7 +4034,7 @@ PatchKernel::InterfaceIterator PatchKernel::_addInterface(ElementType type,
 														  std::unique_ptr<long[]> &&connectStorage,
 														  long id)
 {
-	// Get id
+	// Get the id
 	if (m_interfaceIdGenerator) {
 		if (id < 0) {
 			id = m_interfaceIdGenerator->generate();

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -3903,15 +3903,24 @@ PatchKernel::InterfaceIterator PatchKernel::addInterface(Interface &&source, lon
 		id = source.getId();
 	}
 
-	int connectSize = source.getConnectSize();
-	std::unique_ptr<long[]> connectStorage = std::unique_ptr<long[]>(new long[connectSize]);
+	// Add a dummy interface
+	//
+	// It is not possible to directly add the source into the storage. First
+	// a dummy interface is created and then that interface is replaced with
+	// the source.
+	std::unique_ptr<long[]> dummyConnectStorage = std::unique_ptr<long[]>(nullptr);
 
-	InterfaceIterator iterator = addInterface(source.getType(), std::move(connectStorage), id);
+	InterfaceIterator iterator = _addInterface(ElementType::UNDEFINED, std::move(dummyConnectStorage), id);
+
+	// Replace the newly created interface with the source
+	//
+	// Before replacing the newly created interface we need to set the id
+	// of the source to the id that has been assigned to the newly created
+	// interface.
+	source.setId(iterator->getId());
 
 	Interface &interface = (*iterator);
-	id = interface.getId();
 	interface = std::move(source);
-	interface.setId(id);
 
 	return iterator;
 }
@@ -3989,6 +3998,36 @@ PatchKernel::InterfaceIterator PatchKernel::addInterface(ElementType type,
 		return interfaceEnd();
 	}
 
+	if (Interface::getDimension(type) > (getDimension() - 1)) {
+		return interfaceEnd();
+	}
+
+	InterfaceIterator iterator = _addInterface(type, std::move(connectStorage), id);
+
+	return iterator;
+}
+
+/*!
+	Internal function to add a new interface with the specified id.
+
+	If valid, the specified id will we assigned to the newly created interface,
+	otherwise a new unique id will be generated for the interface. However, it
+	is not possible to create a new interface with an id already assigned to an
+	existing interface of the patch. If this happens, an exception is thrown.
+	Ids are considered valid if they are greater or equal than zero.
+
+	\param type is the type of the interface
+	\param connectStorage is the storage the contains or will contain
+	the connectivity of the element
+	\param id is the id of the new cell. If a negative id value is
+	specified, ad new unique id will be generated
+	\return An iterator pointing to the added interface.
+*/
+PatchKernel::InterfaceIterator PatchKernel::_addInterface(ElementType type,
+														  std::unique_ptr<long[]> &&connectStorage,
+														  long id)
+{
+	// Get id
 	if (m_interfaceIdGenerator) {
 		if (id < 0) {
 			id = m_interfaceIdGenerator->generate();
@@ -3999,10 +4038,7 @@ PatchKernel::InterfaceIterator PatchKernel::addInterface(ElementType type,
 		throw std::runtime_error("No valid id has been provided for the interface.");
 	}
 
-	if (Interface::getDimension(type) > (getDimension() - 1)) {
-		return interfaceEnd();
-	}
-
+	// Create the interface
 	PiercedVector<Interface>::iterator iterator = m_interfaces.emreclaim(id, id, type, std::move(connectStorage));
 
 	// Set the alteration flags
@@ -4053,15 +4089,35 @@ PatchKernel::InterfaceIterator PatchKernel::restoreInterface(ElementType type,
 		throw std::runtime_error("Unable to restore the specified interface: the kernel doesn't contain an entry for that interface.");
 	}
 
-	// There is not need to set the id of the interfaces as assigned, because
-	// also the index generator will be restored.
-	Interface &interface = *iterator;
-	interface.initialize(id, type, std::move(connectStorage));
-
-	// Set the alteration flags
-	setRestoredInterfaceAlterationFlags(id);
+	_restoreInterface(iterator, type, std::move(connectStorage));
 
 	return iterator;
+}
+
+/*!
+	Internal function to restore the interface with the specified id.
+
+	The kernel should already contain the interface, only the contents of the
+	interface will be updated.
+
+	\param type is the type of the interface
+	\param connectStorage is the storage the contains or will contain
+	the connectivity of the element
+	\return An iterator pointing to the restored interface.
+*/
+void PatchKernel::_restoreInterface(const InterfaceIterator &iterator, ElementType type,
+									std::unique_ptr<long[]> &&connectStorage)
+{
+	// Restore the interface
+	//
+	// There is no need to set the id of the interfaces as assigned, because
+	// also the index generator will be restored.
+	long interfaceId = iterator.getId();
+	Interface &interface = *iterator;
+	interface.initialize(interfaceId, type, std::move(connectStorage));
+
+	// Set the alteration flags
+	setRestoredInterfaceAlterationFlags(interfaceId);
 }
 
 /*!
@@ -4085,16 +4141,28 @@ bool PatchKernel::deleteInterface(long id)
 		return false;
 	}
 
+	_deleteInterface(id);
+
+	return true;
+}
+
+/*!
+	Internal function to delete an interface.
+
+	\param id is the id of the interface
+*/
+void PatchKernel::_deleteInterface(long id)
+{
 	// Set the alteration flags
 	setDeletedInterfaceAlterationFlags(id);
 
 	// Delete interface
 	m_interfaces.erase(id, true);
+
+	// Interface id is no longer used
 	if (m_interfaceIdGenerator) {
 		m_interfaceIdGenerator->trash(id);
 	}
-
-	return true;
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1047,6 +1047,13 @@ private:
 #if BITPIT_ENABLE_MPI==1
 	void _deleteGhostCell(long id);
 #endif
+
+	InterfaceIterator _addInterface(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id);
+
+	void _restoreInterface(const InterfaceIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage);
+
+	void _deleteInterface(long id);
+
 };
 
 }

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1019,9 +1019,6 @@ private:
 	void setDeletedInterfaceAlterationFlags(long id);
 
 	VertexIterator _addInternalVertex(const std::array<double, 3> &coords, long id);
-#if BITPIT_ENABLE_MPI==1
-	VertexIterator _addGhostVertex(const std::array<double, 3> &coords, int rank, long id);
-#endif
 
 	void _restoreInternalVertex(const VertexIterator &iterator, const std::array<double, 3> &coords);
 #if BITPIT_ENABLE_MPI==1

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -450,7 +450,10 @@ PatchKernel::VertexIterator PatchKernel::restoreVertex(const std::array<double, 
 */
 void PatchKernel::_restoreGhostVertex(const VertexIterator &iterator, const std::array<double, 3> &coords, int rank)
 {
-	// Restore vertex
+	// Restore the vertex
+	//
+	// There is no need to set the id of the vertex as assigned, because
+	// also the index generator will be restored.
 	Vertex &vertex = *iterator;
 	vertex.initialize(iterator.getId(), coords, false);
 	m_nGhostVertices++;
@@ -968,7 +971,10 @@ PatchKernel::CellIterator PatchKernel::restoreCell(ElementType type, std::unique
 void PatchKernel::_restoreGhostCell(const CellIterator &iterator, ElementType type,
 								std::unique_ptr<long[]> &&connectStorage, int rank)
 {
-	// Restore cell
+	// Restore the cell
+	//
+	// There is no need to set the id of the cell as assigned, because
+	// also the index generator will be restored.
 	long cellId = iterator.getId();
 	Cell &cell = *iterator;
 	cell.initialize(iterator.getId(), type, std::move(connectStorage), false, true);

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -482,6 +482,11 @@ void PatchKernel::_deleteGhostVertex(long id)
 	if (id == m_firstGhostVertexId) {
 		updateFirstGhostVertexId();
 	}
+
+    // Vertex id is no longer used
+    if (m_vertexIdGenerator) {
+        m_vertexIdGenerator->trash(id);
+    }
 }
 
 /*!

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -840,17 +840,6 @@ PatchKernel::CellIterator PatchKernel::addCell(ElementType type, std::unique_ptr
 		return cellEnd();
 	}
 
-	if (m_cellIdGenerator) {
-		if (id < 0) {
-			id = m_cellIdGenerator->generate();
-		} else {
-			m_cellIdGenerator->setAssigned(id);
-		}
-	} else if (id < 0) {
-		throw std::runtime_error("No valid id has been provided for the cell.");
-	}
-
-
 	if (Cell::getDimension(type) > getDimension()) {
 		return cellEnd();
 	}
@@ -885,6 +874,17 @@ PatchKernel::CellIterator PatchKernel::addCell(ElementType type, std::unique_ptr
 PatchKernel::CellIterator PatchKernel::_addGhostCell(ElementType type, std::unique_ptr<long[]> &&connectStorage,
 												 int rank, long id)
 {
+	// Get the id of the cell
+	if (m_cellIdGenerator) {
+		if (id < 0) {
+			id = m_cellIdGenerator->generate();
+		} else {
+			m_cellIdGenerator->setAssigned(id);
+		}
+	} else if (id < 0) {
+		throw std::runtime_error("No valid id has been provided for the cell.");
+	}
+
 	// Create the cell
 	//
 	// If there are internal cells, the ghost cell should be inserted
@@ -999,6 +999,11 @@ void PatchKernel::_deleteGhostCell(long id)
 	m_nGhostCells--;
 	if (id == m_firstGhostCellId) {
 		updateFirstGhostCellId();
+	}
+
+	// Cell id is no longer used
+	if (m_cellIdGenerator) {
+		m_cellIdGenerator->trash(id);
 	}
 }
 


### PR DESCRIPTION
It is not possible to directly transfer a vertex/cell/interface into the storage. First a new element should be created and then that element can be replaced with the source that needs to be transferred into the patch. In order to improve performances, the created element can be just a dummy element, no need to copy its properties from the source.