### PR TITLE
patchkernel: fix dump/restore of index generators

### DIFF
--- a/src/IO/index_generator.tpp
+++ b/src/IO/index_generator.tpp
@@ -183,6 +183,7 @@ void IndexGenerator<id_t>::trash(typename IndexGenerator<id_t>::id_type id)
 {
     assert(id != NULL_ID);
     assert(m_trash.count(id) == 0);
+    assert(id >= m_lowest && id <= m_highest);
 
     // If we are trashing the highest or the lowest id we can update the
     // limits of the generator, otherwise we add the id to the trash.

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -252,17 +252,9 @@ PatchKernel::PatchKernel(const PatchKernel &other)
 #endif
 {
 	// Create index generators
-	if (other.m_vertexIdGenerator) {
-		m_vertexIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(other.m_vertexIdGenerator)));
-	}
-
-	if (other.m_interfaceIdGenerator) {
-		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(other.m_interfaceIdGenerator)));
-	}
-
-	if (other.m_cellIdGenerator) {
-		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(other.m_cellIdGenerator)));
-	}
+	importVertexIndexGenerator(other);
+	importInterfaceIndexGenerator(other);
+	importCellIndexGenerator(other);
 
 	// Register the patch
 	patch::manager().registerPatch(this);
@@ -1539,6 +1531,23 @@ void PatchKernel::createVertexIndexGenerator()
 }
 
 /*!
+	Import the vertex index generator form the specified source patch.
+
+	If the source patch doesn't define an index generator, the intexe generator of the current
+	patch will be deleted.
+
+	\param source is the patch from with the index generator will be imported from
+*/
+void PatchKernel::importVertexIndexGenerator(const PatchKernel &source)
+{
+	if (source.m_vertexIdGenerator) {
+		m_vertexIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(source.m_vertexIdGenerator)));
+	} else {
+		m_vertexIdGenerator.reset();
+	}
+}
+
+/*!
 	Gets the number of vertices in the patch.
 
 	\return The number of vertices in the patch
@@ -2373,6 +2382,23 @@ void PatchKernel::createCellIndexGenerator()
 		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
 	} else {
 		m_cellIdGenerator->reset();
+	}
+}
+
+/*!
+	Import the cell index generator form the specified source patch.
+
+	If the source patch doesn't define an index generator, the intexe generator of the current
+	patch will be deleted.
+
+	\param source is the patch from with the index generator will be imported from
+*/
+void PatchKernel::importCellIndexGenerator(const PatchKernel &source)
+{
+	if (source.m_cellIdGenerator) {
+		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(source.m_cellIdGenerator)));
+	} else {
+		m_cellIdGenerator.reset();
 	}
 }
 
