### PR TITLE
patchkernel: fix evaluation of cell rank from consecutive id

### DIFF
--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -406,7 +406,7 @@ int PatchNumberingInfo::getCellRankFromLocal(long id) const
 */
 int PatchNumberingInfo::getCellRankFromConsecutive(long id) const
 {
-	if (m_patch->isPartitioned()) {
+	if (!m_patch->isPartitioned()) {
 		return m_patch->getRank();
 	}
 


### PR DESCRIPTION
This fixes the identification of cell rank from global/consecutive id.