### PR TITLE
patchkernel: allow to enable thread safe lookups of skdtree

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -927,7 +927,8 @@ PatchSkdTree::PatchSkdTree(const PatchKernel *patch, bool interiorCellsOnly)
     : m_patchInfo(patch, &m_cellRawIds),
       m_cellRawIds(interiorCellsOnly ? patch->getInternalCellCount() : patch->getCellCount()),
       m_nLeafs(0), m_nMinLeafCells(0), m_nMaxLeafCells(0),
-      m_interiorCellsOnly(interiorCellsOnly)
+      m_interiorCellsOnly(interiorCellsOnly),
+      m_threadSafeLookups(false)
 #if BITPIT_ENABLE_MPI
     , m_rank(0), m_nProcessors(1), m_communicator(MPI_COMM_NULL)
 #endif
@@ -1292,6 +1293,26 @@ void PatchSkdTree::createLeaf(std::size_t nodeId)
     ++m_nLeafs;
     m_nMinLeafCells = std::min(nodeCellCount, m_nMinLeafCells);
     m_nMaxLeafCells = std::max(nodeCellCount, m_nMaxLeafCells);
+}
+
+/*!
+* Set if the tree lookups should be thread safe.
+*
+* \param enable if set to true the lookups will be thread safe.
+*/
+void PatchSkdTree::enableThreadSafeLookups(bool enable)
+{
+    m_threadSafeLookups = enable;
+}
+
+/*!
+* Check if tree lookups are thread safe.
+*
+* \result Returns true if tree lookups are thread safe, false otherwise.
+*/
+bool PatchSkdTree::areLookupsThreadSafe() const
+{
+    return m_threadSafeLookups;
 }
 
 #if BITPIT_ENABLE_MPI

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -199,6 +199,9 @@ public:
 
     std::size_t evalMaxDepth(std::size_t rootId = 0) const;
 
+    void enableThreadSafeLookups(bool enable);
+    bool areLookupsThreadSafe() const;
+
 #if BITPIT_ENABLE_MPI
     const SkdBox & getPartitionBox(int rank) const;
 #endif
@@ -214,6 +217,8 @@ protected:
     std::vector<SkdNode, SkdNode::Allocator> m_nodes;
 
     bool m_interiorCellsOnly;
+
+    bool m_threadSafeLookups;                                       /*! Controls if the tree lookups should be thread safe */
 
 #if BITPIT_ENABLE_MPI
     int m_rank;


### PR DESCRIPTION
Modify skd-tree to enable thread safe lookups. 

If thread safe lookup is enabled, temporary data structures are allocated at each searching call and used in place of the stack members of the class.