### PR TITLE
containers: define a thread-safe version of the ProxyVector

### DIFF
--- a/src/containers/proxyVector.cpp
+++ b/src/containers/proxyVector.cpp
@@ -27,12 +27,20 @@
 namespace bitpit{
 
 // Some commonly used ProxyVectors are instantiated explicitly
-template class ProxyVector<int>;
-template class ProxyVector<long>;
-template class ProxyVector<double>;
+template class ProxyVector<int, true>;
+template class ProxyVector<long, true>;
+template class ProxyVector<double, true>;
 
-template class ProxyVector<const int>;
-template class ProxyVector<const long>;
-template class ProxyVector<const double>;
+template class ProxyVector<int, false>;
+template class ProxyVector<long, false>;
+template class ProxyVector<double, false>;
+
+template class ProxyVector<const int, true>;
+template class ProxyVector<const long, true>;
+template class ProxyVector<const double, true>;
+
+template class ProxyVector<const int, false>;
+template class ProxyVector<const long, false>;
+template class ProxyVector<const double, false>;
 
 }

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -38,14 +38,14 @@
 #define  __PXI_REFERENCE__ typename ProxyVectorIterator<value_t, container_t>::reference
 #define  __PXI_POINTER__   typename ProxyVectorIterator<value_t, container_t>::pointer
 
-#define __PXV_REFERENCE__             typename ProxyVector<value_t>::reference
-#define __PXV_CONST_REFERENCE__       typename ProxyVector<value_t>::const_reference
-#define __PXV_POINTER__               typename ProxyVector<value_t>::pointer
-#define __PXV_CONST_POINTER__         typename ProxyVector<value_t>::const_pointer
-#define __PXV_STORAGE_POINTER__       typename ProxyVector<value_t>::storage_pointer
-#define __PXV_STORAGE_CONST_POINTER__ typename ProxyVector<value_t>::storage_const_pointer
-#define __PXV_ITERATOR__              typename ProxyVector<value_t>::iterator
-#define __PXV_CONST_ITERATOR__        typename ProxyVector<value_t>::const_iterator
+#define __PXV_REFERENCE__             typename ProxyVector<value_t, thread_safe>::reference
+#define __PXV_CONST_REFERENCE__       typename ProxyVector<value_t, thread_safe>::const_reference
+#define __PXV_POINTER__               typename ProxyVector<value_t, thread_safe>::pointer
+#define __PXV_CONST_POINTER__         typename ProxyVector<value_t, thread_safe>::const_pointer
+#define __PXV_STORAGE_POINTER__       typename ProxyVector<value_t, thread_safe>::storage_pointer
+#define __PXV_STORAGE_CONST_POINTER__ typename ProxyVector<value_t, thread_safe>::storage_const_pointer
+#define __PXV_ITERATOR__              typename ProxyVector<value_t, thread_safe>::iterator
+#define __PXV_CONST_ITERATOR__        typename ProxyVector<value_t, thread_safe>::const_iterator
 
 #include <cassert>
 #include <memory>
