### PR TITLE
discretization: modify how singular values are discarded

### DIFF
--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2810,7 +2810,7 @@ void ReconstructionKernel::display(std::ostream &out, double tolerance) const
 /*!
  * Is the threshold below which a singular value is considered zero.
  */
-const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-9;
+const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-14;
 
 
 /*!

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -3283,7 +3283,7 @@ void ReconstructionAssembler::computePseudoInverse(int m, int n, double zeroThre
     // To check if a signular value is non zero, we only need to check if it's
     // greater than the defined threshold.
     for (int i = 0; i < k; ++i) {
-        double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : m_sigma[i];
+        double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : 0.;
         cblas_dscal(m, sigma_plus, &m_U[i*m], 1);
     }
 

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -3283,8 +3283,8 @@ void ReconstructionAssembler::computePseudoInverse(int m, int n, double zeroThre
     // To check if a signular value is non zero, we only need to check if it's
     // greater than the defined threshold.
     for (int i = 0; i < k; ++i) {
-       double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : m_sigma[i];
-       cblas_dscal(m, sigma_plus, &m_U[i*m], 1);
+        double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : m_sigma[i];
+        cblas_dscal(m, sigma_plus, &m_U[i*m], 1);
     }
 
     // Inv(A) = (Vt)^T * u^T

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2808,7 +2808,7 @@ void ReconstructionKernel::display(std::ostream &out, double tolerance) const
  */
 
 /*!
- * Is the threshold for which a singuler value is considered zero.
+ * Is the threshold below which a singular value is considered zero.
  */
 const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-9;
 
@@ -3278,6 +3278,10 @@ void ReconstructionAssembler::computePseudoInverse(int m, int n, double zeroThre
     //
     // u = sigma^ + *U
     // and is stored in U
+    //
+    // Sigma are singular values, hence they are non-negative by definition.
+    // To check if a signular value is non zero, we only need to check if it's
+    // greater than the defined threshold.
     for (int i = 0; i < k; ++i) {
        double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : m_sigma[i];
        cblas_dscal(m, sigma_plus, &m_U[i*m], 1);


### PR DESCRIPTION
Threshold that defines when singular values are discarded is reduced and discarded singular values are now set to zero.

It seems that the code:
```
    for (int i = 0; i < k; ++i) {
        double sigma_plus = (m_sigma[i] > zeroThreshold) ? (1. / m_sigma[i]) : 0.;
        cblas_dscal(m, sigma_plus, &m_U[i*m], 1);
    }
```
corresponds to equation 24 of the paper and not to equation 22 (I haven't modified the comment, because I'm not sure if I'm right).

@marcocisternino A threshold of 1e-14 seems quite small, can this threshold be increased to 1e-12?

