### PR TITLE
Set a lower SVD zero threshold

### DIFF
--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2810,7 +2810,7 @@ void ReconstructionKernel::display(std::ostream &out, double tolerance) const
 /*!
  * Is the threshold for which a singuler value is considered zero.
  */
-const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-9;
+const double ReconstructionAssembler::SVD_ZERO_THRESHOLD = 1e-14;
 
 
 /*!


### PR DESCRIPTION
This modification decreases the threshold to consider a singular value of a matrix as a zero . The threshold was set at 1.0e-9. This branch sets the threshold at 1.0e-14. This makes immerflow reconstructions of variables at the wall correct.
Following A. Neumaier "SOLVING ILL-CONDITIONED AND SINGULAR LINEAR SYSTEMS:A TUTORIAL ON REGULARIZATION", considering too small single values in minimum norm least squares regularization method could give ill-conditioned matrices that can amplify possible noise in right hand sides. To be more robust, the diagonal matrix capital sigma plus in equation 22 of the reference should be built using equation 24 (truncated singular value decomposition(TSVD)).
If we can foresee problems with very tiny singular values, implementing TSVD could be a promising alternative, but finding optimal truncation can be tricky.