### PR TITLE
cmake: bump pointcloud and lineunstructured cmake minimum required version to 3.10

### DIFF
--- a/src/lineunstructured/CMakeLists.txt
+++ b/src/lineunstructured/CMakeLists.txt
@@ -23,7 +23,7 @@
 #---------------------------------------------------------------------------*/
 
 # CMake settings
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 # Name of the current module
 get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)

--- a/src/pointcloud/CMakeLists.txt
+++ b/src/pointcloud/CMakeLists.txt
@@ -23,7 +23,7 @@
 #---------------------------------------------------------------------------*/
 
 # CMake settings
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 # Name of the current module
 get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)


### PR DESCRIPTION
CMake minimum required version for the pointcloud and lineunstructured module was erroneously set to 2.8. Minimum required version should be 3.10.