### PR TITLE
PatchKernel: fix  missing implementation of getInternalVertexCount method

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1376,6 +1376,16 @@ long PatchKernel::getVertexCount() const
 }
 
 /*!
+	Gets the number of internal vertices in the patch.
+
+	\return The number of internal vertices in the patch.
+*/
+long PatchKernel::getInternalVertexCount() const
+{
+	return m_nInternalVertices;
+}
+
+/*!
 	Gets the nodes owned by the patch.
 
 	\return The nodes owned by the patch.


### PR DESCRIPTION
method declared in hpp, but missing implementation in cpp.