### PR TITLE
levelset: support distributed objects

### DIFF
--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -78,13 +78,6 @@ LevelSet::LevelSet() {
 }
 
 /*!
- * Destructor of LevelSet
-*/
-LevelSet::~LevelSet(){
-    clear() ;
-}
-
-/*!
  * Sets the grid on which the levelset function should be computed.
  * Only cartesian and octree patches are supported at this moment.
  * @param[in] mesh computational grid

--- a/src/levelset/levelSet.hpp
+++ b/src/levelset/levelSet.hpp
@@ -66,7 +66,6 @@ class LevelSet{
     bool                    removeProcessingOrder(int) ;
 
     public:
-    ~LevelSet() ;
     LevelSet() ;
 
     LevelSet(LevelSet&& other) = default;

--- a/src/levelset/levelSet.hpp
+++ b/src/levelset/levelSet.hpp
@@ -51,6 +51,8 @@ class LevelSetObject;
 class LevelSet{
 
     private:
+    IndexGenerator<long> m_objectIdentifierGenerator; /**< Object identifier generator */
+
     std::unique_ptr<LevelSetKernel>                             m_kernel ;              /**< LevelSet computational kernel */
     std::unordered_map<int,std::unique_ptr<LevelSetObject>>     m_objects ;              /**< Objects defining the boundaries */
 

