### PR TITLE
patchkernel: avoid floating point exceptions in SkdTree class

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -230,7 +230,6 @@ const std::array<double, 3> & SkdBox::getBoxMax() const
     return m_boxMax;
 }
 
-
 /*!
 * Evaluates the minimum distance between the specified point and the box.
 *

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -406,6 +406,10 @@ double SkdBox::evalPointMaxSquareDistance(const std::array<double, 3> &point) co
 */
 bool SkdBox::boxContainsPoint(const std::array<double, 3> &point, double offset) const
 {
+    if (isEmpty()) {
+        return false;
+    }
+
     for (int d = 0; d < 3; d++) {
         if (point[d] < (m_boxMin[d] - offset)) {
             return false;

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -211,6 +211,25 @@ SkdBox::SkdBox(const std::array<double,3> &boxMin, const std::array<double,3> &b
 }
 
 /*!
+* Check if the box is empty.
+*
+* An empty box has a minimum coordinates that is greater than the maximum
+* coordinate.
+*
+* \result Returns true if the box is empty, false otherwise.
+*/
+bool SkdBox::isEmpty() const
+{
+    for (int d = 0; d < 3; ++d) {
+        if (m_boxMin[d] > m_boxMax[d]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/*!
 * Get the minimum coordinate of the box.
 *
 * \result The minimum coordinate of the box.

--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -252,6 +252,27 @@ const std::array<double, 3> & SkdBox::getBoxMax() const
 /*!
 * Evaluates the minimum distance between the specified point and the box.
 *
+* If the box is not valid, the specified defualt distance is returned.
+*
+* \param point is the point
+* \param emptyDistance is the distance that will be return when the box is
+* empty
+* \result The minimum distance between the specified point and the box.
+*/
+double SkdBox::evalPointMinDistance(const std::array<double, 3> &point, double emptyDistance) const
+{
+    if (isEmpty()) {
+        return emptyDistance;
+    }
+
+    return evalPointMinDistance(point);
+}
+
+/*!
+* Evaluates the minimum distance between the specified point and the box.
+*
+* If the box is empty, the result is undefined.
+*
 * \param point is the point
 * \result The minimum distance between the specified point and the box.
 */
@@ -261,19 +282,31 @@ double SkdBox::evalPointMinDistance(const std::array<double, 3> &point) const
 }
 
 /*!
-* Evaluates the maximum distance between the specified point and the box.
+* Evaluates the square of the minimum distance between the specified point
+* and the box.
+*
+* If the box is not valid, the specified default square distance is returned.
 *
 * \param point is the point
-* \result The maximum distance between the specified point and the box.
+* \param emptySquareDistance is the distance that will be return when the box
+* is empty
+* \result The square of the minimum distance between the specified point and
+* the box.
 */
-double SkdBox::evalPointMaxDistance(const std::array<double, 3> &point) const
+double SkdBox::evalPointMinSquareDistance(const std::array<double, 3> &point, double emptySquareDistance) const
 {
-    return std::sqrt(evalPointMaxSquareDistance(point));
+    if (isEmpty()) {
+        return emptySquareDistance;
+    }
+
+    return evalPointMinSquareDistance(point);
 }
 
 /*!
-* Evaluates the square of the minimum distance between the specified point and
-* the box.
+* Evaluates the square of the minimum distance between the specified point
+* and the box.
+*
+* If the box is empty, the result is undefined.
 *
 * \param point is the point
 * \result The square of the minimum distance between the specified point and
@@ -290,8 +323,63 @@ double SkdBox::evalPointMinSquareDistance(const std::array<double, 3> &point) co
 }
 
 /*!
-* Evaluates the square of the maximum distance between the specified point and
+* Evaluates the maximum distance between the specified point and the box.
+*
+* If the box is not valid, the specified default distance is returned.
+*
+* \param point is the point
+* \param emptyDistance is the distance that will be return when the box is
+* empty
+* \result The maximum distance between the specified point and the box.
+*/
+double SkdBox::evalPointMaxDistance(const std::array<double, 3> &point, double emptyDistance) const
+{
+    if (isEmpty()) {
+        return emptyDistance;
+    }
+
+    return evalPointMaxDistance(point);
+}
+
+/*!
+* Evaluates the maximum distance between the specified point and the box.
+*
+* If the box is empty, the result is undefined.
+*
+* \param point is the point
+* \result The maximum distance between the specified point and the box.
+*/
+double SkdBox::evalPointMaxDistance(const std::array<double, 3> &point) const
+{
+    return std::sqrt(evalPointMaxSquareDistance(point));
+}
+
+/*!
+* Evaluates the square of the maximum distance between the specified point
+* and the box.
+*
+* If the box is not valid, the specified default square distance is returned.
+*
+* \param point is the point
+* \param emptySquareDistance is the square distance that will be return when
+* the box is empty
+* \result The square of the maximum distance between the specified point and
 * the box.
+*/
+double SkdBox::evalPointMaxSquareDistance(const std::array<double, 3> &point, double emptySquareDistance) const
+{
+    if (isEmpty()) {
+        return emptySquareDistance;
+    }
+
+    return evalPointMaxSquareDistance(point);
+}
+
+/*!
+* Evaluates the square of the maximum distance between the specified point
+* and the box.
+*
+* If the box is empty, the result is undefined.
 *
 * \param point is the point
 * \result The square of the maximum distance between the specified point and

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -76,10 +76,14 @@ public:
     const std::array<double, 3> & getBoxMax() const;
 
     double evalPointMinDistance(const std::array<double, 3> &point) const;
-    double evalPointMaxDistance(const std::array<double, 3> &point) const;
-
+    double evalPointMinDistance(const std::array<double, 3> &point, double emptyDistance) const;
     double evalPointMinSquareDistance(const std::array<double, 3> &point) const;
+    double evalPointMinSquareDistance(const std::array<double, 3> &point, double emptySquareDistance) const;
+
+    double evalPointMaxDistance(const std::array<double, 3> &point) const;
+    double evalPointMaxDistance(const std::array<double, 3> &point, double emptyDistance) const;
     double evalPointMaxSquareDistance(const std::array<double, 3> &point) const;
+    double evalPointMaxSquareDistance(const std::array<double, 3> &point, double emptySquareDistance) const;
 
     bool boxContainsPoint(const std::array<double,3> &point, double offset) const;
     bool boxIntersectsSphere(const std::array<double,3> &center, double radius) const;

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -70,6 +70,8 @@ public:
     SkdBox();
     SkdBox(const std::array<double,3> &boxMin, const std::array<double,3> &boxMax);
 
+    bool isEmpty() const;
+
     const std::array<double, 3> & getBoxMin() const;
     const std::array<double, 3> & getBoxMax() const;
 

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -717,7 +717,7 @@ long SurfaceSkdTree::findPointClosestGlobalCell(int nPoints, const std::array<do
         // than or equal to the point maximum distance.
         double pointMaxDistance = globalMaxDistances[i];
         for (int rank = 0; rank < m_nProcessors; ++rank) {
-            pointMaxDistance = std::min(getPartitionBox(rank).evalPointMaxDistance(point), pointMaxDistance);
+            pointMaxDistance = std::min(getPartitionBox(rank).evalPointMaxDistance(point, std::numeric_limits<double>::max()), pointMaxDistance);
         }
 
         // Get cell distance information


### PR DESCRIPTION
When performing searches with the SkdTree, empty partitions may lead to floating point exceptions. Also, a floating point exception may be triggered when evaluating the square of an "inifinite" distance (i.e., a distance set to ```std::numeric_limits<double>::max()```).