### PR TITLE
patchkernel: allow to pass a generic container to the functions that delete cells/vertices/interfaces

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2005,58 +2005,6 @@ bool PatchKernel::deleteVertex(long id)
 }
 
 /*!
-	Deletes a list of vertices.
-
-	\param ids are the ids of the vertices to be deleted
-*/
-bool PatchKernel::deleteVertices(const std::vector<long> &ids)
-{
-	if (!isExpert()) {
-		return false;
-	}
-
-	// Deleting the last vertex requires some additional work. If the ids
-	// of vertices to be deleted contain the last vertex, that vertex is
-	// deleted after deleting all other vertices. In this way we make sure
-	// to delete the last vertex just once (after deleting the last vertex,
-	// another vertex becomes the last one and that vertex may be on the
-	// deletion list as well, and on and so forth). The same applies for
-	// the first ghost.
-	bool deleteLastInternalVertex = false;
-#if BITPIT_ENABLE_MPI==1
-	bool deleteFirstGhostVertex = false;
-#endif
-	std::vector<long>::const_iterator end = ids.cend();
-	for (std::vector<long>::const_iterator i = ids.cbegin(); i != end; ++i) {
-		long vertexId = *i;
-		if (vertexId == m_lastInternalVertexId) {
-			deleteLastInternalVertex = true;
-			continue;
-		}
-#if BITPIT_ENABLE_MPI==1
-		else if (vertexId == m_firstGhostVertexId) {
-			deleteFirstGhostVertex = true;
-			continue;
-		}
-#endif
-
-		deleteVertex(vertexId);
-	}
-
-	if (deleteLastInternalVertex) {
-		deleteVertex(m_lastInternalVertexId);
-	}
-
-#if BITPIT_ENABLE_MPI==1
-	if (deleteFirstGhostVertex) {
-		deleteVertex(m_firstGhostVertexId);
-	}
-#endif
-
-	return true;
-}
-
-/*!
 	Internal function to delete an internal vertex.
 
 	\param id is the id of the vertex
@@ -3032,58 +2980,6 @@ bool PatchKernel::deleteCell(long id)
 	}
 #else
 	_deleteInternalCell(id);
-#endif
-
-	return true;
-}
-
-/*!
-	Deletes a list of cells.
-
-	\param ids are the ids of the cells to be deleted
- */
-bool PatchKernel::deleteCells(const std::vector<long> &ids)
-{
-	if (!isExpert()) {
-		return false;
-	}
-
-	// Deleteing the last internal cell requires some additional work. If the
-	// ids of cells to be deleted contains the last internal cell, we delete
-	// that cell ater deleting all other cells. In this way we make sure to
-	// deleting the last internal cells just once (after deleting the last
-	// internal, another cells becomes the last one and  that cells may be
-	// on the deletion list, and on and so forth). The same applies for the
-	// first ghost.
-	bool deleteLastInternalCell = false;
-#if BITPIT_ENABLE_MPI==1
-	bool deleteFirstGhostCell = false;
-#endif
-	std::vector<long>::const_iterator end = ids.cend();
-	for (std::vector<long>::const_iterator i = ids.cbegin(); i != end; ++i) {
-		long cellId = *i;
-		if (cellId == m_lastInternalCellId) {
-			deleteLastInternalCell = true;
-			continue;
-		}
-#if BITPIT_ENABLE_MPI==1
-		else if (cellId == m_firstGhostCellId) {
-			deleteFirstGhostCell = true;
-			continue;
-		}
-#endif
-
-		deleteCell(cellId);
-	}
-
-	if (deleteLastInternalCell) {
-		deleteCell(m_lastInternalCellId);
-	}
-
-#if BITPIT_ENABLE_MPI==1
-	if (deleteFirstGhostCell) {
-		deleteCell(m_firstGhostCellId);
-	}
 #endif
 
 	return true;
@@ -4541,49 +4437,6 @@ void PatchKernel::_deleteInterface(long id)
 	if (m_interfaceIdGenerator) {
 		m_interfaceIdGenerator->trash(id);
 	}
-}
-
-/*!
-	Deletes a list of interfaces.
-
-	\param ids are the ids of the interfaces to be deleted
-*/
-bool PatchKernel::deleteInterfaces(const std::vector<long> &ids)
-{
-	if (!isExpert()) {
-		return false;
-	}
-
-	// Deleting the last interface requires some additional work. If the ids
-	// of interfaces to be deleted contain the last interface, that interface
-	// is deleted after deleting all other interfaces. In this way we make
-	// sure to delete the last interface just once (after deleting the last
-	// interface, another interface becomes the last one and that interface
-	// may be on the deletion list as well, and on and so forth).
-	std::size_t lastId;
-	if (!m_interfaces.empty()) {
-		lastId = m_interfaces.back().getId();
-	} else {
-		lastId = Interface::NULL_ID;
-	}
-
-	bool deleteLast = false;
-	std::vector<long>::const_iterator end = ids.cend();
-	for (std::vector<long>::const_iterator i = ids.cbegin(); i != end; ++i) {
-		std::size_t interfaceId = *i;
-		if (interfaceId == lastId) {
-			deleteLast = true;
-			continue;
-		}
-
-		deleteInterface(interfaceId);
-	}
-
-	if (deleteLast) {
-		deleteInterface(lastId);
-	}
-
-	return true;
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -504,7 +504,8 @@ public:
 	CellIterator addCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank, long id = Element::NULL_ID);
 #endif
 	bool deleteCell(long id);
