### PR TITLE
containers: fix PiercedVector move

### DIFF
--- a/src/containers/piercedKernel.cpp
+++ b/src/containers/piercedKernel.cpp
@@ -33,12 +33,4 @@ namespace bitpit {
 * \brief Base class for the pierced kernel.
 */
 
-/**
-* Constructs an empty base pierced kernel.
-*/
-BasePiercedKernel::BasePiercedKernel()
-    : PiercedSyncMaster()
-{
-}
-
 }

--- a/src/containers/piercedKernel.hpp
+++ b/src/containers/piercedKernel.hpp
@@ -49,7 +49,7 @@ public:
     virtual ~BasePiercedKernel() = default;
 
 protected:
-    BasePiercedKernel();
+    BasePiercedKernel() = default;
 
 };
 

--- a/src/containers/piercedKernel.hpp
+++ b/src/containers/piercedKernel.hpp
@@ -342,6 +342,8 @@ public:
     // Contructors
     PiercedKernel();
     PiercedKernel(std::size_t n);
+    PiercedKernel(const PiercedKernel &other) = default;
+    PiercedKernel(PiercedKernel &&other) = default;
 
     // Destructor
     ~PiercedKernel() override;

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -342,9 +342,8 @@ public:
     PiercedStorage(std::size_t nFields);
     PiercedStorage(std::size_t nFields, const PiercedKernel<id_t> *kernel);
     PiercedStorage(std::size_t nFields, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorage(const PiercedStorage<value_t, id_t> &other, const PiercedKernel<id_t> *kernel);
+    PiercedStorage(const PiercedStorage<value_t, id_t> &other, const PiercedKernel<id_t> *kernel = nullptr);
     PiercedStorage(const PiercedStorage<value_t, id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorage(const PiercedStorage<value_t, id_t> &other);
     PiercedStorage(PiercedStorage<value_t, id_t> &&other);
 
     PiercedStorage & operator=(const PiercedStorage &other);

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -115,9 +115,8 @@ protected:
     PiercedStorageSyncSlave();
     PiercedStorageSyncSlave(const PiercedKernel<id_t> *kernel);
     PiercedStorageSyncSlave(PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, const PiercedKernel<id_t> *kernel);
+    PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, const PiercedKernel<id_t> *kernel = nullptr);
     PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other);
     PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other);
 
     // Methods for synchronizing the storage

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -117,7 +117,8 @@ protected:
     PiercedStorageSyncSlave(PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, const PiercedKernel<id_t> *kernel = nullptr);
     PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other);
+    PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other, const PiercedKernel<id_t> *kernel = nullptr);
+    PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
 
     // Methods for synchronizing the storage
     virtual void _postSetStaticKernel();
