### PR TITLE
cmake: define a verbose version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,14 @@ set(VERSION_TAG_MATCHER_REGEX "^${CMAKE_PROJECT_NAME}-[^-]*(-(.*))?$")
 # Initialize version string
 set(BITPIT_VERSION_STRING "${CMAKE_PROJECT_NAME}-${BITPIT_VERSION}")
 
-# Add git information
+string(REGEX MATCH "${VERSION_MATCHER_REGEX}" VERSION_STRING_VALID "${BITPIT_VERSION_STRING}")
+if ("${VERSION_STRING_VALID}" STREQUAL "")
+    message(FATAL_ERROR "Version string \"${BITPIT_VERSION_STRING}\" is not a valid version.")
+endif()
+
+# Initialize verbose version string
+set(BITPIT_VERBOSE_VERSION_STRING "${BITPIT_VERSION_STRING}")
+
 get_git_head_revision(BITPIT_GIT_REFERENCE BITPIT_GIT_HASH)
 if(NOT "${BITPIT_GIT_REFERENCE}" STREQUAL "GITDIR-NOTFOUND")
     # Add git information
@@ -349,16 +356,16 @@ if(NOT "${BITPIT_GIT_REFERENCE}" STREQUAL "GITDIR-NOTFOUND")
     # Information about git are added only if git tag doens't match the version
     # string.
     git_get_exact_tag(BITPIT_GIT_TAG)
-    if(NOT "${BITPIT_GIT_TAG}" STREQUAL "${BITPIT_VERSION_STRING}")
+    if(NOT "${BITPIT_GIT_TAG}" STREQUAL "${BITPIT_VERBOSE_VERSION_STRING}")
         git_get_branch(BITPIT_GIT_BRANCH)
         if(NOT "${BITPIT_GIT_BRANCH}" MATCHES "NOTFOUND$")
-            set(BITPIT_VERSION_STRING "${BITPIT_VERSION_STRING}-${BITPIT_GIT_BRANCH}")
+            set(BITPIT_VERBOSE_VERSION_STRING "${BITPIT_VERBOSE_VERSION_STRING}-${BITPIT_GIT_BRANCH}")
         else()
-            set(BITPIT_VERSION_STRING "${BITPIT_VERSION_STRING}-detached")
+            set(BITPIT_VERBOSE_VERSION_STRING "${BITPIT_VERBOSE_VERSION_STRING}-detached")
         endif()
 
         git_get_short_hash(BITPIT_GIT_SHORT_HASH)
-        set(BITPIT_VERSION_STRING "${BITPIT_VERSION_STRING}-${BITPIT_GIT_SHORT_HASH}")
+        set(BITPIT_VERBOSE_VERSION_STRING "${BITPIT_VERBOSE_VERSION_STRING}-${BITPIT_GIT_SHORT_HASH}")
     endif()
 
     # Report if there are uncommited changes
@@ -366,22 +373,23 @@ if(NOT "${BITPIT_GIT_REFERENCE}" STREQUAL "GITDIR-NOTFOUND")
     # It's not possible to automatically re-run cmake (and thus update the
     # version) if there are uncommited changes. The label will be reliably
     # added only if, after changing the code, cmake is run manually.
-    set(BITPIT_VERSION_DIRTY_LABEL "dirty" CACHE STRING "Label that will be added to the version string when there are uncommited changes")
-    mark_as_advanced(${BITPIT_VERSION_DIRTY_LABEL})
+    set(BITPIT_VERBOSE_VERSION_DIRTY_TAG "dirty" CACHE STRING "Tag that will be added to the verbose version string when there are uncommited changes")
+    mark_as_advanced(BITPIT_VERBOSE_VERSION_DIRTY_TAG)
 
     git_local_changes(BITPIT_GIT_STATUS)
     if (BITPIT_GIT_STATUS STREQUAL "DIRTY")
-        set(BITPIT_VERSION_STRING "${BITPIT_VERSION_STRING}-${BITPIT_VERSION_DIRTY_LABEL}")
+        set(BITPIT_VERBOSE_VERSION_STRING "${BITPIT_VERBOSE_VERSION_STRING}-${BITPIT_VERBOSE_VERSION_DIRTY_LABEL}")
     endif()
 endif()
 
-# Check if version string is valid
-string(REGEX MATCH "${VERSION_MATCHER_REGEX}" VERSION_STRING_VALID "${BITPIT_VERSION_STRING}")
+string(REGEX MATCH "${VERSION_MATCHER_REGEX}" VERSION_STRING_VALID "${BITPIT_VERBOSE_VERSION_STRING}")
 if ("${VERSION_STRING_VALID}" STREQUAL "")
-    message(FATAL_ERROR "Version string \"${BITPIT_VERSION_STRING}\" is not a valid version.")
+    message(FATAL_ERROR "Version string \"${BITPIT_VERBOSE_VERSION_STRING}\" is not a valid verbose version.")
 endif()
 
 # Extract version information
+string(REGEX REPLACE "${VERSION_MATCHER_REGEX}" "\\1" BITPIT_VERBOSE_VERSION "${BITPIT_VERBOSE_VERSION_STRING}")
+
 string(REGEX REPLACE "${VERSION_MATCHER_REGEX}" "\\1" BITPIT_VERSION "${BITPIT_VERSION_STRING}")
 string(REGEX REPLACE "${VERSION_MATCHER_REGEX}" "\\3" BITPIT_MAJOR_VERSION "${BITPIT_VERSION_STRING}")
 string(REGEX REPLACE "${VERSION_MATCHER_REGEX}" "\\5" BITPIT_MINOR_VERSION "${BITPIT_VERSION_STRING}")

--- a/src/common/bitpit_version.hpp
+++ b/src/common/bitpit_version.hpp
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+ \*---------------------------------------------------------------------------*/
+
+#ifndef __BITPIT_VERSION_INFO_HPP__
+#define __BITPIT_VERSION_INFO_HPP__
+
+#include "version.hpp"
+#include "version_verbose.hpp"
+
+#endif

--- a/src/common/version.hpp.in
+++ b/src/common/version.hpp.in
@@ -33,7 +33,7 @@
 
 namespace bitpit {
 
-const std::string & getVersion();
+const std::string & getVersion(bool verbose = false);
 
 }
 

--- a/src/common/version_verbose.hpp.in
+++ b/src/common/version_verbose.hpp.in
@@ -22,27 +22,11 @@
  *
 \*---------------------------------------------------------------------------*/
 
-#include "version.hpp"
+/*! \file */
 
-#include "version_verbose.hpp"
+#ifndef __BITPIT_VERBOSE_VERSION_HPP__
+#define __BITPIT_VERBOSE_VERSION_HPP__
 
-namespace bitpit {
+#define BITPIT_VERBOSE_VERSION "@BITPIT_VERBOSE_VERSION@"
 
-/*!
- * Get the bitpit version.
- *
- * \param verbose if set to true, verbose version will be returned.
- */
-const std::string & getVersion(bool verbose)
-{
-    const static std::string VERSION_STRING         = BITPIT_VERSION;
-    const static std::string VERBOSE_VERSION_STRING = BITPIT_VERBOSE_VERSION;
-
-    if (verbose) {
-        return VERBOSE_VERSION_STRING;
-    } else {
-        return VERSION_STRING;
-    }
-}
-
-}
+#endif


### PR DESCRIPTION
Information about git will be added only to the verbose version. This should avoid a whole recompilation every time git data is updated.