### PR TITLE
cmake: fix definition of BITPIT_CMAKE_CONFIG_PATH_LAST variable in BITPITConfig.cmake.in

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# BITPIT installation
+# bitpit installation
 
 bitpit runs on Linux and Mac OSX platforms.
 
@@ -25,7 +25,7 @@ When compiling bitpit, both shared library files and header library files are
 required. Therefore, in addition to the library packages, also the corresponding
 '*-devel' packages ('*-dev' in Debian-based distributions) are required.
 
-## Confguring BITPIT
+## Confguring bitpit
 bitpit uses ccmake as building tool.
 In the bitpit's root folder make a building folder, e.g. build
 ```bash

--- a/cmake/BITPITConfig.cmake.in
+++ b/cmake/BITPITConfig.cmake.in
@@ -8,7 +8,7 @@
 # is needed
 if(NOT ("@BITPIT_CMAKE_CONFIG_DIR@" STREQUAL BITPIT_CMAKE_CONFIG_PATH_LAST))
     set(BITPIT_RECONFIGURE 1)
-    set(BITPIT_CMAKE_CONFIG_PATH_LAST CACHE INTERNAL "@BITPIT_CMAKE_CONFIG_DIR@" FORCE)
+    set(BITPIT_CMAKE_CONFIG_PATH_LAST "@BITPIT_CMAKE_CONFIG_DIR@" CACHE INTERNAL "Defines the last bitpit CMake configuration file loaded")
 endif()
 
 # Compute the installation prefix from this BITPITConfig.cmake file location.

--- a/cmake/BITPITConfig.cmake.in
+++ b/cmake/BITPITConfig.cmake.in
@@ -1,8 +1,8 @@
-# BITPITConfig.cmake - BITPIT CMake configuration file for external projects.
+# BITPITConfig.cmake - bitpit CMake configuration file for external projects.
 # -----------
 #
-# This file is configured by BITPIT and used by the UseBITPIT.cmake module
-# to load BITPIT's settings for an external project.
+# This file is configured by bitpit and used by the UseBITPIT.cmake module
+# to load bitpit's settings for an external project.
 
 # If a different UseBITPIT.cmake was previoulsy loaded a reconfiguration
 # is needed
@@ -14,14 +14,14 @@ endif()
 # Compute the installation prefix from this BITPITConfig.cmake file location.
 @BITPIT_INSTALL_PREFIX_CODE@
 
-# The C and C++ flags added by BITPIT to the cmake-configured flags.
+# The C and C++ flags added by bitpit to the cmake-configured flags.
 SET(BITPIT_REQUIRED_C_FLAGS "")
 SET(BITPIT_REQUIRED_CXX_FLAGS "")
 SET(BITPIT_REQUIRED_EXE_LINKER_FLAGS "")
 SET(BITPIT_REQUIRED_SHARED_LINKER_FLAGS "")
 SET(BITPIT_REQUIRED_MODULE_LINKER_FLAGS "")
 
-# The BITPIT version number
+# The bitpit version number
 SET(BITPIT_MAJOR_VERSION "@BITPIT_MAJOR_VERSION@")
 SET(BITPIT_MINOR_VERSION "@BITPIT_MINOR_VERSION@")
 SET(BITPIT_PATCH_VERSION "@BITPIT_PATCH_VERSION@")
@@ -101,10 +101,10 @@ else ()
     set( BITPIT_LIBRARY "BITPIT_LIBRARY-NOTFOUND")
 endif ()
 
-# BITPIT Definitions
+# bitpit Definitions
 set(BITPIT_DEFINITIONS "@BITPIT_DEFINITIONS_PUBLIC@")
 
-# List of currently enabled BITPIT modules
+# List of currently enabled bitpit modules
 set(BITPIT_ENABLED_MODULE_LIST "@BITPIT_ENABLED_MODULE_LIST@")
 
 # Check if requested modules are enabled
@@ -114,7 +114,7 @@ if(BITPIT_FIND_COMPONENTS)
         if(${COMPONENT_INDEX} LESS 0)
             set(BITPIT_${COMPONENT}_FOUND 0)
 
-            set(COMPONENT_NOT_FOUND_MESSAGE "${COMPONENT} module is not enabled in current BITPIT installation")
+            set(COMPONENT_NOT_FOUND_MESSAGE "${COMPONENT} module is not enabled in current bitpit installation")
             if(BITPIT_FIND_REQUIRED_${COMPONENT})
                message(FATAL_ERROR "${COMPONENT_NOT_FOUND_MESSAGE}")
             elseif (NOT BITPIT_FIND_QUIETLY)
@@ -132,7 +132,7 @@ if(BITPIT_FIND_OPTIONAL_COMPONENTS)
         list(FIND BITPIT_ENABLED_MODULE_LIST ${COMPONENT} COMPONENT_INDEX)
         if(${COMPONENT_INDEX} LESS 0)
             set(BITPIT_${COMPONENT}_FOUND 0)
-            set(COMPONENT_NOT_FOUND_MESSAGE "${COMPONENT} optional module is not enabled in current BITPIT installation")
+            set(COMPONENT_NOT_FOUND_MESSAGE "${COMPONENT} optional module is not enabled in current bitpit installation")
             message(STATUS "${COMPONENT_NOT_FOUND_MESSAGE}")
         else()
             set(BITPIT_${COMPONENT}_FOUND 1)


### PR DESCRIPTION
When bitpit is used as dependency library, BITPIT_CMAKE_CONFIG_PATH_LAST chached internal variable wasn't declared properly. This triggered the reconfigure procedure every time.