### PR TITLE
patchkernel: avoid building partitioning information when the patch is on one processor

### DIFF
--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -706,6 +706,7 @@ public:
 
 	bool isPartitioned() const;
 	bool isPartitioningSupported() const;
+	bool arePartitioningInfoDirty(bool global = true) const;
 	PartitioningStatus getPartitioningStatus(bool global = false) const;
 	double evalPartitioningUnbalance() const;
 	double evalPartitioningUnbalance(const std::unordered_map<long, double> &cellWeights) const;
@@ -994,7 +995,6 @@ private:
 	std::vector<adaption::Info> _partitioningAlter_sendCells(const std::unordered_set<int> &recvRanks, bool trackPartitioning, std::unordered_map<long, int> *ghostCellOwnershipChanges);
 	std::vector<adaption::Info> _partitioningAlter_receiveCells(const std::unordered_set<int> &sendRanks, bool trackPartitioning, std::unordered_map<long, int> *ghostCellOwnershipChanges);
 
-	bool arePartitioningInfoDirty(bool global = true) const;
 	void setPartitioningInfoDirty(bool dirty);
 
 	void updatePartitioningInfo(bool forcedUpdated = false);

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -3765,6 +3765,8 @@ bool PatchKernel::arePartitioningInfoDirty(bool global) const
 {
 	if (!isPartitioned()) {
 		return false;
+	} else if (getProcessorCount() == 1) {
+		return false;
 	}
 
 	bool partitioningInfoDirty = m_partitioningInfoDirty;
@@ -3784,6 +3786,8 @@ bool PatchKernel::arePartitioningInfoDirty(bool global) const
 void PatchKernel::setPartitioningInfoDirty(bool dirty)
 {
 	if (dirty && !isPartitioned()) {
+		return;
+	} else if (getProcessorCount() == 1) {
 		return;
 	}
 


### PR DESCRIPTION
There is no need to build partitioning information is the patch is on one single processor.