### PR TITLE
PABLO: fix evaluation of tree constants

### DIFF
--- a/src/PABLO/tree_constants.cpp
+++ b/src/PABLO/tree_constants.cpp
@@ -424,7 +424,7 @@ TreeConstants::initialize(uint8_t dim) {
 	nodeFromCoordinates[0][1][1] = 6;
 	nodeFromCoordinates[1][1][1] = 7;
 
-	for (int level = 0; level < MAX_LEVEL; ++level) {
+	for (int level = 0; level <= MAX_LEVEL; ++level) {
 		lengths[level] = uint32_t(1) << (MAX_LEVEL - level);
 		areas[level]   = uint64_t(1) << ((dim - 1) * (MAX_LEVEL - level));
 		volumes[level] = uint64_t(1) << (dim * (MAX_LEVEL - level));

--- a/src/PABLO/tree_constants.hpp
+++ b/src/PABLO/tree_constants.hpp
@@ -91,9 +91,9 @@ public:
 
 	uint8_t  nodeFromCoordinates[2][2][2];    /**< nodeFromCoordinates[0:1][0:1][0:1] = Local node index from Local coordinates [x][y][z] */
 
-	std::array<uint32_t, MAX_LEVEL> lengths;   /**< Lengths associated to the levels */
-	std::array<uint64_t, MAX_LEVEL> areas;     /**< Areas associated to the levels */
-	std::array<uint64_t, MAX_LEVEL> volumes;   /**< Volumes associated to the levels */
+	std::array<uint32_t, MAX_LEVEL + 1> lengths;   /**< Lengths associated to the levels */
+	std::array<uint64_t, MAX_LEVEL + 1> areas;     /**< Areas associated to the levels */
+	std::array<uint64_t, MAX_LEVEL + 1> volumes;   /**< Volumes associated to the levels */
 
 private:
 	// =================================================================================== //


### PR DESCRIPTION
The constant MAX_LEVEL defines the maximum allowed level, hence tree constants need to be evaluated also for this level.