### PR TITLE
levelset: fix search radius for Cartesian meshes

### DIFF
--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -484,8 +484,8 @@ double LevelSet::getSizeNarrowBand() const{
 
 /*!
  * Manually set the physical size of the narrow band.
- * Setting a size equal or less than zero levelset will be evaluated only on
- * cells that intersect the surface.
+ * Setting a size equal or less than zero, levelset will be evaluated only on
+ * the cells that intersect the surface and on all their first neighbours.
  * After setting the size of the narrowband, the levelset is not automatically
  * updated. It's up to the caller to make sure the levelset will be properly
  * updated if the size of the narrowband changes.

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -189,8 +189,8 @@ double LevelSetObject::getSizeNarrowBand()const{
 
 /*!
  * Manually set the size of the narrow band.
- * Setting a size equal or less than zero levelset will be evaluated only on
- * cells that intersect the surface.
+ * Setting a size equal or less than zero, levelset will be evaluated only on
+ * the cells that intersect the surface and on all their first neighbours.
  * After setting the size of the narrowband, the levelset is not automatically
  * updated. It's up to the caller to make sure the levelset will be properly
  * updated if the size of the narrowband changes.

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -777,14 +777,12 @@ void LevelSetSegmentation::updateLSInNarrowBand( const std::vector<adaption::Inf
 }
 
 /*!
- * Computes the levelset within the narrow band on an
- * cartesian grid.
- * If the size of the narrow band has been set, the
- * method will compute the levelset values only of those
- * cells within the threshold. 
- * In case the size of the narrow band has not been set,
- * the method will calculate the levelset within a band
- * containing one cell on each side of the surface.
+ * Computes the levelset within the narrow band on an cartesian grid.
+ * If the size of the narrow band has been set, the method will compute the
+ * levelset values only of those cells within the threshold.
+ * In case the size of the narrow band has not been set, levelset will be
+ * evaluated only on the cells that intersect the surface and on all their
+ * first neighbours.
  * @param[in] visitee the octree LevelSetKernel
  * @param[in] signd whether signed distance should be calculated
  */
@@ -805,7 +803,7 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetCartesian *visitee, bo
     // size and the diameter of the circumcircle. This guarantees that, when
     // the narrow band size is equal or less than zero, the levelset will be
     // evaluated on the cells that intersect the surface and on all their
-    // neighbours.
+    // first neighbours.
     double searchRadius = std::max(m_narrowBand, 2 * visitee->getCellCircumcircle());
 
     // Define mesh bounding box
@@ -913,14 +911,14 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetCartesian *visitee, bo
 }
 
 /*!
- * Computes the levelset within the narrow band on an
- * octree grid.
- * If the size of the narrow band has been set, the
- * method will compute the levelset values only of those
- * cells within the threshold. 
- * In case the size of the narrow band has not been set,
- * the method will calculate the levelset within the cells
- * that intersect the surface and within their first neighbours,
+ * Computes the levelset within the narrow band on an octree grid.
+ * If the size of the narrow band has been set, the method will compute the
+ * levelset values on the cells that intersect the surface, on all their
+ * first neighbours and on the cells with a distance from the surface less
+ * than the threshold.
+ * In case the size of the narrow band has not been set, levelset will be
+ * evaluated only on the cells that intersect the surface and on all their
+ * first neighbours.
  * \param[in] visitee the octree LevelSetKernel
  * \param[in] signd whether signed distance should be calculated
  */
@@ -1040,15 +1038,15 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetOctree *visitee, bool 
 }
 
 /*!
- * Updates the levelset within the narrow band on an
- * octree grid after an grid adaption.
- * If the size of the narrow band has been set, the
- * method will compute the levelset values only of those
- * cells within the threshold. 
- * In case the size of the narrow band has not been set,
- * the method will calculate the levelset within the cells
- * that intersect the surface and within their first neighbours,
- * @param[in] visitee the octree LevelSetKernel
+ * Updates the levelset within the narrow band on an octree grid after an grid
+ * adaption.
+ * If the size of the narrow band has been set, the method will compute the
+ * levelset values on the cells that intersect the surface, on all their
+ * first neighbours and on the cells with a distance from the surface less
+ * than the threshold.
+ * In case the size of the narrow band has not been set, levelset will be
+ * evaluated only on the cells that intersect the surface and on all their
+ * first neighbours.
  * @param[in] mapper the adaption mapper
  * @param[in] signd whether signed distance should be calculated
  */

--- a/src/levelset/levelSetSegmentation.cpp
+++ b/src/levelset/levelSetSegmentation.cpp
@@ -800,7 +800,13 @@ void LevelSetSegmentation::computeLSInNarrowBand( LevelSetCartesian *visitee, bo
     const SurfUnstructured &surface = m_segmentation->getSurface();
 
     // Define search radius
-    double searchRadius = std::max(m_narrowBand, visitee->getCellCircumcircle());
+    //
+    // Search radius should be equal to the maximum between the narrow band
+    // size and the diameter of the circumcircle. This guarantees that, when
+    // the narrow band size is equal or less than zero, the levelset will be
+    // evaluated on the cells that intersect the surface and on all their
+    // neighbours.
+    double searchRadius = std::max(m_narrowBand, 2 * visitee->getCellCircumcircle());
 
     // Define mesh bounding box
     //


### PR DESCRIPTION
Search radius should be equal to the maximum between the narrow band size and diameter of the circumcircle. This guarantees that, if the size of the narrow band is equal or less than zero, the levelset will be evaluated on the cells that intersect the surface and on all their neighbours.

This is the same behaviour of the octree patch and, as an example, generates the narrow band in the image below. 
![narrowband](https://user-images.githubusercontent.com/7443174/130836890-57ddaaf3-9d3b-4a82-8049-2fe2561729b9.png)
