### PR TITLE
patchkernel: properly release memory when destroying the adjacencies/interfaces

### DIFF
--- a/src/containers/flatVector2D.hpp
+++ b/src/containers/flatVector2D.hpp
@@ -92,6 +92,8 @@ public:
     */
     FlatVector2D & operator=(FlatVector2D &&other) = default;
 
+    bool isInitialized() const;
+
     void initialize(const std::vector<std::size_t> &sizes, const T &value = T());
     void initialize(std::size_t nVectors, std::size_t size, const T &value = T());
     void initialize(std::size_t nVectors, const std::size_t *sizes, const T &value);

--- a/src/containers/flatVector2D.tpp
+++ b/src/containers/flatVector2D.tpp
@@ -149,6 +149,17 @@ FlatVector2D<T>::FlatVector2D(const std::vector<std::vector<T> > &vector2D)
 }
 
 /*!
+    Check if the container has been initialized.
+
+    \result Returns true if the container has been initialized, false otherwise.
+*/
+template <class T>
+bool FlatVector2D<T>::isInitialized() const
+{
+    return (!m_index.empty());
+}
+
+/*!
     Initializes the container.
 
     \param sizes are the sizes of the vectors
@@ -976,6 +987,10 @@ T * FlatVector2D<T>::first()
 template <class T>
 std::size_t FlatVector2D<T>::size() const
 {
+    if (!isInitialized()) {
+        return 0;
+    }
+
     return (m_index.size() - 1);
 }
 
@@ -989,6 +1004,10 @@ std::size_t FlatVector2D<T>::size() const
 template <class T>
 std::size_t FlatVector2D<T>::capacity() const
 {
+    if (!isInitialized()) {
+        return 0;
+    }
+
     return m_index.capacity() - 1;
 }
 
@@ -1014,6 +1033,10 @@ void FlatVector2D<T>::merge()
 template <class T>
 std::size_t FlatVector2D<T>::getItemCount() const
 {
+    if (!isInitialized()) {
+        return 0;
+    }
+
     return m_v.size();
 }
 
@@ -1026,6 +1049,10 @@ std::size_t FlatVector2D<T>::getItemCount() const
 template <class T>
 std::size_t FlatVector2D<T>::getItemCount(std::size_t i) const
 {
+    if (!isInitialized()) {
+        return 0;
+    }
+
     return m_index[i + 1] - m_index[i];
 }
 

--- a/src/containers/flatVector2D.tpp
+++ b/src/containers/flatVector2D.tpp
@@ -606,9 +606,7 @@ template <class T>
 void FlatVector2D<T>::pushBack(std::size_t subArraySize, const T &value)
 {
     std::size_t previousLastIndex = m_index.back();
-    m_index.emplace_back();
-    std::size_t &lastIndex = m_index.back();
-    lastIndex = previousLastIndex + subArraySize;
+    m_index.emplace_back(previousLastIndex + subArraySize);
 
     m_v.resize(m_v.size() + subArraySize, value);
 }
@@ -640,9 +638,7 @@ template <class T>
 void FlatVector2D<T>::pushBack(std::size_t subArraySize, const T *subArray)
 {
     std::size_t previousLastIndex = m_index.back();
-    m_index.emplace_back();
-    std::size_t &lastIndex = m_index.back();
-    lastIndex = previousLastIndex + subArraySize;
+    m_index.emplace_back(previousLastIndex + subArraySize);
 
     m_v.reserve(m_v.size() + subArraySize);
     for (std::size_t j = 0; j < subArraySize; j++) {
@@ -664,9 +660,7 @@ void FlatVector2D<T>::pushBackItem(const T& value)
 {
     m_index.back()++;
 
-    m_v.emplace_back();
-    T &storedValue = m_v.back();
-    storedValue = value;
+    m_v.emplace_back(value);
 }
 
 /*!
@@ -681,9 +675,7 @@ void FlatVector2D<T>::pushBackItem(T &&value)
 {
     m_index.back()++;
 
-    m_v.emplace_back();
-    T &storedValue = m_v.back();
-    storedValue = std::move(value);
+    m_v.emplace_back(std::move(value));
 }
 
 /*!

--- a/src/patchkernel/cell.cpp
+++ b/src/patchkernel/cell.cpp
@@ -133,11 +133,8 @@ Cell::Cell()
 	information
 */
 Cell::Cell(long id, ElementType type, bool interior, bool storeNeighbourhood)