-	bool deleteCells(const std::vector<long> &ids);
+	template<typename IdStorage>
+	bool deleteCells(const IdStorage &ids);
 #if BITPIT_ENABLE_MPI==1
 	CellIterator ghostCell2InternalCell(long id);
 	CellIterator internalCell2GhostCell(long id, int ownerRank);
@@ -586,7 +587,8 @@ public:
 	InterfaceIterator addInterface(ElementType type, const std::vector<long> &connectivity, long id = Element::NULL_ID);
 	InterfaceIterator addInterface(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id = Element::NULL_ID);
 	bool deleteInterface(long id);
-	bool deleteInterfaces(const std::vector<long> &ids);
+	template<typename IdStorage>
+	bool deleteInterfaces(const IdStorage &ids);
 	long countFreeInterfaces() const;
 	long countOrphanInterfaces() const;
 	std::vector<long> findOrphanInterfaces() const;
@@ -799,7 +801,8 @@ protected:
 #endif
 
 	bool deleteVertex(long id);
-	bool deleteVertices(const std::vector<long> &ids);
+	template<typename IdStorage>
+	bool deleteVertices(const IdStorage &ids);
 #if BITPIT_ENABLE_MPI==1
 	VertexIterator ghostVertex2InternalVertex(long id);
 	VertexIterator internalVertex2GhostVertex(long id, int ownerRank);

--- a/src/patchkernel/patch_kernel.tpp
+++ b/src/patchkernel/patch_kernel.tpp
@@ -165,7 +165,7 @@ bool PatchKernel::deleteInterfaces(const IdStorage &ids)
 	// sure to delete the last interface just once (after deleting the last
 	// interface, another interface becomes the last one and that interface
 	// may be on the deletion list as well, and on and so forth).
