### PR TITLE
patchkernel: add a constant max length in skd tree

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -193,8 +193,8 @@ std::array<double, 3> SkdPatchInfo::evalCachedBoxMean(std::size_t rawId) const
 * Default constructor.
 */
 SkdBox::SkdBox()
-    : m_boxMin{  std::numeric_limits<double>::max(),   std::numeric_limits<double>::max(),   std::numeric_limits<double>::max()},
-      m_boxMax{- std::numeric_limits<double>::max(), - std::numeric_limits<double>::max(), - std::numeric_limits<double>::max()}
+    : m_boxMin{  patchSkdTreeConstants::MAX_LENGTH,   patchSkdTreeConstants::MAX_LENGTH,   patchSkdTreeConstants::MAX_LENGTH},
+      m_boxMax{- patchSkdTreeConstants::MAX_LENGTH, - patchSkdTreeConstants::MAX_LENGTH, - patchSkdTreeConstants::MAX_LENGTH}
 {
 }
 
@@ -384,8 +384,8 @@ void SkdNode::initializeBoundingBox()
 {
     // Early return if there are no cells
     if (m_cellRangeBegin == m_cellRangeEnd){
-        m_boxMin.fill(  std::numeric_limits<double>::max());
-        m_boxMax.fill(- std::numeric_limits<double>::max());
+        m_boxMin.fill(  patchSkdTreeConstants::MAX_LENGTH);
+        m_boxMax.fill(- patchSkdTreeConstants::MAX_LENGTH);
 
         return;
     }
@@ -576,7 +576,7 @@ void SkdNode::findPointClosestCell(const std::array<double, 3> &point, bool inte
                                    long *id, double *closestDistance) const
 {
     *id       = Cell::NULL_ID;
-    *closestDistance = std::numeric_limits<double>::max();
+    *closestDistance = patchSkdTreeConstants::MAX_LENGTH;
 
     updatePointClosestCell(point, interiorCellsOnly, id, closestDistance);
 }

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -29,6 +29,13 @@
 
 namespace bitpit {
 
+/*!
+ * @brief namespace containing default values
+ */
+namespace patchSkdTreeConstants{
+    const double MAX_LENGTH = 1.e18 ;       /**< Constant value for maximum length */
+};
+
 class PatchSkdTree;
 
 struct SkdPatchInfo {

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -74,7 +74,7 @@ void SurfaceSkdTree::clear(bool release)
 */
 double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point) const
 {
-    return evalPointDistance(point, std::numeric_limits<double>::max(), false);
+    return evalPointDistance(point, patchSkdTreeConstants::MAX_LENGTH, false);
 }
 
 /*!
@@ -139,7 +139,7 @@ double SurfaceSkdTree::evalPointDistance(const std::array<double, 3> &point, dou
 */
 void SurfaceSkdTree::evalPointDistance(int nPoints, const std::array<double, 3> *points, double *distances) const
 {
-    std::vector<double> maxDistances(nPoints, std::numeric_limits<double>::max());
+    std::vector<double> maxDistances(nPoints, patchSkdTreeConstants::MAX_LENGTH);
 
     evalPointDistance(nPoints, points, maxDistances.data(), false, distances);
 }
@@ -231,7 +231,7 @@ void SurfaceSkdTree::evalPointDistance(int nPoints, const std::array<double, 3> 
 */
 void SurfaceSkdTree::evalPointGlobalDistance(int nPoints, const std::array<double, 3> *points, double *distances) const
 {
-    std::vector<double> maxDistances(nPoints, std::numeric_limits<double>::max());
+    std::vector<double> maxDistances(nPoints, patchSkdTreeConstants::MAX_LENGTH);
 
     evalPointGlobalDistance(nPoints, points, maxDistances.data(), distances);
 }
@@ -305,7 +305,7 @@ void SurfaceSkdTree::evalPointGlobalDistance(int nPoints, const std::array<doubl
 */
 long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, long *id, double *distance) const
 {
-    return findPointClosestCell(point, std::numeric_limits<double>::max(), false, id, distance);
+    return findPointClosestCell(point, patchSkdTreeConstants::MAX_LENGTH, false, id, distance);
 }
 
 /*!
@@ -460,10 +460,9 @@ long SurfaceSkdTree::findPointClosestCell(const std::array<double, 3> &point, do
         ++nDistanceEvaluations;
     }
 
-    // If no closest cell was found set the distance to the maximum
-    // representable distance.
+    // If no closest cell was found set the distance to the maximum length constant.
     if (*id == Cell::NULL_ID) {
-        *distance = std::numeric_limits<double>::max();
+        *distance = patchSkdTreeConstants::MAX_LENGTH;
     }
 
     return nDistanceEvaluations;
@@ -484,7 +483,7 @@ long SurfaceSkdTree::findPointClosestCell(int nPoints, const std::array<double, 
 {
     long nDistanceEvaluations = 0;
     for (int i = 0; i < nPoints; ++i) {
-        nDistanceEvaluations += findPointClosestCell(points[i], std::numeric_limits<double>::max(), false, ids + i, distances + i);
+        nDistanceEvaluations += findPointClosestCell(points[i], patchSkdTreeConstants::MAX_LENGTH, false, ids + i, distances + i);
     }
 
     return nDistanceEvaluations;
@@ -585,7 +584,7 @@ long SurfaceSkdTree::findPointClosestCell(int nPoints, const std::array<double, 
 long SurfaceSkdTree::findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points,
                                                 long *ids, int *ranks, double *distances) const
 {
-    return findPointClosestGlobalCell(nPoints, points, std::numeric_limits<double>::max(), ids, ranks, distances);
+    return findPointClosestGlobalCell(nPoints, points, patchSkdTreeConstants::MAX_LENGTH, ids, ranks, distances);
 }
 
 /*!


### PR DESCRIPTION
Initialize the skdBox extrema to values that do not trigger Floating Point overflow when squared.

