### PR TITLE
patchkernel: set alteration flags only when needed

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2940,7 +2940,15 @@ PatchKernel::CellIterator PatchKernel::_addInternalCell(ElementType type, std::u
 */
 void PatchKernel::setAddedCellAlterationFlags(long id)
 {
-	setCellAlterationFlags(id, FLAG_ADJACENCIES_DIRTY | FLAG_INTERFACES_DIRTY);
+	AlterationFlags flags = FLAG_NONE;
+	if (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE) {
+		flags |= FLAG_ADJACENCIES_DIRTY;
+	}
+	if (getInterfacesBuildStrategy() != INTERFACES_NONE) {
+		flags |= FLAG_INTERFACES_DIRTY;
+	}
+
+	setCellAlterationFlags(id, flags);
 }
 
 #if BITPIT_ENABLE_MPI==0
@@ -3012,7 +3020,15 @@ void PatchKernel::_restoreInternalCell(const CellIterator &iterator, ElementType
 */
 void PatchKernel::setRestoredCellAlterationFlags(long id)
 {
-	setCellAlterationFlags(id, FLAG_ADJACENCIES_DIRTY | FLAG_INTERFACES_DIRTY);
+	AlterationFlags flags = FLAG_NONE;
+	if (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE) {
+		flags |= FLAG_ADJACENCIES_DIRTY;
+	}
+	if (getInterfacesBuildStrategy() != INTERFACES_NONE) {
+		flags |= FLAG_INTERFACES_DIRTY;
+	}
+
+	setCellAlterationFlags(id, flags);
 }
 
 /*!
@@ -3137,7 +3153,15 @@ void PatchKernel::setDeletedCellAlterationFlags(long id)
 	for (int k = 0; k < nCellAdjacencies; ++k) {
 		long adjacencyId = cellAdjacencies[k];
 		if (!testCellAlterationFlags(adjacencyId, FLAG_DELETED)) {
-			setCellAlterationFlags(adjacencyId, FLAG_DANGLING | FLAG_ADJACENCIES_DIRTY | FLAG_INTERFACES_DIRTY);
+			AlterationFlags flags = FLAG_DANGLING;
+			if (getAdjacenciesBuildStrategy() != ADJACENCIES_NONE) {
+				flags |= FLAG_ADJACENCIES_DIRTY;
+			}
+			if (getInterfacesBuildStrategy() != INTERFACES_NONE) {
+				flags |= FLAG_INTERFACES_DIRTY;
+			}
+
+			setCellAlterationFlags(adjacencyId, flags);
 		}
 	}
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -3131,7 +3131,7 @@ void PatchKernel::setDeletedCellAlterationFlags(long id)
 	// Set the alteration flags of the cell
 	resetCellAlterationFlags(id, FLAG_DELETED);
 
-	// Set the alteration flags of the adjacencies
+	// Set the alteration flags of the adjacent cells
 	const int nCellAdjacencies = cell.getAdjacencyCount();
 	const long *cellAdjacencies = cell.getAdjacencies();
 	for (int k = 0; k < nCellAdjacencies; ++k) {

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -881,8 +881,13 @@ void PatchKernel::finalizeAlterations(bool squeezeStorage)
 #endif
 
 	// Clear alteration flags
-	m_alteredCells.clear();
-	m_alteredInterfaces.clear();
+	if (squeezeStorage) {
+		AlterationFlagsStorage().swap(m_alteredCells);
+		AlterationFlagsStorage().swap(m_alteredInterfaces);
+	} else {
+		m_alteredCells.clear();
+		m_alteredInterfaces.clear();
+	}
 
 	// Synchronize storage
 	m_cells.sync();

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2786,19 +2786,21 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
     // We may received cells that connect to the existing mesh through one
     // of the faces that are now borders. Marking those border interfaces as
     // dangling allows to delete them and create new internal interfaces.
-    CellConstIterator endItr = ghostCellConstEnd();
-    for (CellConstIterator itr = ghostCellConstBegin(); itr != endItr; ++itr) {
-        const Cell &cell = *itr;
-        const long *interfaces = cell.getInterfaces();
-        const int nCellInterfaces = cell.getInterfaceCount();
+    if (getInterfacesBuildStrategy() != INTERFACES_NONE) {
+        CellConstIterator endItr = ghostCellConstEnd();
+        for (CellConstIterator itr = ghostCellConstBegin(); itr != endItr; ++itr) {
+            const Cell &cell = *itr;
+            const long *interfaces = cell.getInterfaces();
+            const int nCellInterfaces = cell.getInterfaceCount();
 
-        setCellAlterationFlags(cell.getId(), FLAG_INTERFACES_DIRTY);
+            setCellAlterationFlags(cell.getId(), FLAG_INTERFACES_DIRTY);
 
-        for (int k = 0; k < nCellInterfaces; ++k) {
-            long interfaceId = interfaces[k];
-            const Interface &interface = getInterface(interfaceId);
-            if (interface.isBorder()) {
-                setInterfaceAlterationFlags(interfaceId, FLAG_DANGLING);
+            for (int k = 0; k < nCellInterfaces; ++k) {
+                long interfaceId = interfaces[k];
+                const Interface &interface = getInterface(interfaceId);
+                if (interface.isBorder()) {
+                    setInterfaceAlterationFlags(interfaceId, FLAG_DANGLING);
+                }
             }
         }
     }
@@ -3179,7 +3181,9 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
             }
 
             // The interfaces of the cell need to be updated
-            setCellAlterationFlags(cellId, FLAG_INTERFACES_DIRTY);
+            if (getInterfacesBuildStrategy() != INTERFACES_NONE) {
+                setCellAlterationFlags(cellId, FLAG_INTERFACES_DIRTY);
+            }
 
             // Add the cell to the cell map
             if (cellOriginalId != cellId) {


### PR DESCRIPTION
If no adjacencies/interfaces are build, there is no need to set the associated alteration flag. Since alteration flags are stored in an unordered_map, this will improve PatchKernel memory usage when no adjacencies/interfaces are needed.