### PR TITLE
patchkernel: remove some unneeded vector copies

### DIFF
--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -952,13 +952,13 @@ bool SurfaceKernel::adjustCellOrientation(long seed, bool invert)
 
         for (auto &entry : getGhostCellExchangeSources()) {
             const int rank = entry.first;
-            const std::vector<long> sources = entry.second;
+            const std::vector<long> &sources = entry.second;
             ghostComm->setSend(rank, sources.size() * sizeof(bool));
         }
 
         for (auto &entry : getGhostCellExchangeTargets()) {
             const int rank = entry.first;
-            const std::vector<long> targets = entry.second;
+            const std::vector<long> &targets = entry.second;
             ghostComm->setRecv(rank, targets.size() * sizeof(bool));
         }
     }


### PR DESCRIPTION
When adjusting cell orientation of a surface patch, it is possible to take a reference to the lists of ghost exchange sources/targets instead of making a copy.