@@ -4000,6 +4026,23 @@ void PatchKernel::createInterfaceIndexGenerator()
 		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
 	} else {
 		m_interfaceIdGenerator->reset();
+	}
+}
+
+/*!
+	Import the interface index generator form the specified source patch.
+
+	If the source patch doesn't define an index generator, the intexe generator of the current
+	patch will be deleted.
+
+	\param source is the patch from with the index generator will be imported from
+*/
+void PatchKernel::importInterfaceIndexGenerator(const PatchKernel &source)
+{
+	if (source.m_interfaceIdGenerator) {
+		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>(*(source.m_interfaceIdGenerator)));
+	} else {
+		m_interfaceIdGenerator.reset();
 	}
 }
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1517,6 +1517,27 @@ void PatchKernel::setVertexAutoIndexing(bool enabled)
 }
 
 /*!
+	Dump vertex auto indexing.
+
+ *  \param stream is the stream to write to
+*/
+void PatchKernel::dumpVertexAutoIndexing(std::ostream &stream) const
+{
+	m_vertexIdGenerator->dump(stream);
+}
+
+/*!
+	Restores vertex auto indexing.
+
+	\param stream is the stream to read from
+*/
+void PatchKernel::restoreVertexAutoIndexing(std::istream &stream)
+{
+	createVertexIndexGenerator();
+	m_vertexIdGenerator->restore(stream);
+}
+
+/*!
 	Create the vertex index generator.
 
 	If the index generator is already created, the existing index generator will be reset.
@@ -2369,6 +2390,27 @@ void PatchKernel::setCellAutoIndexing(bool enabled)
 	} else {
 		m_cellIdGenerator.reset();
 	}
+}
+
+/*!
+	Dump cell auto indexing.
+
+ *  \param stream is the stream to write to
+*/
+void PatchKernel::dumpCellAutoIndexing(std::ostream &stream) const
+{
+	m_cellIdGenerator->dump(stream);
+}
+
+/*!
+	Restores cell auto indexing.
+
+	\param stream is the stream to read from
+*/
+void PatchKernel::restoreCellAutoIndexing(std::istream &stream)
+{
+	createCellIndexGenerator();
+	m_cellIdGenerator->restore(stream);
 }
 
 /*!
@@ -4013,6 +4055,27 @@ void PatchKernel::setInterfaceAutoIndexing(bool enabled)
 
 		m_interfaceIdGenerator.reset();
 	}
+}
+
+/*!
+	Dump interface auto indexing.
+
+ *  \param stream is the stream to write to
+*/
+void PatchKernel::dumpInterfaceAutoIndexing(std::ostream &stream) const
+{
+	m_interfaceIdGenerator->dump(stream);
+}
+
+/*!
+	Restores interface auto indexing.
+
+	\param stream is the stream to read from
+*/
+void PatchKernel::restoreInterfaceAutoIndexing(std::istream &stream)
+{
+	createInterfaceIndexGenerator();
+	m_interfaceIdGenerator->restore(stream);
 }
 
 /*!
@@ -7937,19 +8000,22 @@ bool PatchKernel::dump(std::ostream &stream) const
 	}
 
 	// Index generators
-	utils::binary::write(stream, (bool) m_vertexIdGenerator);
-	if (m_vertexIdGenerator) {
-		m_vertexIdGenerator->dump(stream);
+	bool hasVertexAutoIndexing = isVertexAutoIndexingEnabled();
+	utils::binary::write(stream, hasVertexAutoIndexing);
+	if (hasVertexAutoIndexing) {
+		dumpVertexAutoIndexing(stream);
 	}
 
-	utils::binary::write(stream, (bool) m_interfaceIdGenerator);
-	if (m_interfaceIdGenerator) {
-		m_interfaceIdGenerator->dump(stream);
+	bool hasInterfaceAutoIndexing = isInterfaceAutoIndexingEnabled();
+	utils::binary::write(stream, hasInterfaceAutoIndexing);
+	if (hasInterfaceAutoIndexing) {
+		dumpInterfaceAutoIndexing(stream);
 	}
 
-	utils::binary::write(stream, (bool) m_cellIdGenerator);
-	if (m_cellIdGenerator) {
-		m_cellIdGenerator->dump(stream);
+	bool hasCellAutoIndexing = isCellAutoIndexingEnabled();
+	utils::binary::write(stream, hasCellAutoIndexing);
+	if (hasCellAutoIndexing) {
+		dumpCellAutoIndexing(stream);
 	}
 
 	// The patch has been dumped successfully
@@ -8045,22 +8111,28 @@ void PatchKernel::restore(std::istream &stream, bool reregister)
 	}
 
 	// Index generators
-	bool hasVertexIdGenerator;
-	utils::binary::read(stream, hasVertexIdGenerator);
-	if (hasVertexIdGenerator) {
-		m_vertexIdGenerator->restore(stream);
+	bool hasVertexAutoIndexing;
+	utils::binary::read(stream, hasVertexAutoIndexing);
+	if (hasVertexAutoIndexing) {
+		restoreVertexAutoIndexing(stream);
+	} else {
+		setVertexAutoIndexing(false);
 	}
 
-	bool hasInterfaceIdGenerator;
-	utils::binary::read(stream, hasInterfaceIdGenerator);
-	if (hasInterfaceIdGenerator) {
-		m_interfaceIdGenerator->restore(stream);
+	bool hasInterfaceAutoIndexing;
+	utils::binary::read(stream, hasInterfaceAutoIndexing);
+	if (hasInterfaceAutoIndexing) {
+		restoreInterfaceAutoIndexing(stream);
+	} else {
+		setInterfaceAutoIndexing(false);
 	}
 
-	bool hasCellIdGenerator;
-	utils::binary::read(stream, hasCellIdGenerator);
-	if (hasCellIdGenerator) {
-		m_cellIdGenerator->restore(stream);
+	bool hasCellAutoIndexing;
+	utils::binary::read(stream, hasCellAutoIndexing);
+	if (hasCellAutoIndexing) {
+		restoreCellAutoIndexing(stream);
+	} else {
+		setCellAutoIndexing(false);
 	}
 }
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1512,15 +1512,29 @@ void PatchKernel::setVertexAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		createVertexIndexGenerator();
+
 		VertexConstIterator beginItr = m_vertices.cbegin();
 		VertexConstIterator endItr   = m_vertices.cend();
-
-		m_vertexIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
 		for (VertexConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_vertexIdGenerator->setAssigned(itr.getId());
 		}
 	} else {
 		m_vertexIdGenerator.reset();
+	}
+}
+
+/*!
+	Create the vertex index generator.
+
+	If the index generator is already created, the existing index generator will be reset.
+*/
+void PatchKernel::createVertexIndexGenerator()
+{
+	if (!m_vertexIdGenerator) {
+		m_vertexIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
+	} else {
+		m_vertexIdGenerator->reset();
 	}
 }
 