@@ -55,7 +55,7 @@
 
 namespace bitpit {
 
-template<typename PXV_value_t>
+template<typename PXV_value_t, bool PXV_thread_safe>
 class ProxyVector;
 
 /*!
@@ -70,7 +70,7 @@ class ProxyVectorIterator
     : public std::iterator<std::random_access_iterator_tag, value_t, std::ptrdiff_t, __PXI_POINTER_TYPE__, __PXI_REFERENCE_TYPE__>
 {
 
-template<typename PXV_value_t>
+template<typename PXV_value_t, bool PXV_thread_safe>
 friend class ProxyVector;
 
 friend class ProxyVectorIterator<typename std::add_const<value_t>::type, container_t>;
@@ -190,7 +190,7 @@ template<typename value_t, typename pointer_t = value_t *, typename const_pointe
 class ProxyVectorDummyStorage : public ProxyVectorStorageInterface<pointer_t, const_pointer_t>
 {
 
-template<typename PXV_value_t>
+template<typename PXV_value_t, bool PXV_thread_safe>
 friend class ProxyVector;
 
 public:
@@ -218,12 +218,14 @@ protected:
 
     @tparam value_t is the type of the objects handled by the storage
     @tparam container_t defines the type of container where the data is stored
+    @tparam thread_safe controls if it is safe to use the container in
+    a multi-threaded code
 */
-template<typename value_t, typename container_t>
+template<typename value_t, typename container_t, bool thread_safe>
 class ProxyVectorStorage : public ProxyVectorStorageInterface<typename container_t::pointer, typename container_t::const_pointer>
 {
 
-template<typename PXV_value_t>
+template<typename PXV_value_t, bool PXV_thread_safe>
 friend class ProxyVector;
 
 public:
@@ -280,8 +282,10 @@ private:
     bject itself.
 
     @tparam value_t is the type of the objects handled by the ProxyVector
+    @tparam thread_safe controls if it is safe to use the container in
+    a multi-threaded code
 */
-template<typename value_t>
+template<typename value_t, bool thread_safe = false>
 class ProxyVector
 {
 
@@ -429,7 +433,7 @@ private:
     */
     typedef
         typename std::conditional<std::is_const<value_t>::value,
-            ProxyVectorStorage<value_no_cv_t, container_type>,
+            ProxyVectorStorage<value_no_cv_t, container_type, thread_safe>,
             ProxyVectorDummyStorage<value_no_cv_t>>::type
         storage_t;
 
@@ -441,8 +445,8 @@ private:
 };
 
 // Constant proxy vector
-template<typename value_t>
-using ConstProxyVector = ProxyVector<const value_t>;
+template<typename value_t, bool thread_safe = false>
+using ConstProxyVector = ProxyVector<const value_t, thread_safe>;
 
 }
 
@@ -452,13 +456,21 @@ using ConstProxyVector = ProxyVector<const value_t>;
 namespace bitpit{
 
 // Some commonly used ProxyVectors are instantiated explicitly
-extern template class ProxyVector<int>;
-extern template class ProxyVector<long>;
-extern template class ProxyVector<double>;
+extern template class ProxyVector<int, true>;
+extern template class ProxyVector<long, true>;
+extern template class ProxyVector<double, true>;
 
-extern template class ProxyVector<const int>;
-extern template class ProxyVector<const long>;
-extern template class ProxyVector<const double>;
+extern template class ProxyVector<int, false>;
+extern template class ProxyVector<long, false>;
+extern template class ProxyVector<double, false>;
+
+extern template class ProxyVector<const int, true>;
+extern template class ProxyVector<const long, true>;
+extern template class ProxyVector<const double, true>;
+
+extern template class ProxyVector<const int, false>;
+extern template class ProxyVector<const long, false>;
+extern template class ProxyVector<const double, false>;
 
 }
 

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -238,8 +238,8 @@ public:
 
     void swap(ProxyVectorStorage &other) noexcept;
 
-    container_t * container();
-    const container_t * container() const;
+    container_t * container(bool forceCreation);
+    const container_t * container(bool forceCreation) const;
 
     pointer data() override;
     const_pointer data() const override;
@@ -260,8 +260,8 @@ private:
 
     static std::vector<std::unique_ptr<container_t>> m_containerPool;
 
-    std::unique_ptr<container_t> createContainer(std::size_t size);
-    std::unique_ptr<container_t> createContainer(const std::unique_ptr<container_t> &source);
+    std::unique_ptr<container_t> createContainer(std::size_t size, bool allowEmpty);
+    std::unique_ptr<container_t> createContainer(const std::unique_ptr<container_t> &source, bool allowEmpty);
     void destroyContainer(std::unique_ptr<container_t> *container);
 
     std::unique_ptr<container_t> m_container;
@@ -392,9 +392,9 @@ public:
     __PXV_STORAGE_CONST_POINTER__ storedData() const noexcept;
 
     template<typename U = value_t, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    container_type * storedDataContainer();
+    container_type * storedDataContainer(bool forceCreation = false);
     template<typename U = value_t, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
-    const container_type * storedDataContainer() const;
+    const container_type * storedDataContainer(bool forceCreation = false) const;
 
     template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_POINTER__ data() noexcept;

--- a/src/containers/proxyVector.hpp
+++ b/src/containers/proxyVector.hpp
@@ -227,7 +227,7 @@ template<typename PXV_value_t>
 friend class ProxyVector;
 
 public:
-    typedef container_t container;
+    typedef container_t container_type;
 
     typedef typename container_t::pointer pointer;
     typedef typename container_t::const_pointer const_pointer;
@@ -235,6 +235,9 @@ public:
     ~ProxyVectorStorage();
 
     void swap(ProxyVectorStorage &other) noexcept;
+
+    container_t * container();
+    const container_t * container() const;
 
     pointer data() override;
     const_pointer data() const override;
@@ -383,6 +386,11 @@ public:
 
     __PXV_STORAGE_POINTER__ storedData() noexcept;
     __PXV_STORAGE_CONST_POINTER__ storedData() const noexcept;
+
+    template<typename U = value_t, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
+    container_type * storedDataContainer();
+    template<typename U = value_t, typename std::enable_if<std::is_const<U>::value, int>::type = 0>
+    const container_type * storedDataContainer() const;
 
     template<typename U = value_t, typename std::enable_if<!std::is_const<U>::value, int>::type = 0>
     __PXV_POINTER__ data() noexcept;

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -226,6 +226,7 @@ typename ProxyVectorDummyStorage<value_t, pointer_t, const_pointer_t>::const_poi
 {
     return nullptr;
 }
+
 /*!
     Check if the storage is empty.
 

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -368,6 +368,28 @@ ProxyVectorStorage<value_t, container_t>::~ProxyVectorStorage()
 }
 
 /*!
+    Get a reference to the data container associated with the storage.
+
+    \result A reference to the data container associated with the storage.
+*/
+template<typename value_t, typename container_t>
+container_t * ProxyVectorStorage<value_t, container_t>::container()
+{
+    return m_container.get();
+}
+
+/*!
+    Get a reference to the data container associated with the storage.
+
+    \result A reference to the data container associated with the storage.
+*/
+template<typename value_t, typename container_t>
+const container_t * ProxyVectorStorage<value_t, container_t>::container() const
+{
+    return m_container.get();
+}
+
+/*!
     Swaps the contents.
 
     \param other is another storage of the same type
@@ -729,6 +751,42 @@ __PXV_STORAGE_CONST_POINTER__ ProxyVector<value_t>::storedData() const noexcept
     }
 
     return internalData;
+}
+
+/*!
+    Returns a direct reference to the container associated with the internal
+    storage.
+
+    Interacting directly with the container associated with the internal
+    storage may leave the proxy vector in an inconsistent state. It's up
+    to the caller of this function to guarantee that this will not happen.
+
+    \result A direct reference to the container associated with the internal
+    storage.
+*/
+template<typename value_t>
+template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
+typename ProxyVector<value_t>::container_type * ProxyVector<value_t>::storedDataContainer()
+{
+    return m_storage.container();
+}
+
+/*!
+    Returns a constant direct reference to the container associated with the
+    internal storage.
+
+    Interacting directly with the container associated with the internal
+    storage may leave the proxy vector in an inconsistent state. It's up
+    to the caller of this function to guarantee that this will not happen.
+
+    \result A constant direct reference to the container associated with the
+    internal storage.
+*/
+template<typename value_t>
+template<typename U, typename std::enable_if<std::is_const<U>::value, int>::type>
+const typename ProxyVector<value_t>::container_type * ProxyVector<value_t>::storedDataContainer() const
+{
+    return m_storage.container();
 }
 
 /*!

--- a/src/containers/proxyVector.tpp
+++ b/src/containers/proxyVector.tpp
@@ -30,8 +30,8 @@ namespace bitpit {
 /*!
     Constructor
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator()
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t>::ProxyVectorIterator()
     : m_position(nullptr)
 {
 }
@@ -44,9 +44,9 @@ ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator()
 
     \param other is the iterator that will be copied
 */
-template<typename value_t, typename value_no_cv_t>
+template<typename value_t, typename container_t>
 template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
-ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(const ProxyVectorIterator<other_value_t> &other)
+ProxyVectorIterator<value_t, container_t>::ProxyVectorIterator(const ProxyVectorIterator<other_value_t, container_t> &other)
     : m_position(other.m_position)
 {
 }
@@ -57,8 +57,8 @@ ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(const ProxyVect
 
     \param other is the iterator to exchange values with
 */
-template<typename value_t, typename value_no_cv_t>
-void ProxyVectorIterator<value_t, value_no_cv_t>::swap(ProxyVectorIterator& other) noexcept
+template<typename value_t, typename container_t>
+void ProxyVectorIterator<value_t, container_t>::swap(ProxyVectorIterator& other) noexcept
 {
     std::swap(m_position, other.m_position);
 }
@@ -66,8 +66,8 @@ void ProxyVectorIterator<value_t, value_no_cv_t>::swap(ProxyVectorIterator& othe
 /*!
     Pre-increment operator.
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator++()
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t> & ProxyVectorIterator<value_t, container_t>::operator++()
 {
     m_position++;
 
@@ -77,8 +77,8 @@ ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value
 /*!
     Post-increment operator.
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_no_cv_t>::operator++(int)
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t> ProxyVectorIterator<value_t, container_t>::operator++(int)
 {
     ProxyVectorIterator tmp(m_position);
 
@@ -90,8 +90,8 @@ ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_n
 /*!
     Pre-decrement operator.
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator--()
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t> & ProxyVectorIterator<value_t, container_t>::operator--()
 {
     m_position--;
 
@@ -101,8 +101,8 @@ ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value
 /*!
     Post-decrement operator.
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_no_cv_t>::operator--(int)
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t> ProxyVectorIterator<value_t, container_t>::operator--(int)
 {
     ProxyVectorIterator tmp(m_position);
 
@@ -116,8 +116,8 @@ ProxyVectorIterator<value_t, value_no_cv_t> ProxyVectorIterator<value_t, value_n
 
     \param increment is the increment
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t>& ProxyVectorIterator<value_t, value_no_cv_t>::operator+=(int increment)
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t>& ProxyVectorIterator<value_t, container_t>::operator+=(int increment)
 {
     m_position += increment;
 
@@ -129,8 +129,8 @@ ProxyVectorIterator<value_t, value_no_cv_t>& ProxyVectorIterator<value_t, value_
 
     \result A reference to the element currently pointed to by the iterator.
 */
-template<typename value_t, typename value_no_cv_t>
-__PXI_REFERENCE__ ProxyVectorIterator<value_t, value_no_cv_t>::operator*() const
+template<typename value_t, typename container_t>
+__PXI_REFERENCE__ ProxyVectorIterator<value_t, container_t>::operator*() const
 {
     return *m_position;
 }
@@ -140,8 +140,8 @@ __PXI_REFERENCE__ ProxyVectorIterator<value_t, value_no_cv_t>::operator*() const
 
     \result A reference to the element currently pointed to by the iterator.
 */
-template<typename value_t, typename value_no_cv_t>
-__PXI_POINTER__ ProxyVectorIterator<value_t, value_no_cv_t>::operator->() const
+template<typename value_t, typename container_t>
+__PXI_POINTER__ ProxyVectorIterator<value_t, container_t>::operator->() const
 {
     return m_position;
 }
@@ -152,9 +152,9 @@ __PXI_POINTER__ ProxyVectorIterator<value_t, value_no_cv_t>::operator->() const
 *
 * \param other is the iterator that will be copied
 */
-template<typename value_t, typename value_no_cv_t>
+template<typename value_t, typename container_t>
 template<typename other_value_t, typename std::enable_if<std::is_const<value_t>::value && !std::is_const<other_value_t>::value && std::is_same<other_value_t, typename std::remove_cv<value_t>::type>::value, int>::type>
-ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value_no_cv_t>::operator=(const ProxyVectorIterator<other_value_t> &other)
+ProxyVectorIterator<value_t, container_t> & ProxyVectorIterator<value_t, container_t>::operator=(const ProxyVectorIterator<other_value_t, container_t> &other)
 {
     m_position = other.m_position;
 
@@ -165,8 +165,8 @@ ProxyVectorIterator<value_t, value_no_cv_t> & ProxyVectorIterator<value_t, value
     Creates a new iterator and initializes it with the position of
     the const base iterator recevied in input.
 */
-template<typename value_t, typename value_no_cv_t>
-ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(__PXI_POINTER__ position)
+template<typename value_t, typename container_t>
+ProxyVectorIterator<value_t, container_t>::ProxyVectorIterator(__PXI_POINTER__ position)
     : m_position(position)
 {
 }
@@ -177,8 +177,8 @@ ProxyVectorIterator<value_t, value_no_cv_t>::ProxyVectorIterator(__PXI_POINTER__
     \param other is the iterator from which the distance will be evaluated
     \result The distance between the specified iterator.
 */
-template<typename value_t, typename value_no_cv_t>
-std::size_t ProxyVectorIterator<value_t, value_no_cv_t>::operator-(const ProxyVectorIterator &other)
+template<typename value_t, typename container_t>
+std::size_t ProxyVectorIterator<value_t, container_t>::operator-(const ProxyVectorIterator &other)
 {
     return (m_position - other.m_position);
 }
@@ -262,75 +262,75 @@ void ProxyVectorDummyStorage<value_t, pointer_t, const_pointer_t>::resize(std::s
 /*!
     Memory pool
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-std::vector<std::unique_ptr<std::vector<value_t>>> ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::m_storagePool = std::vector<std::unique_ptr<std::vector<value_t>>>();
+template<typename value_t, typename container_t>
+std::vector<std::unique_ptr<container_t>> ProxyVectorStorage<value_t, container_t>::m_containerPool = std::vector<std::unique_ptr<container_t>>();
 
 /*!
-    Create a storage.
+    Create a data container.
 
-    \param size is the size of the storage, expressed in number of elements.
+    \param size is the size of the container, expressed in number of elements.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-std::unique_ptr<std::vector<value_t>> ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::createStorage(std::size_t size)
+template<typename value_t, typename container_t>
+std::unique_ptr<container_t> ProxyVectorStorage<value_t, container_t>::createContainer(std::size_t size)
 {
     if (size == 0) {
-        return std::unique_ptr<std::vector<value_t>>(nullptr);
+        return std::unique_ptr<container_t>(nullptr);
     }
 
-    if (!m_storagePool.empty()) {
-        std::unique_ptr<std::vector<value_t>> storage = std::move(m_storagePool.back());
-        if (storage->size() < size) {
-            storage->resize(size);
+    if (!m_containerPool.empty()) {
+        std::unique_ptr<container_t> container = std::move(m_containerPool.back());
+        if (container->size() < size) {
+            container->resize(size);
         }
 
-        m_storagePool.resize(m_storagePool.size() - 1);
+        m_containerPool.resize(m_containerPool.size() - 1);
 
-        return storage;
+        return container;
     } else {
-        return std::unique_ptr<std::vector<value_t>>(new std::vector<value_t>(size));
+        return std::unique_ptr<container_t>(new container_t(size));
     }
 }
 
 /*!
-    Create a storage.
+    Create a data container.
 
-    \param source is the storage whose content will be copied in newly created
-    storage
+    \param source is the container whose content will be copied in newly
+    created container
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-std::unique_ptr<std::vector<value_t>> ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::createStorage(const std::unique_ptr<std::vector<value_t>> &source)
+template<typename value_t, typename container_t>
+std::unique_ptr<container_t> ProxyVectorStorage<value_t, container_t>::createContainer(const std::unique_ptr<container_t> &source)
 {
     if (!source || source->empty()) {
-        return std::unique_ptr<std::vector<value_t>>(nullptr);
+        return std::unique_ptr<container_t>(nullptr);
     }
 
-    if (!m_storagePool.empty()) {
-        std::unique_ptr<std::vector<value_t>> storage = createStorage(source->size());
-        std::copy_n(source->data(), source->size(), storage->data());
+    if (!m_containerPool.empty()) {
+        std::unique_ptr<container_t> container = createContainer(source->size());
+        std::copy_n(source->data(), source->size(), container->data());
 
-        return storage;
+        return container;
     } else {
-        return std::unique_ptr<std::vector<value_t>>(new std::vector<value_t>(*source));
+        return std::unique_ptr<container_t>(new container_t(*source));
     }
 }
 
 /*!
-    Delete a storage.
+    Delete a data container.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-void ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::destroyStorage(std::unique_ptr<std::vector<value_t>> *storage)
+template<typename value_t, typename container_t>
+void ProxyVectorStorage<value_t, container_t>::destroyContainer(std::unique_ptr<container_t> *container)
 {
-    if (!(*storage)) {
+    if (!(*container)) {
         return;
     }
 
-    if (m_storagePool.size() < MEMORY_POOL_VECTOR_COUNT) {
-        if ((*storage)->size() > MEMORY_POOL_MAX_CAPACITY) {
-            (*storage)->resize(MEMORY_POOL_MAX_CAPACITY);
+    if (m_containerPool.size() < MEMORY_POOL_VECTOR_COUNT) {
+        if ((*container)->size() > MEMORY_POOL_MAX_CAPACITY) {
+            (*container)->resize(MEMORY_POOL_MAX_CAPACITY);
         }
 
-        m_storagePool.emplace_back(std::move(*storage));
-        storage->reset();
+        m_containerPool.emplace_back(std::move(*container));
+        container->reset();
     }
 }
 
@@ -339,9 +339,9 @@ void ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::destroyStorage(std
 
     \param size is the size of the storage expressed in number of elements.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::ProxyVectorStorage(std::size_t size)
-    : m_storage(createStorage(size))
+template<typename value_t, typename container_t>
+ProxyVectorStorage<value_t, container_t>::ProxyVectorStorage(std::size_t size)
+    : m_container(createContainer(size))
 {
 }
 
@@ -351,19 +351,19 @@ ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::ProxyVectorStorage(std:
     \param x is another storage of the same type (i.e., instantiated with
     the same template parameters) whose content is copied in this container.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::ProxyVectorStorage(const ProxyVectorStorage<value_t, pointer_t, const_pointer_t> &other)
-    : m_storage(createStorage(other.m_storage))
+template<typename value_t, typename container_t>
+ProxyVectorStorage<value_t, container_t>::ProxyVectorStorage(const ProxyVectorStorage<value_t, container_t> &other)
+    : m_container(createContainer(other.m_container))
 {
 }
 
 /*!
     Destructor.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::~ProxyVectorStorage()
+template<typename value_t, typename container_t>
+ProxyVectorStorage<value_t, container_t>::~ProxyVectorStorage()
 {
-    destroyStorage(&m_storage);
+    destroyContainer(&m_container);
 }
 
 /*!
@@ -371,10 +371,10 @@ ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::~ProxyVectorStorage()
 
     \param other is another storage of the same type
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-void ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::swap(ProxyVectorStorage &other) noexcept
+template<typename value_t, typename container_t>
+void ProxyVectorStorage<value_t, container_t>::swap(ProxyVectorStorage &other) noexcept
 {
-    m_storage.swap(other.m_storage);
+    m_container.swap(other.m_container);
 }
 
 /*!
@@ -382,14 +382,14 @@ void ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::swap(ProxyVectorSt
 
     \result A pointer to the data.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-typename ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::pointer ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::data()
+template<typename value_t, typename container_t>
+typename ProxyVectorStorage<value_t, container_t>::pointer ProxyVectorStorage<value_t, container_t>::data()
 {
     if (empty()) {
         return nullptr;
     }
 
-    return m_storage->data();
+    return m_container->data();
 }
 
 /*!
@@ -397,14 +397,14 @@ typename ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::pointer ProxyV
 
     \result A constant pointer to the data.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-typename ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::const_pointer ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::data() const
+template<typename value_t, typename container_t>
+typename ProxyVectorStorage<value_t, container_t>::const_pointer ProxyVectorStorage<value_t, container_t>::data() const
 {
     if (empty()) {
         return nullptr;
     }
 
-    return m_storage->data();
+    return m_container->data();
 }
 
 /*!
@@ -412,14 +412,14 @@ typename ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::const_pointer 
 
     \result Returns true if the storage is empty, false otherwise.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-bool ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::empty() const
+template<typename value_t, typename container_t>
+bool ProxyVectorStorage<value_t, container_t>::empty() const
 {
-    if (!m_storage) {
+    if (!m_container) {
         return true;
     }
 
-    return m_storage->empty();
+    return m_container->empty();
 }
 
 /*!
@@ -427,14 +427,14 @@ bool ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::empty() const
 
     \result The size of the storage, expressed in number of elements.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-std::size_t ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::size() const
+template<typename value_t, typename container_t>
+std::size_t ProxyVectorStorage<value_t, container_t>::size() const
 {
-    if (!m_storage) {
+    if (!m_container) {
         return 0;
     }
 
-    return m_storage->size();
+    return m_container->size();
 }
 
 /*!
@@ -442,19 +442,19 @@ std::size_t ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::size() cons
 
     \result The size of the storage expressed in number of elements.
 */
-template<typename value_t, typename pointer_t, typename const_pointer_t>
-void ProxyVectorStorage<value_t, pointer_t, const_pointer_t>::resize(std::size_t size)
+template<typename value_t, typename container_t>
+void ProxyVectorStorage<value_t, container_t>::resize(std::size_t size)
 {
     if (size == 0) {
-        destroyStorage(&m_storage);
+        destroyContainer(&m_container);
         return;
 
     }
 
-    if (m_storage) {
-        m_storage->resize(size);
+    if (m_container) {
+        m_container->resize(size);
     } else {
-        m_storage = createStorage(size);
+        m_container = createContainer(size);
     }
 }
 

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -406,38 +406,50 @@ void LevelSetObject::restore( std::istream &stream ){
 
 /*!
  * Enables or disables the VTK output
- * @param[in] writeField describes the field(s) that should be written
+ * @param[in] fieldset describes the field(s) that should be written
  * @param[in] enable true for enabling, false for diabling
  */
-void LevelSetObject::enableVTKOutput( LevelSetWriteField writeField, bool enable) {
+void LevelSetObject::enableVTKOutput( LevelSetWriteField fieldset, bool enable) {
+
+    std::stringstream objectNameStream;
+    objectNameStream << getId();
+
+    enableVTKOutput(fieldset, objectNameStream.str(), enable);
+
+}
+
+/*!
+ * Enables or disables the VTK output
+ * @param[in] fieldset describes the field(s) that should be written
+ * @param[in] objectName is the name that will be associated with the object
+ * @param[in] enable true for enabling, false for diabling
+ */
+void LevelSetObject::enableVTKOutput( LevelSetWriteField fieldset, const std::string &objectName, bool enable) {
 
     std::vector<LevelSetWriteField> fields;
 
-    if( writeField==LevelSetWriteField::ALL){
+    if( fieldset==LevelSetWriteField::ALL){
         fields.push_back(LevelSetWriteField::VALUE);
         fields.push_back(LevelSetWriteField::GRADIENT);
         fields.push_back(LevelSetWriteField::NORMAL);
         fields.push_back(LevelSetWriteField::PART);
 
-    } else if ( writeField==LevelSetWriteField::DEFAULT){
+    } else if ( fieldset==LevelSetWriteField::DEFAULT){
         fields.push_back(LevelSetWriteField::VALUE);
         fields.push_back(LevelSetWriteField::GRADIENT);
 
     } else {
-        fields.push_back(writeField);
+        fields.push_back(fieldset);
     }
 
     for( LevelSetWriteField &field : fields){
 
         std::stringstream name;
-        name << "ls_";
-        name << getId();
-        name << "_";
-
+        name << "levelset";
 
         switch(field){
             case LevelSetWriteField::VALUE:
-                name << "value";
+                name << "Value_" << objectName;
                 if(enable){
                     m_kernelPtr->getMesh()->getVTK().addData<double>( name.str(), VTKFieldType::SCALAR, VTKLocation::CELL, this);
                 } else {
@@ -446,7 +458,7 @@ void LevelSetObject::enableVTKOutput( LevelSetWriteField writeField, bool enable
                 break;
 
             case LevelSetWriteField::GRADIENT:
-                name << "gradient";
+                name << "Gradient_" << objectName;
                 if(enable){
                     m_kernelPtr->getMesh()->getVTK().addData<double>( name.str(), VTKFieldType::VECTOR, VTKLocation::CELL, this);
                 } else {
@@ -455,7 +467,7 @@ void LevelSetObject::enableVTKOutput( LevelSetWriteField writeField, bool enable
                 break;
 
             case LevelSetWriteField::NORMAL:
-                name << "normal";
+                name << "Normal_" << objectName;
                 if(enable){
                     m_kernelPtr->getMesh()->getVTK().addData<double>( name.str(), VTKFieldType::VECTOR, VTKLocation::CELL, this);
                 } else {
@@ -464,7 +476,7 @@ void LevelSetObject::enableVTKOutput( LevelSetWriteField writeField, bool enable
                 break;
 
             case LevelSetWriteField::PART:
-                name << "partId";
+                name << "PartId_" << objectName;
                 if(enable){
                     m_kernelPtr->getMesh()->getVTK().addData<int>( name.str(), VTKFieldType::SCALAR, VTKLocation::CELL, this);
                 } else {
@@ -493,7 +505,7 @@ void LevelSetObject::enableVTKOutput( LevelSetWriteField writeField, bool enable
 void LevelSetObject::flushData( std::fstream &stream, const std::string &name, VTKFormat format){
 
 
-    if(utils::string::keywordInString(name,"value")){
+    if(utils::string::keywordInString(name,"levelsetValue")){
 
         void (*writeFunctionPtr)(std::fstream &, const double &) = nullptr;
 
@@ -511,7 +523,7 @@ void LevelSetObject::flushData( std::fstream &stream, const std::string &name, V
             (*writeFunctionPtr)(stream,value);
         }
 
-    } else if( utils::string::keywordInString(name,"gradient")){
+    } else if( utils::string::keywordInString(name,"levelsetGradient")){
 
         void (*writeFunctionPtr)(std::fstream &, const std::array<double,3> &) = nullptr;
 
@@ -529,7 +541,7 @@ void LevelSetObject::flushData( std::fstream &stream, const std::string &name, V
             (*writeFunctionPtr)(stream,value);
         }
 
-    } else if( utils::string::keywordInString(name,"normal")){
+    } else if( utils::string::keywordInString(name,"levelsetNormal")){
 
         void (*writeFunctionPtr)(std::fstream &, const std::array<double,3> &) = nullptr;
 
@@ -547,7 +559,7 @@ void LevelSetObject::flushData( std::fstream &stream, const std::string &name, V
             (*writeFunctionPtr)(stream,value);
         }
 
-    } else if( utils::string::keywordInString(name,"part")){
+    } else if( utils::string::keywordInString(name,"levelsetPart")){
 
         void (*writeFunctionPtr)(std::fstream &, const int &) = nullptr;
 

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -131,7 +131,8 @@ class LevelSetObject : public VTKBaseStreamer{
     virtual double                              getMinSurfaceFeatureSize() const;
     virtual double                              getMaxSurfaceFeatureSize() const;
 
-    void                                        enableVTKOutput(LevelSetWriteField field, bool enable=true);
+    void                                        enableVTKOutput(LevelSetWriteField writeField, bool enable=true);
+    void                                        enableVTKOutput(LevelSetWriteField writeField, const std::string &objectName, bool enable=true);
     void                                        flushData(std::fstream &, const std::string &, VTKFormat) override;
 
 


### PR DESCRIPTION
It is now possible to create a thread-safe ProxyVector.