@@ -344,7 +345,8 @@ public:
     PiercedStorage(std::size_t nFields, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     PiercedStorage(const PiercedStorage<value_t, id_t> &other, const PiercedKernel<id_t> *kernel = nullptr);
     PiercedStorage(const PiercedStorage<value_t, id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
-    PiercedStorage(PiercedStorage<value_t, id_t> &&other);
+    PiercedStorage(PiercedStorage<value_t, id_t> &&other, const PiercedKernel<id_t> *kernel = nullptr);
+    PiercedStorage(PiercedStorage<value_t, id_t> &&other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
 
     PiercedStorage & operator=(const PiercedStorage &other);
     PiercedStorage & operator=(PiercedStorage &&other);

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -485,7 +485,8 @@ PiercedStorage<value_t, id_t>::PiercedStorage(std::size_t nFields, PiercedKernel
 */
 template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t> &other, const PiercedKernel<id_t> *kernel)
-    : PiercedStorageSyncSlave<id_t>(other, kernel), m_nFields(other.m_nFields), m_fields(other.m_fields)
+    : PiercedStorageSyncSlave<id_t>(other, kernel),
+      m_nFields(other.m_nFields), m_fields(other.m_fields)
 {
     // Base class constructor cannot call virtual functions
     if (this->getKernel()) {
@@ -503,7 +504,8 @@ PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t
 */
 template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode)
-    : PiercedStorageSyncSlave<id_t>(other, kernel, syncMode), m_nFields(other.m_nFields), m_fields(other.m_fields)
+    : PiercedStorageSyncSlave<id_t>(other, kernel, syncMode),
+      m_nFields(other.m_nFields), m_fields(other.m_fields)
 {
     // Base class constructor cannot call virtual functions
     if (this->getKernel()) {

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -210,7 +210,7 @@ void PiercedStorageSyncSlave<id_t>::setStaticKernel(const PiercedKernel<id_t> *k
     m_kernel       = nullptr;
     m_const_kernel = kernel;
 
-    // Action to be performed afetr setting the kernel
+    // Action to be performed after setting the kernel
     _postSetStaticKernel();
 }
 
@@ -246,7 +246,7 @@ void PiercedStorageSyncSlave<id_t>::setDynamicKernel(PiercedKernel<id_t> *kernel
     m_kernel = kernel;
     m_kernel->registerSlave(this, syncMode);
 
-    // Action to be performed afetr setting the kernel
+    // Action to be performed after setting the kernel
     _postSetDynamicKernel();
 }
 
@@ -274,7 +274,7 @@ void PiercedStorageSyncSlave<id_t>::unsetKernel(bool release)
     // Detach the kernel
     detachKernel();
 
-    // Action to be performed afetr unsetting the kernel
+    // Action to be performed after unsetting the kernel
     _postUnsetKernel(release);
 }
 
@@ -406,7 +406,7 @@ template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(std::size_t nFields, const PiercedKernel<id_t> *kernel)
     : PiercedStorageSyncSlave<id_t>(kernel), m_nFields(nFields)
 {
-    // Base class construcotr cannot call virtual functions
+    // Base class constructor cannot call virtual functions
     _postSetStaticKernel();
 }
 
@@ -421,7 +421,7 @@ template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(std::size_t nFields, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode)
     : PiercedStorageSyncSlave<id_t>(kernel, syncMode), m_nFields(nFields)
 {
-    // Base class construcotr cannot call virtual functions
+    // Base class constructor cannot call virtual functions
     _postSetStaticKernel();
     _postSetDynamicKernel();
 }
@@ -437,7 +437,7 @@ template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t> &other, const PiercedKernel<id_t> *kernel)
     : PiercedStorageSyncSlave<id_t>(other, kernel), m_nFields(other.m_nFields), m_fields(other.m_fields)
 {
-    // Base class construcotr cannot call virtual functions
+    // Base class constructor cannot call virtual functions
     if (this->getKernel()) {
         _postSetStaticKernel();
     }
@@ -455,7 +455,7 @@ template<typename value_t, typename id_t>
 PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode)
     : PiercedStorageSyncSlave<id_t>(other, kernel, syncMode), m_nFields(other.m_nFields), m_fields(other.m_fields)
 {
-    // Base class construcotr cannot call virtual functions
+    // Base class constructor cannot call virtual functions
     if (this->getKernel()) {
         _postSetStaticKernel();
 
@@ -479,7 +479,7 @@ PiercedStorage<value_t, id_t>::PiercedStorage(PiercedStorage<value_t, id_t> &&ot
     : PiercedStorageSyncSlave<id_t>(std::move(other)),
       m_nFields(std::move(other.m_nFields)), m_fields(std::move(other.m_fields))
 {
-    // Base class construcotr cannot call virtual functions
+    // Base class constructor cannot call virtual functions
     if (this->getKernel()) {
         _postSetStaticKernel();
 

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -491,18 +491,6 @@ PiercedStorage<value_t, id_t>::PiercedStorage(PiercedStorage<value_t, id_t> &&ot
 }
 
 /**
-* Copy constructor.
-*
-* \param other is another container of the same type (i.e., instantiated with
-* the same template parameters) whose content is copied in this container
-*/
-template<typename value_t, typename id_t>
-PiercedStorage<value_t, id_t>::PiercedStorage(const PiercedStorage<value_t, id_t> &other)
-    : PiercedStorage<value_t, id_t>(other, nullptr)
-{
-}
-
-/**
 * Copy assignment operator.
 *
 * \param other is another container of the same type (i.e., instantiated with

--- a/src/containers/piercedVector.tpp
+++ b/src/containers/piercedVector.tpp
@@ -84,7 +84,7 @@ PiercedVector<value_t, id_t>::PiercedVector(PiercedVector<value_t, id_t> &&other
     : PiercedVectorKernel<id_t>(std::move(other)),
       PiercedVectorStorage<value_t, id_t>(std::move(other), this, other.getSyncMode())
 {
-    // Since we have swapped the kernel, the list of registered slaves contains
+    // Since we have moved the kernel, the list of registered slaves contains
     // also the internal storage of other vector. We need to unregister that
     // storage from the kernel.
     this->unregisterSlave(&other);

--- a/src/containers/piercedVectorStorage.cpp
+++ b/src/containers/piercedVectorStorage.cpp
@@ -33,11 +33,4 @@ namespace bitpit {
 * \brief Base class for pierced vector kernels.
 */
 
-/**
-* Constructs an empty base pierced vector storage.
-*/
-BasePiercedVectorStorage::BasePiercedVectorStorage()
-{
-}
-
 }

--- a/src/containers/piercedVectorStorage.hpp
+++ b/src/containers/piercedVectorStorage.hpp
@@ -43,7 +43,7 @@ public:
     virtual ~BasePiercedVectorStorage() = default;
 
 protected:
-    BasePiercedVectorStorage();
+    BasePiercedVectorStorage() = default;
 
 };
 

--- a/test/integration_tests/containers/CMakeLists.txt
+++ b/test/integration_tests/containers/CMakeLists.txt
@@ -32,6 +32,7 @@ get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 set(TESTS "")
 list(APPEND TESTS "test_containers_00001")
 list(APPEND TESTS "test_containers_00002")
+list(APPEND TESTS "test_containers_00003")
 
 # Test extra libraries
 set(TEST_EXTRA_LIBRARIES "")

--- a/test/integration_tests/containers/test_containers_00001.cpp
+++ b/test/integration_tests/containers/test_containers_00001.cpp
@@ -555,6 +555,7 @@ int main(int argc, char *argv[])
 		}
 	} catch (const std::exception &exception) {
 		std::cout << exception.what();
+		exit(1);
 	}
 
 #if BITPIT_ENABLE_MPI==1

--- a/test/integration_tests/containers/test_containers_00002.cpp
+++ b/test/integration_tests/containers/test_containers_00002.cpp
@@ -456,6 +456,7 @@ int main(int argc, char *argv[])
 		}
 	} catch (const std::exception &exception) {
 		std::cout << exception.what();
+		exit(1);
 	}
 
 #if BITPIT_ENABLE_MPI==1

--- a/test/integration_tests/containers/test_containers_00003.cpp
+++ b/test/integration_tests/containers/test_containers_00003.cpp
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include "bitpit_containers.hpp"
+
+#if BITPIT_ENABLE_MPI==1
+#include <mpi.h>
+#endif
+
+#include <stdexcept>
+
+using namespace bitpit;
+
+
+/*!
+* Subtest 001
+*
+* Testing move constructor capabilities.
+*/
+int subtest_001()
+{
+    std::cout << std::endl;
+    std::cout << "Testing move constructor capabilities" << std::endl;
+
+    // Create container
+    std::cout << "Creating container..." << std::endl;
+
+    PiercedVector<double> containerExpected;
+    containerExpected.insert(21, 12.0);
+    containerExpected.insert(22, 13.0);
+    containerExpected.insert(23, 14.0);
+
+    std::cout << "  Size of container ....... " << containerExpected.size() << std::endl;
+
+    // Create a new container moving data from container with move constructor
+    std::cout << "Moving container..." << std::endl;
+
+    PiercedVector<double> container(containerExpected);
+    PiercedVector<double> movedContainer(std::move(container));
+
+    std::cout << "  Size of original container ....... " << container.size() << std::endl;
+    std::cout << "  Size of moved container .......... " << movedContainer.size() << std::endl;
+    if (containerExpected.size() != movedContainer.size()) {
+        throw std::runtime_error("Contents of moved container doesn't match expected values");
+    }
+
+    for (auto itr = movedContainer.begin(), end = movedContainer.end(); itr != end; ++itr) {
+        long id = itr.getId();
+        if (containerExpected[id] != *itr) {
+            throw std::runtime_error("Contents of moved container doesn't match expected values");
+        }
+    }
+
+    std::cout << "Test completed." << std::endl;
+
+    return 0;
+}
+
+/*!
+* Subtest 002
+*
+* Testing move assignment operator capabilities.
+*/
+int subtest_002()
+{
+    std::cout << std::endl;
+    std::cout << "Testing move assignment operator capabilities" << std::endl;
+
+    // Create source containers
+    std::cout << "Creating container..." << std::endl;
+
+    PiercedVector<double> containerExpected;
+    containerExpected.insert(21, 12.0);
+    containerExpected.insert(22, 13.0);
+    containerExpected.insert(23, 14.0);
+
+    std::cout << "  Size of container ....... " << containerExpected.size() << std::endl;
+
+    // Create a new container moving data from container with move assignment
+    std::cout << "Moving container..." << std::endl;
+
+    PiercedVector<double> container(containerExpected);
+    PiercedVector<double> movedContainer;
+    movedContainer = std::move(container);
+
+    std::cout << "  Size of original container ....... " << container.size() << std::endl;
+    std::cout << "  Size of moved container .......... " << movedContainer.size()<< std::endl;
+
+    if (containerExpected.size() != movedContainer.size()) {
+        throw std::runtime_error("Contents of moved container doesn't match expected values");
+    }
+
+    for (auto itr = movedContainer.begin(), end = movedContainer.end(); itr != end; ++itr) {
+        long id = itr.getId();
+        if (containerExpected[id] != *itr) {
+            throw std::runtime_error("Contents of moved container doesn't match expected values");
+        }
+    }
+
+    std::cout << "Test completed." << std::endl;
+
+    return 0;
+}
+
+/*!
+* Main program.
+*/
+int main(int argc, char *argv[])
+{
+#if BITPIT_ENABLE_MPI==1
+    MPI_Init(&argc,&argv);
+#else
+    BITPIT_UNUSED(argc);
+    BITPIT_UNUSED(argv);
+#endif
+
+    // Run the subtests
+    std::cout << "Testing PiercedVector move constructor/operator" << std::endl;
+
+    int status;
+    try {
+        status = subtest_001();
+        if (status != 0) {
+            return status;
+        }
+
+        status = subtest_002();
+        if (status != 0) {
+            return status;
+        }
+    } catch (const std::exception &exception) {
+        std::cout << exception.what();
+        exit(1);
+    }
+
+#if BITPIT_ENABLE_MPI==1
+    MPI_Finalize();
+#endif
+}


### PR DESCRIPTION
Some contents of the PiercedVector were copied instead of being moved.