### PR TITLE
IO: add support for reading/writing XML attributes

### DIFF
--- a/src/IO/configuration_JSON.cpp
+++ b/src/IO/configuration_JSON.cpp
@@ -264,13 +264,13 @@ void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::
 {
     // Write the options
     for (const auto &entry : config->getOptions()) {
-        const std::string &configKey   = entry.first;
-        const std::string &configValue = entry.second;
+        const std::string &key = entry.first;
+        const Config::Option &option = entry.second;
 
         rapidjson::Value jsonKey;
-        jsonKey.SetString(configKey, allocator);
+        jsonKey.SetString(key, allocator);
 
-        rapidjson::Value jsonValue = encodeValue(configValue, allocator);
+        rapidjson::Value jsonValue = encodeValue(option.value, allocator);
 
         rootJSONData.AddMember(jsonKey, jsonValue, allocator);
     }

--- a/src/IO/configuration_JSON.cpp
+++ b/src/IO/configuration_JSON.cpp
@@ -263,7 +263,7 @@ void writeConfiguration(const std::string &filename, const Config *rootConfig, b
 void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::Document::AllocatorType &allocator)
 {
     // Write the options
-    for (auto &entry : config->getOptions()) {
+    for (const auto &entry : config->getOptions()) {
         const std::string &configKey   = entry.first;
         const std::string &configValue = entry.second;
 

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -83,6 +83,8 @@ void readNode(xmlNodePtr root, Config *config)
 */
 void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string &encoding)
 {
+    int status;
+
     // Write the options
     for (const auto &entry : config->getOptions()) {
         const std::string &key   = entry.first;
@@ -91,6 +93,12 @@ void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string 
         xmlChar *elementName = encodeString(key, encoding);
         xmlChar *elementText = encodeString(value, encoding);
         int status = xmlTextWriterWriteFormatElement(writer, BAD_CAST elementName, "%s", elementText);
+        if (elementText) {
+            xmlFree(elementText);
+        }
+        if (elementName) {
+            xmlFree(elementName);
+        }
         if (status < 0) {
             throw std::runtime_error("Error at xmlTextWriterWriteFormatElement");
         }
@@ -103,7 +111,10 @@ void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string 
 
         // Start the section
         xmlChar *elementName = encodeString(key, encoding);
-        int status = xmlTextWriterStartElement(writer, BAD_CAST elementName);
+        status = xmlTextWriterStartElement(writer, BAD_CAST elementName);
+        if (elementName) {
+            xmlFree(elementName);
+        }
         if (status < 0) {
             throw std::runtime_error("Error at xmlTextWriterStartElement");
         }
@@ -250,6 +261,9 @@ void writeConfiguration(const std::string &filename, const std::string &rootname
     // Start the root element
     xmlChar *elementName = encodeString(rootname, DEFAULT_ENCODING);
     status = xmlTextWriterStartElement(writer, BAD_CAST elementName);
+    if (elementName) {
+        xmlFree(elementName);
+    }
     if (status < 0) {
         throw std::runtime_error("Error at xmlTextWriterStartElement");
     }
@@ -260,6 +274,9 @@ void writeConfiguration(const std::string &filename, const std::string &rootname
 
     xmlChar *versionAttr = encodeString(versionStream.str(), DEFAULT_ENCODING);
     status = xmlTextWriterWriteAttribute(writer, BAD_CAST "version", BAD_CAST versionAttr);
+    if (versionAttr) {
+        xmlFree(versionAttr);
+    }
     if (status < 0) {
         throw std::runtime_error("Error at xmlTextWriterWriteAttribute");
     }

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -84,7 +84,7 @@ void readNode(xmlNodePtr root, Config *config)
 void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string &encoding)
 {
     // Write the options
-    for (auto &entry : config->getOptions()) {
+    for (const auto &entry : config->getOptions()) {
         const std::string &key   = entry.first;
         const std::string &value = entry.second;
 

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -205,8 +205,7 @@ void readConfiguration(const std::string &filename, const std::string &rootname,
     }
 
     // Check if the version is supported
-    const xmlChar *versionAttributeName =
-        reinterpret_cast<const xmlChar *>("version");
+    const xmlChar *versionAttributeName = reinterpret_cast<const xmlChar *>("version");
     if (checkVersion && xmlHasProp(rootElement, versionAttributeName)) {
         xmlChar *versionValue = xmlGetProp(rootElement, versionAttributeName);
         std::string versionString((char *) versionValue);

--- a/src/IO/configuration_config.cpp
+++ b/src/IO/configuration_config.cpp
@@ -79,13 +79,6 @@ Config & Config::operator=(Config other)
 }
 
 /*!
-    Destructor.
-*/
-Config::~Config()
-{
-}
-
-/*!
     Swap operator.
 
     \param other is another config whose content is swapped with that of

--- a/src/IO/configuration_config.cpp
+++ b/src/IO/configuration_config.cpp
@@ -133,6 +133,130 @@ const Config::Options & Config::getOptions() const
 }
 
 /*!
+    Gets a reference to the specified option.
+
+    \param key is the name of the option
+    \result A reference to the specified option.
+*/
+Config::Option & Config::getOption(const std::string &key)
+{
+    return const_cast<Option &>(static_cast<const Config &>(*this).getOption(key));
+}
+
+/*!
+    Gets a constant reference to the specified option.
+
+    \param key is the name of the option
+    \result A constant reference to the specified option.
+*/
+const Config::Option & Config::getOption(const std::string &key) const
+{
+    return (*m_options).at(key);
+}
+
+/*!
+    Gets the value of the specified option.
+
+    If the option does not exists an exception is thrown.
+
+    \param key is the name of the option
+    \result The value of the specified option.
+*/
+std::string Config::get(const std::string &key) const
+{
+    return getOption(key).value;
+}
+
+/*!
+    Gets the value of the specified option.
+
+    If the option does not exists the fallback value is returned.
+
+    \param key is the name of the option
+    \param fallback is the value that will be returned if the specified
+    options does not exist
+    \result The value of the specified option or the fallback value if the
+    options does not exist.
+*/
+std::string Config::get(const std::string &key, const std::string &fallback) const
+{
+    if (hasOption(key)) {
+        return getOption(key).value;
+    } else {
+        return fallback;
+    }
+}
+
+/*!
+    Set the value of the specified option.
+
+    If the option does not exists, a new option will be added.
+
+    \param key is the name of the option
+    \param value is the value of the option
+*/
+void Config::set(const std::string &key, const std::string &value)
+{
+    if (hasOption(key)) {
+        getOption(key).value = value;
+    } else {
+        addOption(key, value);
+    }
+}
+
+/*!
+    Gets the value of the specified option attribute.
+
+    If the option or the attribute does not exists, an exception is thrown.
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \result The value of the specified attribute.
+*/
+std::string Config::getAttribute(const std::string &key, const std::string &name) const
+{
+    return getOption(key).attributes.at(name);
+}
+
+/*!
+    Gets the value of the specified option attribute.
+
+    If the option does not exists, an exception will be thrown. However, if
+    the attribute do not exists, the fallback walue will be returned
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \param fallback is the value that will be returned if the specified
+    attribute does not exist
+    \result The value of the specified attribute or the fallback value if
+    the options or the attribute does not exist.
+*/
+std::string Config::getAttribute(const std::string &key, const std::string &name, const std::string &fallback) const
+{
+    const Option &option = getOption(key);
+    if (option.attributes.count(name) > 0) {
+        return option.attributes.at(name);
+    }
+
+    return fallback;
+}
+
+/*!
+    Set the value of the specified option attribute.
+
+    If the option does not exists, an exception will be thrown. However,
+    if the attribute does not exists, a new attribute will be added.
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \param value is the value of the attribute
+*/
+void Config::setAttribute(const std::string &key, const std::string &name, const std::string &value)
+{
+    getOption(key).attributes[name] = value;
+}
+
+/*!
     Checks if the specified option exists.
 
     \param key is the name of the option
@@ -144,47 +268,91 @@ bool Config::hasOption(const std::string &key) const
 }
 
 /*!
-    Gets the specified option.
+    Add an option to the configuration storage.
 
-    If the option does not exists an exception is thrown.
+    If an option with the same key already exists, it will be overwritten.
 
     \param key is the name of the option
-    \result The specified option.
+    \param option is the option that will be added
 */
-std::string Config::get(const std::string &key) const
+void Config::addOption(const std::string &key, const Option &option)
 {
-    return m_options->at(key);
+    (*m_options)[key] = option;
 }
 
 /*!
-    Gets the specified option.
+    Add an option to the configuration storage.
 
-    If the option does not exists the fallback value is returned.
+    If an option with the same key already exists, it will be overwritten.
 
     \param key is the name of the option
-    \param fallback is the value that will be returned if the specified
-    options does not exist
-    \result The specified option or the fallback value if the specified
-    options does not exist.
+    \param option is the option that will be added
 */
-std::string Config::get(const std::string &key, const std::string &fallback) const
+void Config::addOption(const std::string &key, Option &&option)
 {
-    if (hasOption(key)) {
-        return get(key);
-    } else {
-        return fallback;
-    }
+    (*m_options)[key] = std::move(option);
 }
 
 /*!
-    Set the given option to the specified value
+    Add an option to the configuration storage.
+
+    If an option with the same key already exists, it will be overwritten.
 
     \param key is the name of the option
     \param value is the value of the option
 */
-void Config::set(const std::string &key, const std::string &value)
+void Config::addOption(const std::string &key, const std::string &value)
 {
-    (*m_options)[key] = value;
+    addOption(key, std::string(value), Attributes());
+}
+
+/*!
+    Add an option to the configuration storage.
+
+    If an option with the same key already exists, it will be overwritten.
+
+    \param key is the name of the option
+    \param value is the value of the option
+*/
+void Config::addOption(const std::string &key, std::string &&value)
+{
+    addOption(key, std::move(value), Attributes());
+}
+
+/*!
+    Add an option to the configuration storage.
+
+    If an option with the same key already exists, it will be overwritten.
+
+    \param key is the name of the option
+    \param value is the value of the option
+    \param attributes are the attributes of the option
+*/
+void Config::addOption(const std::string &key, const std::string &value, const Attributes &attributes)
+{
+    Option option;
+    option.value = value;
+    option.attributes = attributes;
+
+    addOption(key, std::move(option));
+}
+
+/*!
+    Add an option to the configuration storage.
+
+    If an option with the same key already exists, it will be overwritten.
+
+    \param key is the name of the option
+    \param value is the value of the option
+    \param attributes are the attributes of the option
+*/
+void Config::addOption(const std::string &key, std::string &&value, Attributes &&attributes)
+{
+    Option option;
+    option.value = std::move(value);
+    option.attributes = std::move(attributes);
+
+    addOption(key, std::move(option));
 }
 
 /*!
@@ -402,7 +570,23 @@ void Config::dump(std::ostream &out, int indentLevel) const
     out << indent << "Options..." << std::endl;
     if (getOptionCount() > 0) {
         for (const auto &optionEntry : getOptions()) {
-            out << indent << padding << entry.first << " = " << entry.second << std::endl;
+            const std::string &key = optionEntry.first;
+            const Option &option = optionEntry.second;
+
+            // Option value
+            out << indent << padding << key << " = " << option.value << std::endl;
+
+            // Option attributes
+            if (!option.attributes.empty()) {
+                for (const auto &attributeEntry : option.attributes) {
+                    const std::string &name = attributeEntry.first;
+                    const std::string &value = attributeEntry.second;
+
+                    out << indent << padding << padding << "Attribute: " << name << " = " << value << std::endl;
+                }
+            } else {
+                out << indent << padding << padding << "Option has not attributes." << std::endl;
+            }
         }
     } else {
         out << indent << padding << "No options." << std::endl;

--- a/src/IO/configuration_config.cpp
+++ b/src/IO/configuration_config.cpp
@@ -408,7 +408,7 @@ void Config::dump(std::ostream &out, int indentLevel) const
     out << std::endl;
     out << indent << "Options..." << std::endl;
     if (getOptionCount() > 0) {
-        for (auto &entry : getOptions()) {
+        for (const auto &optionEntry : getOptions()) {
             out << indent << padding << entry.first << " = " << entry.second << std::endl;
         }
     } else {
@@ -416,7 +416,7 @@ void Config::dump(std::ostream &out, int indentLevel) const
     }
 
     ++indentLevel;
-    for (auto &entry : getSections()) {
+    for (const auto &entry : getSections()) {
         out << std::endl;
         out << indent << padding << "::: Section " << entry.first << " :::" << std::endl;
         entry.second->dump(out, indentLevel);

--- a/src/IO/configuration_config.cpp
+++ b/src/IO/configuration_config.cpp
@@ -162,7 +162,7 @@ const Config::Option & Config::getOption(const std::string &key) const
     \param key is the name of the option
     \result The value of the specified option.
 */
-std::string Config::get(const std::string &key) const
+const std::string & Config::get(const std::string &key) const
 {
     return getOption(key).value;
 }
@@ -213,7 +213,7 @@ void Config::set(const std::string &key, const std::string &value)
     \param name is the name of the attribute
     \result The value of the specified attribute.
 */
-std::string Config::getAttribute(const std::string &key, const std::string &name) const
+const std::string & Config::getAttribute(const std::string &key, const std::string &name) const
 {
     return getOption(key).attributes.at(name);
 }

--- a/src/IO/configuration_config.hpp
+++ b/src/IO/configuration_config.hpp
@@ -48,7 +48,7 @@ public:
     Config & operator=(Config other);
     Config & operator=(Config &&other) = default;
 
-    virtual ~Config();
+    virtual ~Config() = default;
 
     void swap(Config &other);
 

--- a/src/IO/configuration_config.hpp
+++ b/src/IO/configuration_config.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace bitpit {
@@ -35,10 +36,18 @@ class Config
 {
 
 public:
+    typedef std::map<std::string, std::string> Attributes;
+
+    struct Option {
+        std::string value;
+        Attributes attributes;
+    };
+
+    typedef std::map<std::string, Option> Options;
+
     typedef Config Section;
     typedef std::vector<Section *> MultiSection;
     typedef std::vector<const Section *> ConstMultiSection;
-    typedef std::map<std::string, std::string> Options;
     typedef std::multimap<std::string, std::unique_ptr<Config>> Sections;
 
     Config(bool multiSections = false);
@@ -54,13 +63,26 @@ public:
 
     bool isMultiSectionsEnabled() const;
 
-    int getOptionCount() const;
-    Options & getOptions();
-    const Options & getOptions() const;
-    bool hasOption(const std::string &key) const;
     std::string get(const std::string &key) const;
     std::string get(const std::string &key, const std::string &fallback) const;
     void set(const std::string &key, const std::string &value);
+
+    std::string getAttribute(const std::string &key, const std::string &name) const;
+    std::string getAttribute(const std::string &key, const std::string &name, const std::string &fallback) const;
+    void setAttribute(const std::string &key, const std::string &name, const std::string &value);
+
+    int getOptionCount() const;
+    Options & getOptions();
+    const Options & getOptions() const;
+    Option & getOption(const std::string &key);
+    const Option & getOption(const std::string &key) const;
+    bool hasOption(const std::string &key) const;
+    void addOption(const std::string &key, const Option &option);
+    void addOption(const std::string &key, Option &&option);
+    void addOption(const std::string &key, const std::string &value);
+    void addOption(const std::string &key, std::string &&value);
+    void addOption(const std::string &key, const std::string &value, const Attributes &attributes);
+    void addOption(const std::string &key, std::string &&value, Attributes &&attributes);
     bool removeOption(const std::string &key);
 
     int getSectionCount() const;
@@ -90,6 +112,15 @@ public:
 
     template<typename T>
     void set(const std::string &key, const T &value);
+
+    template<typename T>
+    T getAttribute(const std::string &key, const std::string &name) const;
+
+    template<typename T>
+    T getAttribute(const std::string &key, const std::string &name, const T &fallback) const;
+
+    template<typename T>
+    void setAttribute(const std::string &key, const std::string &name, const T &value);
 
 protected:
     bool m_multiSections;

--- a/src/IO/configuration_config.hpp
+++ b/src/IO/configuration_config.hpp
@@ -63,11 +63,11 @@ public:
 
     bool isMultiSectionsEnabled() const;
 
-    std::string get(const std::string &key) const;
+    const std::string & get(const std::string &key) const;
     std::string get(const std::string &key, const std::string &fallback) const;
     void set(const std::string &key, const std::string &value);
 
-    std::string getAttribute(const std::string &key, const std::string &name) const;
+    const std::string & getAttribute(const std::string &key, const std::string &name) const;
     std::string getAttribute(const std::string &key, const std::string &name, const std::string &fallback) const;
     void setAttribute(const std::string &key, const std::string &name, const std::string &value);
 

--- a/src/IO/configuration_config.tpp
+++ b/src/IO/configuration_config.tpp
@@ -41,7 +41,7 @@ template<typename T>
 T Config::get(const std::string &key) const
 {
     T value;
-    if (std::istringstream(get(key)) >> value) {
+    if (std::istringstream(getOption(key).value) >> value) {
         return value;
     } else {
         throw std::runtime_error("Unable to convert the option \"" + key + "\"");
@@ -80,7 +80,72 @@ void Config::set(const std::string &key, const T &value)
 {
     std::ostringstream valueStream;
     if (valueStream << value) {
-        set(key, valueStream.str());
+        getOption(key).value = valueStream.str();
+    } else {
+        throw std::runtime_error("Unable to convert the option \"" + key + "\"");
+    }
+}
+
+/*!
+    Gets the value of the specified option attribute.
+
+    If the option or the attribute does not exists, an exception is thrown.
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \result The value of the specified attribute.
+*/
+template<typename T>
+T Config::getAttribute(const std::string &key, const std::string &name) const
+{
+    T value;
+    if (std::istringstream(getOption(key).attributes.at(name)) >> value) {
+        return value;
+    } else {
+        throw std::runtime_error("Unable to convert the option \"" + key + "\"");
+    }
+}
+
+/*!
+    Gets the value of the specified option attribute.
+
+    If the option does not exists, an exception will be thrown. However, if
+    the attribute do not exists, the fallback walue will be returned
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \param fallback is the value that will be returned if the specified
+    attribute does not exist
+    \result The value of the specified attribute or the fallback value if
+    the options or the attribute does not exist.
+*/
+template<typename T>
+T Config::getAttribute(const std::string &key, const std::string &name, const T &fallback) const
+{
+    const Option &option = getOption(key);
+    if (option.attributes.count(name) > 0) {
+        return getAttribute<T>(key);
+    }
+
+    return fallback;
+}
+
+/*!
+    Set the value of the specified option attribute.
+
+    If the option does not exists, an exception will be thrown. However,
+    if the attribute does not exists, a new attribute will be added.
+
+    \param key is the name of the option
+    \param name is the name of the attribute
+    \param value is the value of the attribute
+*/
+template<typename T>
+void Config::setAttribute(const std::string &key, const std::string &name, const T &value)
+{
+    std::ostringstream valueStream;
+    if (valueStream << value) {
+        getOption(key).attributes[name] = valueStream.str();
     } else {
         throw std::runtime_error("Unable to convert the option \"" + key + "\"");
     }

--- a/test/integration_tests/IO/data/configuration.xml
+++ b/test/integration_tests/IO/data/configuration.xml
@@ -2,18 +2,18 @@
 <bitpit version="1">
     <first>
         <color>blue</color>
-        <distance>11</distance>
+        <distance unit="km" type="offroad">11</distance>
         <exists>1</exists>
         <data>
-            <x>11.11</x>
+            <x min="0" max="100">11.11</x>
         </data>
     </first>
     <second>
         <color>red</color>
-        <distance>22</distance>
+        <distance unit="mi" type="urban">22</distance>
         <exists>0</exists>
         <data>
-            <y>22.22</y>
+            <y min="20" max="200">22.22</y>
         </data>
     </second>
 </bitpit>

--- a/test/integration_tests/IO/test_IO_00004.cpp
+++ b/test/integration_tests/IO/test_IO_00004.cpp
@@ -59,8 +59,8 @@ int subtest_001()
     std::cout << "Access configuration..." << std::endl;
     std::cout << "  - Section \"first\" has color..." << config::root["first"].get("color") << std::endl;
     std::cout << "  - Section \"second\" has color..." << config::root["second"].get("color") << std::endl;
-    std::cout << "  - Section \"first\" has distance..." << config::root.getSection("first").get("distance") << std::endl;
-    std::cout << "  - Section \"second\" has y data..." << config::root["second"]["data"].get("y") << std::endl;
+    std::cout << "  - Section \"first\" has distance..." << config::root.getSection("first").get("distance") << " " << config::root.getSection("first").getAttribute("distance", "unit") << std::endl;
+    std::cout << "  - Section \"second\" has y data..." << config::root["second"]["data"].get("y") << " " << config::root.getSection("second").getSection("data").getAttribute("y", "unit", "kg") << std::endl;
     std::cout << "  - Section \"first\" option count..." << config::root.getSection("first").getOptionCount() << std::endl;
     std::cout << "  - Section \"first\" sub-section count..." << config::root.getSection("first").getSectionCount() << std::endl;
 
@@ -68,10 +68,16 @@ int subtest_001()
     std::cout << "  - Section \"first\" has distance (int)..." << firstDistanceInt << std::endl;
 
     double firstDistanceDouble = config::root["first"].get<double>("distance");
-    std::cout << "  - Section \"first\" has distance (double)..." << firstDistanceDouble << std::endl;
+    std::cout << "  - Section \"first\" has distance (double)..." << firstDistanceDouble << " " << config::root.getSection("first").getOption("distance").attributes["unit"] << std::endl;
 
     double secondDataDouble = config::root["second"]["data"].get<double>("y");
-    std::cout << "  - Section \"section\" has y data (double)..." << secondDataDouble << std::endl;
+    std::cout << "  - Section \"section\" has y data (double)..." << secondDataDouble << " " << config::root["second"]["data"].getAttribute("y", "unit", "kg") << std::endl;
+
+    double secondMinDataDouble = config::root["second"]["data"].getAttribute<double>("y", "min");
+    std::cout << "  - Section \"section\" has y min value (double)..." << secondMinDataDouble << std::endl;
+
+    double secondMaxDataDouble = config::root["second"]["data"].getAttribute<double>("y", "max");
+    std::cout << "  - Section \"section\" has y max value (double)..." << secondMaxDataDouble << std::endl;
 
     bool firstExistsBool = config::root["first"].get<bool>("exists");
     std::cout << "  - Section \"first\" has distance..." << firstExistsBool << std::endl;
@@ -88,12 +94,16 @@ int subtest_001()
     config::root["second"].set("color", "orange");
 
     config::root["first"].set("distance", 111);
-    config::root["second"].set("distance", 222);
+    config::root["first"].setAttribute("distance", "unit", "mi");
+    config::root["second"].getOption("distance").value = "111";
+    config::root["second"].getOption("distance").attributes["unit"] = "km";
 
     config::root["first"].set("exists", true);
     config::root["second"].set("exists", true);
 
+    config::root["first"]["data"].setAttribute("x", "max", 150);
     config::root["first"]["data"].set("x", 111.111);
+    config::root["second"]["data"].setAttribute("y", "max", 250);
     config::root["second"]["data"].set("y", 222.222);
 
     // Dump the configuration


### PR DESCRIPTION
The class ConfigParser is now able to read/write XML attributes. XML attributes are designed to contain data related to a specific element, for example here:
```
<x min="0" max="100">11.11</x>
```
```min``` and ```max``` are two attributes of the element ```x```.

I tried to keep the interface for interacting with the attributes as close as possible to the existing interface to interact with options. Attribute can be get/set using the following functions (and their corresponding templates):
```    
    std::string getAttribute(const std::string &key, const std::string &name) const;
    std::string getAttribute(const std::string &key, const std::string &name, const std::string &fallback) const;
    const Attributes & getAttributes(const std::string &key) const;
    void setAttribute(const std::string &key, const std::string &name, const std::string &value);
```

Options stored in the configuration are now a struct and not a string anymore. This break compatibility with previous versions, however this is a problem only if the function "getOptions" was used. The struct stores both the option value an its attributes. There are new function to add/get Option objects:
```
    Option & getOption(const std::string &key);
    const Option & getOption(const std::string &key) const;
    void addOption(const std::string &key, const Option &option);
    void addOption(const std::string &key, Option &&option);
    void addOption(const std::string &key, const std::string &value);
    void addOption(const std::string &key, std::string &&value);
    void addOption(const std::string &key, const std::string &value, const Attributes &attributes);
    void addOption(const std::string &key, std::string &&value, Attributes &&attributes);
```