### PR TITLE
patchkernel: allow evaluating patch owner also when patch is dirty

### DIFF
--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -684,8 +684,8 @@ public:
 	int getRank() const;
 	int getProcessorCount() const;
 
-	bool isDistributed() const;
-	int getOwner() const;
+	bool isDistributed(bool allowDirty = false) const;
+	int getOwner(bool allowDirty = false) const;
 
 	void setHaloSize(std::size_t haloSize);
 	std::size_t getHaloSize() const;
@@ -1015,6 +1015,7 @@ private:
 	void updateGhostVertexExchangeInfo();
 
 	void updateOwner();
+	int evalOwner() const;
 
 	std::unordered_map<long, int> evaluateExchangeVertexOwners() const;
 #endif


### PR DESCRIPTION
The functions isDistributed and getOwner can now be called also when the patch is not up-to-date (the argument allowDirty should be set to true). If dirty patches are allowed and the patch is actually dirty, the functions will evaluate the owner on-the-fly. Otherwise the functions will use the owner evaluated during the last update. In any case, if dirt patches are allowed, the function is a collective function and needs to be called by all processes (otherwise a deadlock will occur).