### PR TITLE
patchkernel: make updateOwner method of PatchKernel public

### DIFF
--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -686,6 +686,7 @@ public:
 
 	bool isDistributed() const;
 	int getOwner() const;
+    void updateOwner();
 
 	void setHaloSize(std::size_t haloSize);
 	std::size_t getHaloSize() const;
@@ -1013,8 +1014,6 @@ private:
 
 	void updateGhostVertexOwners();
 	void updateGhostVertexExchangeInfo();
-
-	void updateOwner();
 
 	std::unordered_map<long, int> evaluateExchangeVertexOwners() const;
 #endif


### PR DESCRIPTION
The method is useful to update the ownership of a parellel patch outside a complete update of the patch.

For example when filling a sub-selection of a _parallel_ mesh the selected ghost cells have to be connected to the local cells on each partition, for this a deletion of non-connected ghost cell must be performed; in order to carry out this identification/deletion procedure the adjacencies must be computed; when your starting mesh is completely owned by a single processor (_parallel_ but not _distributed_) the ghosts cleaning procedure is no needed and this allows to avoid the allocation of the adjacencies (lower memory usage, shorter execution time). 

The call to the method _updateOwner_ updates the (unitialized) owner information and a subsequent call to _isDistributed_ function gives the correct information. 

Using them during a patch filling method avoids to reimplement the same code in an external application.