@@ -2336,15 +2350,29 @@ void PatchKernel::setCellAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		createCellIndexGenerator();
+
 		CellConstIterator beginItr = m_cells.cbegin();
 		CellConstIterator endItr   = m_cells.cend();
-
-		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
 		for (CellConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_cellIdGenerator->setAssigned(itr.getId());
 		}
 	} else {
 		m_cellIdGenerator.reset();
+	}
+}
+
+/*!
+	Create the cell index generator.
+
+	If the index generator is already created, the existing index generator will be reset.
+*/
+void PatchKernel::createCellIndexGenerator()
+{
+	if (!m_cellIdGenerator) {
+		m_cellIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
+	} else {
+		m_cellIdGenerator->reset();
 	}
 }
 
@@ -3945,10 +3973,10 @@ void PatchKernel::setInterfaceAutoIndexing(bool enabled)
 	}
 
 	if (enabled) {
+		createInterfaceIndexGenerator();
+
 		InterfaceConstIterator beginItr = m_interfaces.cbegin();
 		InterfaceConstIterator endItr   = m_interfaces.cend();
-
-		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
 		for (InterfaceConstIterator itr = beginItr; itr != endItr; ++itr) {
 			m_interfaceIdGenerator->setAssigned(itr.getId());
 		}
@@ -3958,6 +3986,20 @@ void PatchKernel::setInterfaceAutoIndexing(bool enabled)
 		}
 
 		m_interfaceIdGenerator.reset();
+	}
+}
+
+/*!
+	Create the interface index generator.
+
+	If the index generator is already created, the existing index generator will be reset.
+*/
+void PatchKernel::createInterfaceIndexGenerator()
+{
+	if (!m_interfaceIdGenerator) {
+		m_interfaceIdGenerator = std::unique_ptr<IndexGenerator<long>>(new IndexGenerator<long>());
+	} else {
+		m_interfaceIdGenerator->reset();
 	}
 }
 

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1047,12 +1047,18 @@ private:
 	void setAddedInterfaceAlterationFlags(long id);
 	void setDeletedInterfaceAlterationFlags(long id);
 
+	void dumpVertexAutoIndexing(std::ostream &stream) const;
+	void restoreVertexAutoIndexing(std::istream &stream);
 	void createVertexIndexGenerator();
 	void importVertexIndexGenerator(const PatchKernel &source);
 
+	void dumpCellAutoIndexing(std::ostream &stream) const;
+	void restoreCellAutoIndexing(std::istream &stream);
 	void createCellIndexGenerator();
 	void importCellIndexGenerator(const PatchKernel &source);
 
+	void dumpInterfaceAutoIndexing(std::ostream &stream) const;
+	void restoreInterfaceAutoIndexing(std::istream &stream);
 	void createInterfaceIndexGenerator();
 	void importInterfaceIndexGenerator(const PatchKernel &source);
 

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1047,6 +1047,12 @@ private:
 	void setAddedInterfaceAlterationFlags(long id);
 	void setDeletedInterfaceAlterationFlags(long id);
 
+	void createVertexIndexGenerator();
+
+	void createCellIndexGenerator();
+
+	void createInterfaceIndexGenerator();
+
 	VertexIterator _addInternalVertex(const std::array<double, 3> &coords, long id);
 
 	void _restoreInternalVertex(const VertexIterator &iterator, const std::array<double, 3> &coords);

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1048,10 +1048,13 @@ private:
 	void setDeletedInterfaceAlterationFlags(long id);
 
 	void createVertexIndexGenerator();
+	void importVertexIndexGenerator(const PatchKernel &source);
 
 	void createCellIndexGenerator();
+	void importCellIndexGenerator(const PatchKernel &source);
 
 	void createInterfaceIndexGenerator();
+	void importInterfaceIndexGenerator(const PatchKernel &source);
 
 	VertexIterator _addInternalVertex(const std::array<double, 3> &coords, long id);
 


### PR DESCRIPTION
Index generators were not properly restored when auto indexing was set to false.