### PR TITLE
patchkernel: reduce memory usage of Skd-Tree cache

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -73,24 +73,10 @@ void SkdPatchInfo::buildCache(const PatchKernel::CellConstRange &cellRange)
     for (auto itr = cellRange.cbegin(); itr != cellRange.cend(); ++itr) {
         std::size_t rawCellId = itr.getRawIndex();
 
-        // Cell info
-        const Cell &cell = *itr;
-        ConstProxyVector<long> cellConnect = cell.getVertexIds();
-        int nCellVertices = cellConnect.size();
-
         // Bounding box
-        std::array<double, 3> &cellBoxMin = m_cellBoxes->rawAt(rawCellId, 0);
-        std::array<double, 3> &cellBoxMax = m_cellBoxes->rawAt(rawCellId, 1);
-
-        cellBoxMin = m_patch->getVertexCoords(cellConnect[0]);
-        cellBoxMax = cellBoxMin;
-        for (int i = 1; i < nCellVertices; ++i) {
-            const std::array<double, 3> &coords = m_patch->getVertexCoords(cellConnect[i]);
-            for (int d = 0; d < 3; ++d) {
-                cellBoxMin[d] = std::min(coords[d], cellBoxMin[d]);
-                cellBoxMax[d] = std::max(coords[d], cellBoxMax[d]);
-            }
-        }
+        std::array<double, 3> *cellBoxMin = m_cellBoxes->rawData(rawCellId, 0);
+        std::array<double, 3> *cellBoxMax = m_cellBoxes->rawData(rawCellId, 1);
+        m_patch->evalElementBoundingBox(*itr, cellBoxMin, cellBoxMax);
     }
 }
 

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -44,12 +44,13 @@ public:
     const std::vector<std::size_t> & getCellRawIds() const;
     std::size_t getCellRawId(std::size_t n) const;
 
-    const std::array<double, 3> & getCachedBoxMin(std::size_t rawId) const;
-    const std::array<double, 3> & getCachedBoxMax(std::size_t rawId) const;
+    const std::array<std::array<double, 3>, 2> & getCachedBox(std::size_t rawId) const;
+
     std::array<double, 3> evalCachedBoxMean(std::size_t rawId) const;
+    double evalCachedBoxMean(std::size_t rawId, int direction) const;
 
 protected:
-    typedef PiercedStorage<std::array<double, 3>, long> BoxCache;
+    typedef PiercedStorage<std::array<std::array<double, 3>, 2>, long> BoxCache;
 
     SkdPatchInfo(const PatchKernel *patch, const std::vector<std::size_t> *cellRawIds);
 
@@ -113,6 +114,7 @@ public:
     const SkdBox & getBoundingBox() const;
 
     std::array<double,3> evalBoxWeightedMean() const;
+    double evalBoxWeightedMean(int direction) const;
 
     bool isLeaf() const;
     bool hasChild(ChildLocation child) const;

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -44,14 +44,11 @@ public:
     const std::vector<std::size_t> & getCellRawIds() const;
     std::size_t getCellRawId(std::size_t n) const;
 
-    const std::array<double, 3> & getCachedCentroid(std::size_t rawId) const;
-
     const std::array<double, 3> & getCachedBoxMin(std::size_t rawId) const;
     const std::array<double, 3> & getCachedBoxMax(std::size_t rawId) const;
     std::array<double, 3> evalCachedBoxMean(std::size_t rawId) const;
 
 protected:
-    typedef PiercedStorage<std::array<double, 3>, long> CentroidCache;
     typedef PiercedStorage<std::array<double, 3>, long> BoxCache;
 
     SkdPatchInfo(const PatchKernel *patch, const std::vector<std::size_t> *cellRawIds);
@@ -59,7 +56,6 @@ protected:
     const PatchKernel *m_patch;
     const std::vector<std::size_t> *m_cellRawIds;
 
-    std::unique_ptr<CentroidCache> m_cellCentroids;
     std::unique_ptr<BoxCache> m_cellBoxes;
 
 };


### PR DESCRIPTION
Cell centroids were only used to detect element ordering. For this purpose, the centroid of the element's bounding box can be used.

In order to recover the performances lost due to the computation of the cell bounding box centroid, I've also optimized the generation of the Skd-Tree. The splitting between left and right elements can be done evaluating only the position of the element along the direction of the splitting rather than evaluating the whole bounding box of the element.