### PR TITLE
levelset: fix identification of external cells

### DIFF
--- a/src/levelset/levelSetCachedObject.hpp
+++ b/src/levelset/levelSetCachedObject.hpp
@@ -57,8 +57,8 @@ class LevelSetCachedObject : public LevelSetObject{
     void                                        setSign( long id, int sign ) ;
 
     void                                        initializeCellSignPropagation( long cellId, int cellSign,
-                                                                               const std::array<double, 3> &boxMin,
-                                                                               const std::array<double, 3> &boxMax,
+                                                                               const std::array<double, 3> &objectBoxMin,
+                                                                               const std::array<double, 3> &objectBoxMax,
                                                                                int *cellStatus, std::vector<long> *seeds,
                                                                                long *nWaiting, long *nExternal,
                                                                                int *externalSign ) ;


### PR DESCRIPTION
A cell should be considered external if it is completely outside the object bounding box. If the cell may be intersected by the object (i.e., the bounding box of the cell intersects the bounding box of the object), the cell cannot be flagged as external.