### PR TITLE
patchkernel: fix Element::getBinarySize method

### DIFF
--- a/src/patchkernel/element.cpp
+++ b/src/patchkernel/element.cpp
@@ -2051,7 +2051,7 @@ std::vector<ConstProxyVector<long>> Element::evalEdgeConnects(int nRequestedEdge
 unsigned int Element::getBinarySize() const
 {
 	unsigned int binarySize = sizeof(m_type) + sizeof(m_id) + getConnectSize() * sizeof(long) + sizeof(m_pid);
-	if (bitpit::ReferenceElementInfo::hasInfo(m_type)) {
+	if (!bitpit::ReferenceElementInfo::hasInfo(m_type)) {
 		binarySize += sizeof(int);
 	}
 


### PR DESCRIPTION
FIx to get the correct binary size of non standard Cell Elements  (like polyhedra)

