### PR TITLE
Add lapacke-based solveLU

### DIFF
--- a/src/LA/matrix_utilities.tpp
+++ b/src/LA/matrix_utilities.tpp
@@ -261,7 +261,6 @@ m = A.size();
 if (m == 0) { return; }
 n = A[0].size();
 if (n == 0) { return; }
-i--; j--;
 if ((i >= m) || (i < 0)) {
     return;
 }
@@ -275,9 +274,9 @@ if ((j >= n) || (j < 0)) {
 
 // Resize output variables
 B.resize(m-1);
-for (i = 0; i < m-1; ++i) {
-    B[i].resize(n-1, 0.0);
-} //next i
+for (int p = 0; p < m-1; ++p) {
+    B[p].resize(n-1, 0.0);
+} //next p
 
 // Extract complement
 for (l = 0; l < i; l++) {
@@ -332,7 +331,6 @@ int            l, k;
 // ========================================================================== //
 if (m == 0) { return; }
 if (n == 0) { return; }
-i--; j--;
 if ((i >= (long) m) || (i < 0)) {
     return;
 }
@@ -692,9 +690,6 @@ int                     m, n;
 T                       d = (T) 1.0e+18;
 std::vector< std::vector < T > >  C;
 
-// Counters
-int                     i;
-
 // ========================================================================== //
 // CHECK INPUT                                                                //
 // ========================================================================== //
@@ -722,9 +717,9 @@ else if (m == 3) {
 }
 else {
     d = (T) 0.0;
-    for (i = 0; i < m; i++) {
-        complement(1, i+1, A, C);
-        d += pow(-1.0, i+2) * A[0][i] * det(C);
+    for (int i = 0; i < m; i++) {
+        complement(0, i, A, C);
+        d += pow(-1.0, i) * A[0][i] * det(C);
     } //next i
 }
 
@@ -781,8 +776,8 @@ else if (m == 3) {
 else {
     std::array< std::array < double, m-1 >, m-1 >     C;
     for (i = 0; i < m; i++) {
-        complement(1, i+1, A, C);
-        d += pow(-1.0, i+2) * A[0][i] * det(C);
+        complement(0, i, A, C);
+        d += pow(-1.0, i) * A[0][i] * det(C);
     } //next i
 }
 

--- a/src/LA/system_solvers_small.hpp
+++ b/src/LA/system_solvers_small.hpp
@@ -57,6 +57,13 @@ namespace bitpit{
  */
 namespace linearalgebra{
 
+namespace constants{
+
+extern const int ROW_MAJOR;
+extern const int COL_MAJOR;
+
+}
+
 template <class T>
 void cramer(                                                                  // Solve linear system using Cramer's rule
     std::vector< std::vector < T > >            &,                            // (input) coeff. matrix
@@ -123,6 +130,20 @@ void solveLU(                                                                 //
     std::array<std::array<double, m>, m>        &,                            // (input) Input coeffs. matrix
     std::array<double, m>                       &,                            // (input) Source term
     std::array<double, m>                       &                             // (input/output) Solution
+);
+
+int solveLU(                                                                  // Solve linear system using Lapack DGESV
+    int                                          ,                            // (input) Matrix layout
+    std::vector<double>                         &,                            // (input) Input coeffs. matrix (linear)
+    std::vector<double>                         &                             // (input/output) Source term / Solution
+);
+
+int solveLU(                                                                  // Solve linear system using Lapack DGESV
+    int                                          ,                            // (input) Matrix layout
+    int                                          ,                            // (input) Matrix order
+    double                                      *,                            // (input) Pointer to input coeffs. matrix (linear)
+    double                                      *,                            // (input/output) Pointer to source term / solution
+    int                                         *                             // (output) Pivot indeces of the permutation matrix
 );
 
 }


### PR DESCRIPTION
Two commits are in this branch.
The first one introduces two new solveLU functions (one for solution only, the other one for solution and factorization). The number of rhs is limited to 1. Two extern constant have been introduced to set the matrix layout using lapack values and to avoid application to include lapacke headers.
The second commit fix the determinant evaluation by fixing the complement build and by calling the complement function with opportune arguments.