-	: Element(id, type),
-      m_interfaces(createNeighbourhoodStorage(storeNeighbourhood)),
-      m_adjacencies(createNeighbourhoodStorage(storeNeighbourhood))
+	: Cell(id, type, interior, storeNeighbourhood, storeNeighbourhood)
 {
-	_initialize(interior, false, false);
 }
 
 /*!
@@ -152,11 +149,8 @@ Cell::Cell(long id, ElementType type, bool interior, bool storeNeighbourhood)
 	information
 */
 Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood)
-	: Element(id, type, connectSize),
-      m_interfaces(createNeighbourhoodStorage(storeNeighbourhood)),
-      m_adjacencies(createNeighbourhoodStorage(storeNeighbourhood))
+	: Cell(id, type, connectSize, interior, storeNeighbourhood, storeNeighbourhood)
 {
-	_initialize(interior, false, false);
 }
 
 /*!
@@ -171,11 +165,69 @@ Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool store
 	information
 */
 Cell::Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood)
-	: Element(id, type, std::move(connectStorage)),
-      m_interfaces(createNeighbourhoodStorage(storeNeighbourhood)),
-      m_adjacencies(createNeighbourhoodStorage(storeNeighbourhood))
+	: Cell(id, type, std::move(connectStorage), interior, storeNeighbourhood, storeNeighbourhood)
 {
-	_initialize(interior, false, false);
+}
+
+/*!
+	Creates a new cell.
+
+	\param id is the id that will be assigned to the element
+	\param type is the type of the element
+	\param interior defines is the cell is interior or ghost
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+Cell::Cell(long id, ElementType type, bool interior, bool storeInterfaces, bool storeAdjacencies)
+	: Element(id, type),
+      m_interfaces(createNeighbourhoodStorage(storeInterfaces)),
+      m_adjacencies(createNeighbourhoodStorage(storeAdjacencies))
+{
+	_initialize(interior, false, false, false, false);
+}
+
+/*!
+	Creates a new cell.
+
+	\param id is the id that will be assigned to the element
+	\param type is the type of the element
+	\param connectSize is the size of the connectivity, this is only used
+	if the element is not associated to a reference element
+	\param interior defines is the cell is interior or ghost
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool storeInterfaces, bool storeAdjacencies)
+	: Element(id, type, connectSize),
+      m_interfaces(createNeighbourhoodStorage(storeInterfaces)),
+      m_adjacencies(createNeighbourhoodStorage(storeAdjacencies))
+{
+	_initialize(interior, false, false, false, false);
+}
+
+/*!
+	Creates a new cell.
+
+	\param id is the id that will be assigned to the element
+	\param type is the type of the element
+	\param connectStorage is the storage the contains or will contain
+	the connectivity of the element
+	\param interior defines is the cell is interior or ghost
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+Cell::Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeInterfaces, bool storeAdjacencies)
+	: Element(id, type, std::move(connectStorage)),
+      m_interfaces(createNeighbourhoodStorage(storeInterfaces)),
+      m_adjacencies(createNeighbourhoodStorage(storeAdjacencies))
+{
+	_initialize(interior, false, false, false, false);
 }
 
 /**
@@ -204,9 +256,7 @@ void Cell::swap(Cell &other) noexcept
 */
 void Cell::initialize(long id, ElementType type, bool interior, bool storeNeighbourhood)
 {
-	Element::initialize(id, type);
-
-	_initialize(interior, true, storeNeighbourhood);
+	initialize(id, type, interior, storeNeighbourhood, storeNeighbourhood);
 }
 
 /*!
@@ -222,9 +272,7 @@ void Cell::initialize(long id, ElementType type, bool interior, bool storeNeighb
 */
 void Cell::initialize(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood)
 {
-	Element::initialize(id, type, connectSize);
-
-	_initialize(interior, true, storeNeighbourhood);
+	initialize(id, type, connectSize, interior, storeNeighbourhood, storeNeighbourhood);
 }
 
 /*!
@@ -240,28 +288,92 @@ void Cell::initialize(long id, ElementType type, int connectSize, bool interior,
 */
 void Cell::initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood)
 {
+	initialize(id, type, std::move(connectStorage), interior, storeNeighbourhood, storeNeighbourhood);
+}
+
+/*!
+	Initializes the data structures of the cell.
+
+	\param id is the id of the element
+	\param type is the type of the element
+	\param interior if true the cell is flagged as interior
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+void Cell::initialize(long id, ElementType type, bool interior, bool storeInterfaces, bool storeAdjacencies)
+{
+	Element::initialize(id, type);
+
+	_initialize(interior, true, storeInterfaces, true, storeAdjacencies);
+}
+
+/*!
+	Initializes the data structures of the cell.
+
+	\param id is the id of the element
+	\param type is the type of the element
+	\param connectSize is the size of the connectivity, this is only used
+	if the element is not associated to a reference element
+	\param interior if true the cell is flagged as interior
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+void Cell::initialize(long id, ElementType type, int connectSize, bool interior, bool storeInterfaces, bool storeAdjacencies)
+{
+	Element::initialize(id, type, connectSize);
+
+	_initialize(interior, true, storeInterfaces, true, storeAdjacencies);
+}
+
+/*!
+	Initializes the data structures of the cell.
+
+	\param id is the id of the element
+	\param type is the type of the element
+	\param connectStorage is the storage the contains or will contain
+	the connectivity of the element
+	\param interior if true the cell is flagged as interior
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
+*/
+void Cell::initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeInterfaces, bool storeAdjacencies)
+{
 	Element::initialize(id, type, std::move(connectStorage));
 
-	_initialize(interior, true, storeNeighbourhood);
+	_initialize(interior, true, storeInterfaces, true, storeAdjacencies);
 }
 
 /*!
 	Internal function to initialize the data structures of the cell.
 
 	\param interior if true the cell is flagged as interior
-	\param initializeNeighbourhood defines if neighbourhood information will
+	\param initializeInterfaces defines if interface information will
 	be initialized
-	\param storeNeighbourhood defines is the cell should store neighbourhood
-	information
+	\param storeInterfaces defines if the cell should initialize the storage
+	for storing interface information
+	\param initializeAdjacency defines if adjacency information will
+	be initialized
+	\param storeAdjacencies defines if the cell should initialize the storage
+	for storing adjacency information
 */
