### PR TITLE
RBF: fix data set removal

### DIFF
--- a/src/RBF/rbf.cpp
+++ b/src/RBF/rbf.cpp
@@ -98,21 +98,21 @@ RBFKernel::RBFKernel(const RBFKernel & other)
 /*!
  * Swap method. Exchange contents of each class member with those 
  * corresponding in the argument object.
- * \param[in] x object to be swapped
+ * \param[in] other object to be swapped
  */
-void RBFKernel::swap(RBFKernel &x) noexcept
+void RBFKernel::swap(RBFKernel &other) noexcept
 {
-   std::swap(m_fields, x.m_fields);
-   std::swap(m_mode, x.m_mode);
-   std::swap(m_supportRadius, x.m_supportRadius);
-   std::swap(m_typef, x.m_typef);
-   std::swap(m_fPtr, x.m_fPtr);
-   std::swap(m_error, x.m_error);
-   std::swap(m_value, x.m_value);
-   std::swap(m_weight, x.m_weight);
-   std::swap(m_activeNodes, x.m_activeNodes);
-   std::swap(m_maxFields, x.m_maxFields);
-   std::swap(m_nodes, x.m_nodes);
+   std::swap(m_fields, other.m_fields);
+   std::swap(m_mode, other.m_mode);
+   std::swap(m_supportRadius, other.m_supportRadius);
+   std::swap(m_typef, other.m_typef);
+   std::swap(m_fPtr, other.m_fPtr);
+   std::swap(m_error, other.m_error);
+   std::swap(m_value, other.m_value);
+   std::swap(m_weight, other.m_weight);
+   std::swap(m_activeNodes, other.m_activeNodes);
+   std::swap(m_maxFields, other.m_maxFields);
+   std::swap(m_nodes, other.m_nodes);
 }
 
 /*!
@@ -1001,13 +1001,13 @@ RBF & RBF::operator=(RBF other)
 /*!
  * Swap method. Exchange contents of each class member with those 
  * corresponding in the argument object.
- * \param[in] x object to be swapped
+ * \param[in] other object to be swapped
  */
-void RBF::swap(RBF &x) noexcept
+void RBF::swap(RBF &other) noexcept
 {
-    RBFKernel::swap(x);
+    RBFKernel::swap(other);
 
-    std::swap(m_node, x.m_node);
+    std::swap(m_node, other.m_node);
 }
 
 /*!

--- a/src/RBF/rbf.cpp
+++ b/src/RBF/rbf.cpp
@@ -511,7 +511,7 @@ bool RBFKernel::removeData(int id)
 
     m_fields--;
     if(m_mode == RBFMode::INTERP)    m_value.erase(m_value.begin()+id);
-    else                            m_weight.erase(m_value.begin()+id);
+    else                             m_weight.erase(m_weight.begin()+id);
 
     return(true);
 }

--- a/src/RBF/rbf.cpp
+++ b/src/RBF/rbf.cpp
@@ -841,19 +841,17 @@ double RBFKernel::evalError( )
 
     int                     i(0), j(0);
     //int                     index;
-    double                  maxError(0), relError, realValue, norm;
+    double                  maxError(0), relError, realValue;
     std::vector<double>     reconValues;
 
     for( int iX=0; iX< m_nodes; ++iX ) {
         reconValues = evalRBF( iX );
 
         j=0;
-        norm = 0.;
         relError = 0.;
         for( auto &val : reconValues ) {
             realValue = m_value[j][i];
             relError += std::pow( (val - realValue), 2  );
-            norm += std::pow( realValue, 2  );
 
             ++j;
         }


### PR DESCRIPTION
I'm not sure this is the right fix, but weights were erased using values' iteratror . Found by cppcheck.

Other than the fix for data set removal, there are some cosmetic fixes.