--- a/src/levelset/levelSetBoolean.cpp
+++ b/src/levelset/levelSetBoolean.cpp
@@ -43,13 +43,6 @@ namespace bitpit {
 */
 
 /*!
- * Destructor
- */
-LevelSetBoolean::~LevelSetBoolean(){
-    m_objPtr.clear();
-}
-
-/*!
  * Constructor taking two objects.
  * @param[in] id identifier of object
  * @param[in] op type of boolean operation

--- a/src/levelset/levelSetBoolean.hpp
+++ b/src/levelset/levelSetBoolean.hpp
@@ -56,7 +56,6 @@ class LevelSetBoolean: public LevelSetMetaObject {
     void                                        _restore( std::istream &) override;
 
     public:
-    ~LevelSetBoolean();
     LevelSetBoolean(int, LevelSetBooleanOperation, LevelSetObject*, LevelSetObject*);
     LevelSetBoolean(int, LevelSetBooleanOperation, const std::vector<LevelSetObject*> &);
     LevelSetBoolean(const LevelSetBoolean &);

--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -56,12 +56,6 @@ const int LevelSetCachedObject::PROPAGATION_SIGN_UNDEFINED = -3;
 */
 
 /*!
- * Destructor
- */
-LevelSetCachedObject::~LevelSetCachedObject( ){
-}
-
-/*!
  * Constructor
  * @param[in] id id assigned to object
  */

--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -176,9 +176,17 @@ void LevelSetCachedObject::propagateSign() {
     seeds.reserve(mesh.getCellCount());
 
     // Evaluate the bounding box of the object
+    //
+    // The current process may only have the portion of the object needed for
+    // evaluating the levelset on the cells of its mesh, therefore we need to
+    // evaluate the overall bounding box across all process.
     std::array<double,3> boxMin;
     std::array<double,3> boxMax;
+#if BITPIT_ENABLE_MPI
+    getGlobalBoundingBox(boxMin, boxMax);
+#else
     getBoundingBox(boxMin, boxMax);
+#endif
 
     // Set the initial propagation status of the cells
     //

--- a/src/levelset/levelSetCachedObject.hpp
+++ b/src/levelset/levelSetCachedObject.hpp
@@ -91,7 +91,6 @@ class LevelSetCachedObject : public LevelSetObject{
 # endif 
 
     public:
-    virtual ~LevelSetCachedObject();
     LevelSetCachedObject(int);
 
     LevelSetInfo                                getLevelSetInfo(long ) const override ;

--- a/src/levelset/levelSetCachedObject.hpp
+++ b/src/levelset/levelSetCachedObject.hpp
@@ -70,6 +70,9 @@ class LevelSetCachedObject : public LevelSetObject{
     protected:
     PiercedVector<LevelSetInfo>                 m_ls ;          /**< Levelset information for each cell */
     virtual void                                getBoundingBox( std::array<double,3> &, std::array<double,3> & )const =0  ;
+# if BITPIT_ENABLE_MPI
+    virtual void                                getGlobalBoundingBox( std::array<double,3> &, std::array<double,3> & )const =0  ;
+#endif
 
     void                                        _clear( ) override ;
     virtual void                                __clear() ;

--- a/src/levelset/levelSetMask.cpp
+++ b/src/levelset/levelSetMask.cpp
@@ -47,12 +47,6 @@ namespace bitpit {
 */
 
 /*!
- * Destructor
- */
-LevelSetMask::~LevelSetMask() {
-}
-
-/*!
  * Constructor
  * @param[in] id identifier of object
  * @param[in] mask the list of inner cells

--- a/src/levelset/levelSetMask.hpp
+++ b/src/levelset/levelSetMask.hpp
@@ -44,7 +44,6 @@ class LevelSetMask : public LevelSetSegmentation {
 
 
     public:
-    ~LevelSetMask();
     LevelSetMask(int, const std::unordered_set<long> &, const VolumeKernel &);
     LevelSetMask(int, const std::vector<long> &, long, bool, const VolumeKernel &);
 };

--- a/src/levelset/levelSetMetaObject.cpp
+++ b/src/levelset/levelSetMetaObject.cpp
@@ -41,13 +41,6 @@ namespace bitpit {
 LevelSetMetaObject::LevelSetMetaObject(int id) : LevelSetObject(id){
 }
 
-
-/*!
- * Destructor
- */
-LevelSetMetaObject::~LevelSetMetaObject(){
-}
-
 /*!
  * If the object is primary 
  * @return true

--- a/src/levelset/levelSetMetaObject.hpp
+++ b/src/levelset/levelSetMetaObject.hpp
@@ -32,7 +32,6 @@ class LevelSetObject;
 class LevelSetMetaObject : public LevelSetObject{
     public:
     LevelSetMetaObject(int);
-    virtual ~LevelSetMetaObject();
 
     bool            isPrimary() const override;
     virtual int     getPrimaryObjectId( long ) const =0;

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -49,7 +49,16 @@ LevelSetObject::~LevelSetObject( ){
  * Constructor
  * @param[in] id id assigned to object
  */
-LevelSetObject::LevelSetObject(int id) : m_id(id), m_kernelPtr(nullptr), m_narrowBand(levelSetDefaults::NARROWBAND_SIZE) {
+LevelSetObject::LevelSetObject(int id) :m_kernelPtr(nullptr), m_narrowBand(levelSetDefaults::NARROWBAND_SIZE) {
+    setId(id);
+}
+
+/*!
+ * Sets the identifier of object
+ * @param[in] id is the identifier
+ */
+void LevelSetObject::setId(int id) {
+    m_id = id;
 }
 
 /*!

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -40,12 +40,6 @@ namespace bitpit {
 */
 
 /*!
- * Destructor
- */
-LevelSetObject::~LevelSetObject( ){
-}
-
-/*!
  * Constructor
  * @param[in] id id assigned to object
  */

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -100,7 +100,7 @@ class LevelSetObject : public VTKBaseStreamer{
 # endif 
 
     public:
-    virtual ~LevelSetObject();
+    virtual ~LevelSetObject() = default;
 
     const LevelSetKernel *                      getKernel() const;
 

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -55,6 +55,8 @@ class LevelSetObject : public VTKBaseStreamer{
     private:
     int                                         m_id;           /**< identifier of object */
 
+    void                                        setId(int id);
+
     protected:
     LevelSetObject(int);
     LevelSetObject(const LevelSetObject &other) = default;

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -502,12 +502,6 @@ LevelSetSegmentation::SurfaceInfo::SurfaceInfo( long index, const std::array<dou
 */
 
 /*!
- * Destructor
- */
-LevelSetSegmentation::~LevelSetSegmentation() {
-}
-
-/*!
  * Constructor
  * @param[in] id identifier of object
  */

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -140,6 +140,9 @@ class LevelSetSegmentation : public LevelSetCachedObject {
 # endif
 
     void                                        getBoundingBox( std::array<double,3> &, std::array<double,3> &) const override;
+# if BITPIT_ENABLE_MPI
+    void                                        getGlobalBoundingBox( std::array<double,3> &, std::array<double,3> &) const override;
+#endif
 
     void                                        computeLSInNarrowBand( LevelSetCartesian *, bool);
     void                                        computeLSInNarrowBand( LevelSetOctree *, bool);

--- a/src/levelset/levelSetSegmentation.hpp
+++ b/src/levelset/levelSetSegmentation.hpp
@@ -146,7 +146,6 @@ class LevelSetSegmentation : public LevelSetCachedObject {
     void                                        updateLSInNarrowBand(LevelSetOctree *, const std::vector<adaption::Info> &, bool);
 
     public:
-    virtual ~LevelSetSegmentation();
     LevelSetSegmentation(int);
     LevelSetSegmentation(int, std::unique_ptr<const SurfUnstructured> &&, double featureAngle = 2. * BITPIT_PI);
     LevelSetSegmentation(int, const SurfUnstructured*, double featureAngle = 2. * BITPIT_PI);


### PR DESCRIPTION
 The current process may only have the portion of the object needed for evaluating the levelset on the cells of its mesh, therefore, when the bounding box of the object is needed, we need to evaluate the overall bounding box across all process.

@edoardolombardi I've also modified the levelset to handle object ids using an IndexGenerator. This should fix the problem you were having when deleting objects from the levelset.