-void Cell::_initialize(bool interior, bool initializeNeighbourhood, bool storeNeighbourhood)
+void Cell::_initialize(bool interior, bool initializeInterfaces, bool storeInterfaces, bool initializeAdjacency, bool storeAdjacencies)
 {
 	setInterior(interior);
 
-	// Neighbourhood
-	if (initializeNeighbourhood) {
-		resetInterfaces(storeNeighbourhood);
-		resetAdjacencies(storeNeighbourhood);
+	// Interface information
+	if (initializeInterfaces) {
+		resetInterfaces(storeInterfaces);
+	}
+
+	// Interface information
+	if (initializeAdjacency) {
+		resetAdjacencies(storeAdjacencies);
 	}
 }
 

--- a/src/patchkernel/cell.cpp
+++ b/src/patchkernel/cell.cpp
@@ -93,7 +93,7 @@ namespace bitpit {
 	must be taken to ensure that all members needed by the function are
 	already initialized at the time the function is called.
 
-	\param storeNeighbourhood defines is the cell should store neighbourhood
+	\param storeNeighbourhood defines if the cell should store neighbourhood
 	information
 */
 bitpit::FlatVector2D<long> Cell::createNeighbourhoodStorage(bool storeNeighbourhood)
@@ -128,8 +128,8 @@ Cell::Cell()
 
 	\param id is the id that will be assigned to the element
 	\param type is the type of the element
-	\param interior defines is the cell is interior or ghost
-	\param storeNeighbourhood defines is the cell should store neighbourhood
+	\param interior defines if the cell is interior or ghost
+	\param storeNeighbourhood defines if the cell should store neighbourhood
 	information
 */
 Cell::Cell(long id, ElementType type, bool interior, bool storeNeighbourhood)
@@ -144,8 +144,8 @@ Cell::Cell(long id, ElementType type, bool interior, bool storeNeighbourhood)
 	\param type is the type of the element
 	\param connectSize is the size of the connectivity, this is only used
 	if the element is not associated to a reference element
-	\param interior defines is the cell is interior or ghost
-	\param storeNeighbourhood defines is the cell should store neighbourhood
+	\param interior defines if the cell is interior or ghost
+	\param storeNeighbourhood defines if the cell should store neighbourhood
 	information
 */
 Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood)
@@ -160,8 +160,8 @@ Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool store
 	\param type is the type of the element
 	\param connectStorage is the storage the contains or will contain
 	the connectivity of the element
-	\param interior defines is the cell is interior or ghost
-	\param storeNeighbourhood defines is the cell should store neighbourhood
+	\param interior defines if the cell is interior or ghost
+	\param storeNeighbourhood defines if the cell should store neighbourhood
 	information
 */
 Cell::Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood)
