### PR TITLE
levelset: fix restore of sign storage

### DIFF
--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -853,6 +853,8 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
         } else if( adaptionInfo.type == adaption::Type::TYPE_PARTITION_RECV){
             partitioningRecvList.insert({{adaptionInfo.rank,adaptionInfo.current}}) ;
             updatePartitioning = true;
+        } else if (adaptionInfo.type == adaption::Type::TYPE_DELETION) {
+            updateNarrowBand = true;
         } else {
             if (!updateNarrowBand) {
                 for (long cellId : adaptionInfo.current) {

--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -875,6 +875,11 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
     }
 #endif
 
+    // Early return if no update is needed
+    if (!updateNarrowBand && !updatePartitioning) {
+        return;
+    }
+
 #if BITPIT_ENABLE_MPI
     // Get data communicator for updating partitioning
     std::unique_ptr<DataCommunicator> dataCommunicator;

--- a/src/levelset/levelSetSignPropagator.cpp
+++ b/src/levelset/levelSetSignPropagator.cpp
@@ -110,8 +110,12 @@ void LevelSetSignPropagator::execute(const std::vector<adaption::Info> &adaption
         return;
     }
 
-    // Initialize stored sign of new cells
-    bool propagationNeeded = false;
+    // Initialize sign propagation
+    //
+    // We need to check if propagation is really needed and initialize stored sign of new cells.
+    // Propagation is needed if the stored sign is marked as dirty or if cells has been modified
+    // by mesh adaption.
+    bool propagationNeeded = storage->isDirty();
     for (const adaption::Info &adaptionInfo : adaptionData) {
         if (adaptionInfo.entity != adaption::Entity::ENTITY_CELL) {
             continue;

--- a/src/levelset/levelSetSignedObject.cpp
+++ b/src/levelset/levelSetSignedObject.cpp
@@ -199,8 +199,9 @@ void LevelSetSignedObjectInterface::clearSignStorage()
  */
 void LevelSetSignedObjectInterface::dumpSignStorage(std::ostream &stream)
 {
-    // Stored sign
-    if (m_signStorage) {
+    bool hasSignStorage = static_cast<bool>(m_signStorage);
+    utils::binary::write(stream, hasSignStorage);
+    if (hasSignStorage) {
         m_signStorage->dump( stream );
     }
 }
@@ -212,8 +213,10 @@ void LevelSetSignedObjectInterface::dumpSignStorage(std::ostream &stream)
  */
 void LevelSetSignedObjectInterface::restoreSignStorage(std::istream &stream)
 {
-    // Stored sign
-    if (m_signStorage) {
+    bool hasSignStorage;
+    utils::binary::read(stream, hasSignStorage);
+    if (hasSignStorage) {
+        initializeSignStorage();
         m_signStorage->restore( stream );
     }
 }


### PR DESCRIPTION
When restoring LevelSetSignedObjectInterface, the sign storage needs to be explicitly initialized.