-	std::size_t lastId;
+	long lastId;
 	if (!m_interfaces.empty()) {
 		lastId = m_interfaces.back().getId();
 	} else {

--- a/src/patchkernel/patch_kernel.tpp
+++ b/src/patchkernel/patch_kernel.tpp
@@ -46,6 +46,150 @@ std::unique_ptr<patch_t> PatchKernel::clone(const patch_t *original)
 }
 
 /*!
+	Deletes a list of cells.
+
+	\param ids are the ids of the cells to be deleted
+ */
+template<typename IdStorage>
+bool PatchKernel::deleteCells(const IdStorage &ids)
+{
+	if (!isExpert()) {
+		return false;
+	}
+
+	// Deleteing the last internal cell requires some additional work. If the
+	// ids of cells to be deleted contains the last internal cell, we delete
+	// that cell ater deleting all other cells. In this way we make sure to
+	// deleting the last internal cells just once (after deleting the last
+	// internal, another cells becomes the last one and  that cells may be
+	// on the deletion list, and on and so forth). The same applies for the
+	// first ghost.
+	bool deleteLastInternalCell = false;
+#if BITPIT_ENABLE_MPI==1
+	bool deleteFirstGhostCell = false;
+#endif
+	for (long id : ids) {
+		if (id == m_lastInternalCellId) {
+			deleteLastInternalCell = true;
+			continue;
+		}
+#if BITPIT_ENABLE_MPI==1
+		else if (id == m_firstGhostCellId) {
+			deleteFirstGhostCell = true;
+			continue;
+		}
+#endif
+
+		deleteCell(id);
+	}
+
+	if (deleteLastInternalCell) {
+		deleteCell(m_lastInternalCellId);
+	}
+
+#if BITPIT_ENABLE_MPI==1
+	if (deleteFirstGhostCell) {
+		deleteCell(m_firstGhostCellId);
+	}
+#endif
+
+	return true;
+}
+
+/*!
+	Deletes a list of vertices.
+
+	\param ids are the ids of the vertices to be deleted
+*/
+template<typename IdStorage>
+bool PatchKernel::deleteVertices(const IdStorage &ids)
+{
+	if (!isExpert()) {
+		return false;
+	}
+
+	// Deleting the last vertex requires some additional work. If the ids
+	// of vertices to be deleted contain the last vertex, that vertex is
+	// deleted after deleting all other vertices. In this way we make sure
+	// to delete the last vertex just once (after deleting the last vertex,
+	// another vertex becomes the last one and that vertex may be on the
+	// deletion list as well, and on and so forth). The same applies for
+	// the first ghost.
+	bool deleteLastInternalVertex = false;
+#if BITPIT_ENABLE_MPI==1
+	bool deleteFirstGhostVertex = false;
+#endif
+	for (long id : ids) {
+		if (id == m_lastInternalVertexId) {
+			deleteLastInternalVertex = true;
+			continue;
+		}
+#if BITPIT_ENABLE_MPI==1
+		else if (id == m_firstGhostVertexId) {
+			deleteFirstGhostVertex = true;
+			continue;
+		}
+#endif
+
+		deleteVertex(id);
+	}
+
+	if (deleteLastInternalVertex) {
+		deleteVertex(m_lastInternalVertexId);
+	}
+
+#if BITPIT_ENABLE_MPI==1
+	if (deleteFirstGhostVertex) {
+		deleteVertex(m_firstGhostVertexId);
+	}
+#endif
+
+	return true;
+}
+
+/*!
+	Deletes a list of interfaces.
+
+	\param ids are the ids of the interfaces to be deleted
+*/
+template<typename IdStorage>
+bool PatchKernel::deleteInterfaces(const IdStorage &ids)
+{
+	if (!isExpert()) {
+		return false;
+	}
+
+	// Deleting the last interface requires some additional work. If the ids
+	// of interfaces to be deleted contain the last interface, that interface
+	// is deleted after deleting all other interfaces. In this way we make
+	// sure to delete the last interface just once (after deleting the last
+	// interface, another interface becomes the last one and that interface
+	// may be on the deletion list as well, and on and so forth).
+	std::size_t lastId;
+	if (!m_interfaces.empty()) {
+		lastId = m_interfaces.back().getId();
+	} else {
+		lastId = Interface::NULL_ID;
+	}
+
+	bool deleteLast = false;
+	for (long id : ids) {
+		if (id == lastId) {
+			deleteLast = true;
+			continue;
+		}
+
+		deleteInterface(id);
+	}
+
+	if (deleteLast) {
+		deleteInterface(lastId);
+	}
+
+	return true;
+}
+
+/*!
 	Renumber the ids of the items in the specified container.
 
 	\param container is the container

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1742,8 +1742,7 @@ VolOctree::StitchInfo VolOctree::deleteCells(const std::vector<DeleteInfo> &dele
 	}
 
 	// Delete the vertices
-	std::vector<long> deadVerticesList(deadVertices.cbegin(), deadVertices.cend());
-	PatchKernel::deleteVertices(deadVerticesList);
+	PatchKernel::deleteVertices(deadVertices);
 
 	// Done
 	return stitchVertices;


### PR DESCRIPTION
This avoid creating a list of vertices to delete during the adaption of the VolOctree patch.