@@ -174,7 +174,7 @@ Cell::Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, 
 
 	\param id is the id that will be assigned to the element
 	\param type is the type of the element
-	\param interior defines is the cell is interior or ghost
+	\param interior defines if the cell is interior or ghost
 	\param storeInterfaces defines if the cell should initialize the storage
 	for storing interface information
 	\param storeAdjacencies defines if the cell should initialize the storage
@@ -195,7 +195,7 @@ Cell::Cell(long id, ElementType type, bool interior, bool storeInterfaces, bool 
 	\param type is the type of the element
 	\param connectSize is the size of the connectivity, this is only used
 	if the element is not associated to a reference element
-	\param interior defines is the cell is interior or ghost
+	\param interior defines if the cell is interior or ghost
 	\param storeInterfaces defines if the cell should initialize the storage
 	for storing interface information
 	\param storeAdjacencies defines if the cell should initialize the storage
@@ -216,7 +216,7 @@ Cell::Cell(long id, ElementType type, int connectSize, bool interior, bool store
 	\param type is the type of the element
 	\param connectStorage is the storage the contains or will contain
 	the connectivity of the element
-	\param interior defines is the cell is interior or ghost
+	\param interior defines if the cell is interior or ghost
 	\param storeInterfaces defines if the cell should initialize the storage
 	for storing interface information
 	\param storeAdjacencies defines if the cell should initialize the storage
@@ -283,7 +283,7 @@ void Cell::initialize(long id, ElementType type, int connectSize, bool interior,
 	\param connectStorage is the storage the contains or will contain
 	the connectivity of the element
 	\param interior if true the cell is flagged as interior
-	\param storeNeighbourhood defines is the cell should store neighbourhood
+	\param storeNeighbourhood defines if the cell should store neighbourhood
 	information
 */
 void Cell::initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood)

--- a/src/patchkernel/cell.hpp
+++ b/src/patchkernel/cell.hpp
@@ -50,12 +50,12 @@ friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream& buf, Cell& 
 
 public:
 	Cell();
-	Cell(long id, ElementType type,
-	     bool interior = true, bool storeNeighbourhood = true);
-	Cell(long id, ElementType type, int connectSize,
-	     bool interior = true, bool storeNeighbourhood = true);
-	Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage,
-	     bool interior = true, bool storeNeighbourhood = true);
+	BITPIT_DEPRECATED(Cell(long id, ElementType type, bool interior, bool storeNeighbourhood));
+	BITPIT_DEPRECATED(Cell(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood));
+	BITPIT_DEPRECATED(Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood));
+	Cell(long id, ElementType type, bool interior = true, bool storeInterfaces = true, bool storeAjacencies = true);
+	Cell(long id, ElementType type, int connectSize, bool interior = true, bool storeInterfaces = true, bool storeAjacencies = true);
+	Cell(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior = true, bool storeInterfaces = true, bool storeAjacencies = true);
 
 	Cell(const Cell &other) = default;
 	Cell(Cell&& other) = default;
