### PR TITLE
Add absolute convergence threshold to KSP options

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1415,8 +1415,8 @@ void SystemSolver::preKSPSetupActions()
     if (m_KSPOptions.restart != PETSC_DEFAULT) {
         KSPGMRESSetRestart(m_KSP, m_KSPOptions.restart);
     }
-    if (m_KSPOptions.rtol != PETSC_DEFAULT || m_KSPOptions.maxits != PETSC_DEFAULT) {
-        KSPSetTolerances(m_KSP, m_KSPOptions.rtol, PETSC_DEFAULT, PETSC_DEFAULT, m_KSPOptions.maxits);
+    if (m_KSPOptions.rtol != PETSC_DEFAULT || m_KSPOptions.atol != PETSC_DEFAULT || m_KSPOptions.maxits != PETSC_DEFAULT) {
+        KSPSetTolerances(m_KSP, m_KSPOptions.rtol, m_KSPOptions.atol, PETSC_DEFAULT, m_KSPOptions.maxits);
     }
     KSPSetInitialGuessNonzero(m_KSP, PETSC_TRUE);
 }

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -39,6 +39,7 @@ struct KSPOptions {
     PetscInt restart;
     PetscInt maxits;
     PetscScalar rtol;
+    PetscScalar atol;
 
     PetscInt overlap;
     PetscInt levels;
@@ -47,7 +48,8 @@ struct KSPOptions {
     PetscScalar subrtol;
 
     KSPOptions()
-        : restart(PETSC_DEFAULT), maxits(PETSC_DEFAULT), rtol(PETSC_DEFAULT),
+        : restart(PETSC_DEFAULT), maxits(PETSC_DEFAULT),
+          rtol(PETSC_DEFAULT), atol(PETSC_DEFAULT),
           overlap(PETSC_DEFAULT), levels(PETSC_DEFAULT),
           sublevels(PETSC_DEFAULT), subrtol(PETSC_DEFAULT)
     {


### PR DESCRIPTION
When the solution of the system is the null vector, it may be necessary to impose an absolute tolerance to get a properly convergence of the solver.