@@ -64,9 +64,12 @@ public:
 
 	void swap(Cell &other) noexcept;
 
-	void initialize(long id, ElementType type, bool interior, bool storeNeighbourhood = true);
-	void initialize(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood = true);
-	void initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood = true);
+	BITPIT_DEPRECATED(void initialize(long id, ElementType type, bool interior, bool storeNeighbourhood ));
+	BITPIT_DEPRECATED(void initialize(long id, ElementType type, int connectSize, bool interior, bool storeNeighbourhood));
+	BITPIT_DEPRECATED(void initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeNeighbourhood));
+	void initialize(long id, ElementType type, bool interior, bool storeInterfaces = true, bool storeAjacencies = true);
+	void initialize(long id, ElementType type, int connectSize, bool interior, bool storeInterfaces = true, bool storeAjacencies = true);
+	void initialize(long id, ElementType type, std::unique_ptr<long[]> &&connectStorage, bool interior, bool storeInterfaces = true, bool storeAjacencies = true);
 
 	bool isInterior() const;
 	
@@ -121,7 +124,7 @@ private:
 
 	bitpit::FlatVector2D<long> createNeighbourhoodStorage(bool storeNeighbourhood);
 
-	void _initialize(bool interior, bool initializeNeighbourhood, bool storeNeighbourhood);
+	void _initialize(bool interior, bool initializeInterfaces, bool storeInterfaces, bool initializeAdjacency, bool storeAdjacencies);
 
 };
 

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -212,6 +212,9 @@ void PatchNumberingInfo::_extract()
 	}
 #endif
 
+	// Initialize data structure for consecutive ids
+	m_cellLocalToConsecutiveMap.reserve(m_patch->getCellCount());
+
 	// Evalaute the consecutive id of the internal cells
 	if (m_patch->getInternalCellCount() > 0) {
 		PatchKernel::CellConstIterator beginItr = m_patch->internalCellConstBegin();
@@ -226,9 +229,12 @@ void PatchNumberingInfo::_extract()
 			nativeIds[index++] = std::make_pair(nativeId, id);
 		}
 
+		auto nativeIdsBegin = nativeIds.begin();
+		auto nativeIdsEnd   = nativeIds.end();
+
 		std::sort(
-			nativeIds.begin(),
-			nativeIds.end(),
+			nativeIdsBegin,
+			nativeIdsEnd,
 			[](const std::pair<long, long> &x, const std::pair<long, long> &y) -> bool
 			{
 				return x.first < y.first;
@@ -242,7 +248,7 @@ void PatchNumberingInfo::_extract()
 #endif
 
 		consecutiveId = m_cellConsecutiveOffset;
-		for (auto itr = nativeIds.begin(); itr != nativeIds.end(); ++itr) {
+		for (auto itr = nativeIdsBegin; itr != nativeIdsEnd; ++itr) {
 			m_cellLocalToConsecutiveMap.insert({itr->second, consecutiveId++});
 		}
 	}

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2641,11 +2641,14 @@ PatchKernel::CellIterator PatchKernel::_addInternalCell(ElementType type, std::u
 #endif
 
 	// Create the cell
+	bool storeInterfaces  = (getInterfacesBuildStrategy() != INTERFACES_NONE);
+	bool storeAdjacencies = storeInterfaces || (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
+
 	CellIterator iterator;
 	if (referenceId == Cell::NULL_ID) {
-		iterator = m_cells.emreclaim(id, id, type, std::move(connectStorage), true, true);
+		iterator = m_cells.emreclaim(id, id, type, std::move(connectStorage), true, storeInterfaces, storeAdjacencies);
 	} else {
-		iterator = m_cells.emreclaimBefore(referenceId, id, id, type, std::move(connectStorage), true, true);
+		iterator = m_cells.emreclaimBefore(referenceId, id, id, type, std::move(connectStorage), true, storeInterfaces, storeAdjacencies);
 	}
 	m_nInternalCells++;
 
@@ -2730,9 +2733,12 @@ void PatchKernel::_restoreInternalCell(const CellIterator &iterator, ElementType
 	//
 	// There is no need to set the id of the cell as assigned, because
 	// also the index generator will be restored.
+	bool storeInterfaces  = (getInterfacesBuildStrategy() != INTERFACES_NONE);
+	bool storeAdjacencies = storeInterfaces || (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
+
 	long cellId = iterator.getId();
 	Cell &cell = *iterator;
-	cell.initialize(cellId, type, std::move(connectStorage), true, true);
+	cell.initialize(cellId, type, std::move(connectStorage), true, storeInterfaces, storeAdjacencies);
 	m_nInternalCells++;
 
 	// Set the alteration flags of the cell

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -822,7 +822,7 @@ protected:
 	void setAdjacenciesBuildStrategy(AdjacenciesBuildStrategy status);
 	void resetAdjacencies();
 	void pruneStaleAdjacencies();
-	virtual void _resetAdjacencies();
+	virtual void _resetAdjacencies(bool release);
 	virtual void _updateAdjacencies();
 
 	void setInterfacesBuildStrategy(InterfacesBuildStrategy status);

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -827,7 +827,7 @@ protected:
 
 	void setInterfacesBuildStrategy(InterfacesBuildStrategy status);
 	void pruneStaleInterfaces();
-	virtual void _resetInterfaces();
+	virtual void _resetInterfaces(bool release);
 	virtual void _updateInterfaces();
 
 	bool testCellAlterationFlags(long id, AlterationFlags flags) const;

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -892,11 +892,14 @@ PatchKernel::CellIterator PatchKernel::_addGhostCell(ElementType type, std::uniq
 	//
 	// If there are internal cells, the ghost cell should be inserted
 	// after the last internal cell.
+	bool storeInterfaces  = (getInterfacesBuildStrategy() != INTERFACES_NONE);
+	bool storeAdjacencies = storeInterfaces || (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
+
 	CellIterator iterator;
 	if (m_lastInternalCellId < 0) {
-		iterator = m_cells.emreclaim(id, id, type, std::move(connectStorage), false, true);
+		iterator = m_cells.emreclaim(id, id, type, std::move(connectStorage), false, storeInterfaces, storeAdjacencies);
 	} else {
-		iterator = m_cells.emreclaimAfter(m_lastInternalCellId, id, id, type, std::move(connectStorage), false, true);
+		iterator = m_cells.emreclaimAfter(m_lastInternalCellId, id, id, type, std::move(connectStorage), false, storeInterfaces, storeAdjacencies);
 	}
 	m_nGhostCells++;
 
@@ -975,9 +978,12 @@ void PatchKernel::_restoreGhostCell(const CellIterator &iterator, ElementType ty
 	//
 	// There is no need to set the id of the cell as assigned, because
 	// also the index generator will be restored.
+	bool storeInterfaces  = (getInterfacesBuildStrategy() != INTERFACES_NONE);
+	bool storeAdjacencies = storeInterfaces || (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE);
+
 	long cellId = iterator.getId();
 	Cell &cell = *iterator;
-	cell.initialize(iterator.getId(), type, std::move(connectStorage), false, true);
+	cell.initialize(iterator.getId(), type, std::move(connectStorage), false, storeInterfaces, storeAdjacencies);
 	m_nGhostCells++;
 
 	// Set owner

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -669,7 +669,7 @@ void VolOctree::simulateCellUpdate(long id, adaption::Marker marker, std::vector
 			virtualVertices->emplaceBack(vertexId, vertexId, m_tree->getNode(virtualOctant, i));
 		}
 
-		virtualCells->emplace_back(id, m_cellTypeInfo->type, std::move(connectStorage), true, false);
+		virtualCells->emplace_back(id, m_cellTypeInfo->type, std::move(connectStorage), true, false, false);
 	}
 }
 


### PR DESCRIPTION
When destroying adjacencies/interfaces their memory should be released.

Note: in terms of memory, the difference between resetting and deleting interfaces/adjacencies is just 4+4 bytes per cell.