### PR TITLE
IO/config: parse from XML/JSON formatted string

### DIFF
--- a/src/IO/configuration.cpp
+++ b/src/IO/configuration.cpp
@@ -374,50 +374,46 @@ namespace config {
 /*!
     Construct a new parser.
 
-    \param XMLorJSON false to activate XML format, true for JSON format if supported,
-    otherwise fallback automatically to XML.
+    \param format type of format to parse, of ConfigStringParser::Format enum type
 */
-ConfigStringParser::ConfigStringParser(bool XMLorJSON)
+ConfigStringParser::ConfigStringParser(ConfigStringParser::Format format)
     : Config(false)
 {
 #if HAS_RAPIDJSON_LIB
-    m_xmlOrJson = XMLorJSON;
+    m_format = format;
 #else
-    BITPIT_UNUSED(XMLorJSON);
+    BITPIT_UNUSED(format);
     //revert to default XML
-    m_xmlOrJson = false;
+    m_format = Format::XML;
 #endif
 }
 
 /*!
     Construct a new parser, activating multiSections support.
 
-    \param XMLorJSON false to activate XML format, true for JSON format if supported,
-    otherwise fallback automatically to XML.
+    \param format type of format to parse, of ConfigStringParser::Format enum type
     \param multiSections if set to true the configuration parser will allow
     multiple sections with the same name
 */
-ConfigStringParser::ConfigStringParser(bool XMLorJSON, bool multiSections)
+ConfigStringParser::ConfigStringParser(ConfigStringParser::Format format, bool multiSections)
     : Config(multiSections)
 {
 #if HAS_RAPIDJSON_LIB
-    m_xmlOrJson = XMLorJSON;
+    m_format = format;
 #else
-    BITPIT_UNUSED(XMLorJSON);
+    BITPIT_UNUSED(format);
     //revert to default XML
-    m_xmlOrJson = false;
+    m_format = Format::XML;
 #endif
 }
 
 /*!
-    Return a bool to identify the format targeted by the class to parse/write the 
-    buffer string. 0 is XML, 1 is JSON 
-
-    \return boolean identifying the target format 
+    \return the format of the class in ConfigStringParser::Format enum type 
 */
-bool ConfigStringParser::getFormat()
+ConfigStringParser::Format 
+ConfigStringParser::getFormat()
 {
-    return m_xmlOrJson;
+    return m_format;
 }
 
 /*!
@@ -436,7 +432,7 @@ void ConfigStringParser::read(const std::string &source, bool append)
         Config::clear();
     }
 
-    if(m_xmlOrJson){
+    if(m_format == Format::JSON){
 #if HAS_RAPIDJSON_LIB
         config::JSON::readBufferConfiguration(source, this);
 #endif
@@ -460,7 +456,7 @@ void ConfigStringParser::write(std::string &source, bool append) const
         source.clear();
     }
 
-    if(m_xmlOrJson){
+    if(m_format == Format::JSON){
 #if HAS_RAPIDJSON_LIB
         config::JSON::writeBufferConfiguration(source, this);
 #endif

--- a/src/IO/configuration.cpp
+++ b/src/IO/configuration.cpp
@@ -458,10 +458,10 @@ void ConfigStringParser::write(std::string &source, bool append) const
 
     if(m_format == Format::JSON){
 #if HAS_RAPIDJSON_LIB
-        config::JSON::writeBufferConfiguration(source, this);
+        config::JSON::writeBufferConfiguration(this, source);
 #endif
     }else{
-        config::XML::writeBufferConfiguration(source, this, "root");
+        config::XML::writeBufferConfiguration(this, source, "root");
     }
 
 }

--- a/src/IO/configuration.hpp
+++ b/src/IO/configuration.hpp
@@ -102,6 +102,23 @@ namespace config {
 
 };
 
+// Configuration parsing from/ writing to string 
+class ConfigStringParser : public Config
+{
+
+public:
+    ConfigStringParser(bool XMLorJSON = false);
+    ConfigStringParser(bool XMLorJSON, bool multiSections);
+
+    bool getFormat();
+
+    void read(const std::string &source, bool append = true);
+    void write(std::string & source, bool append = true) const;
+
+private:
+    bool m_xmlOrJson;
+};
+
 }
 
 #endif

--- a/src/IO/configuration.hpp
+++ b/src/IO/configuration.hpp
@@ -107,16 +107,26 @@ class ConfigStringParser : public Config
 {
 
 public:
-    ConfigStringParser(bool XMLorJSON = false);
-    ConfigStringParser(bool XMLorJSON, bool multiSections);
 
-    bool getFormat();
+    /*!
+     * @ingroup Configuration
+    * Enum class defining format allowed in ConfigStringParser class
+    */
+    enum class Format{
+        XML = 0,/**< xml formatted  */ 
+        JSON= 1 /**< json formatted  */
+    };
+
+    ConfigStringParser(Format format = Format::XML);
+    ConfigStringParser(Format format, bool multiSections);
+
+    Format getFormat();
 
     void read(const std::string &source, bool append = true);
     void write(std::string & source, bool append = true) const;
 
 private:
-    bool m_xmlOrJson;
+    Format m_format;
 };
 
 }

--- a/src/IO/configuration_JSON.cpp
+++ b/src/IO/configuration_JSON.cpp
@@ -290,10 +290,11 @@ void writeConfiguration(const std::string &filename, const Config *rootConfig, b
     Tree contents will be written to a plain c++ string, with UTF-8 standard encoding, and 
     appended to any previous content of the source string.
     
-    \param[in] source string to write JSON contents.
     \param[in] rootConfig pointer to the Config tree to be written on target string
+    \param[inout] source string to write JSON contents.
+
 */
-void writeBufferConfiguration(std::string &source, const Config *rootConfig)
+void writeBufferConfiguration(const Config *rootConfig, std::string &source)
 {
     if (!rootConfig) {
         throw std::runtime_error("JSON::writeConfiguration Null Config tree structure passed");

--- a/src/IO/configuration_JSON.hpp
+++ b/src/IO/configuration_JSON.hpp
@@ -36,9 +36,11 @@ namespace config {
 namespace JSON {
 
 void readConfiguration(const std::string &filename, Config *rootConfig);
+void readBufferConfiguration(const std::string &source, Config *rootConfig);
 void readNode(const std::string &key, const rapidjson::Value &value, Config *config);
 
 void writeConfiguration(const std::string &filename, const Config *rootConfig, bool prettify = true);
+void writeBufferConfiguration(std::string &source, const Config *rootConfig);
 void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::Document::AllocatorType &allocator);
 
 std::string decodeValue(const rapidjson::Value &value);

--- a/src/IO/configuration_JSON.hpp
+++ b/src/IO/configuration_JSON.hpp
@@ -40,7 +40,7 @@ void readBufferConfiguration(const std::string &source, Config *rootConfig);
 void readNode(const std::string &key, const rapidjson::Value &value, Config *config);
 
 void writeConfiguration(const std::string &filename, const Config *rootConfig, bool prettify = true);
-void writeBufferConfiguration(std::string &source, const Config *rootConfig);
+void writeBufferConfiguration(const Config *rootConfig, std::string &source);
 void writeNode(const Config *config, rapidjson::Value &rootJSONData, rapidjson::Document::AllocatorType &allocator);
 
 std::string decodeValue(const rapidjson::Value &value);

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -323,11 +323,11 @@ void writeConfiguration(const std::string &filename, const std::string &rootname
     Write the Config Tree to a c++ string (xml-stringfication). All contents will 
     be appended to the target source string.
     The method is meant for general-purpose xml info flushing.  
-    \param source string to write to
     \param rootConfig pointer to the Config tree to be stringfied.
+    \param source string to write to
     \param rootname (optional) name of the root section. Default is "root".
 */
-void writeBufferConfiguration(std::string &source, const Config *rootConfig, const std::string &rootname)
+void writeBufferConfiguration(const Config *rootConfig, std::string &source, const std::string &rootname)
 {
     if (!rootConfig) {
         throw std::runtime_error("XML::writeConfiguration Null Config tree structure passed");

--- a/src/IO/configuration_XML.hpp
+++ b/src/IO/configuration_XML.hpp
@@ -38,9 +38,11 @@ namespace XML {
 extern const std::string DEFAULT_ENCODING;
 
 void readConfiguration(const std::string &filename, const std::string &rootname, bool checkVersion, int version, Config *rootConfig);
+void readBufferConfiguration(const std::string &source,  Config *rootConfig);
 void readNode(xmlNodePtr root, Config *config);
 
 void writeConfiguration(const std::string &filename, const std::string & rootname, int version, const Config *rootConfig);
+void writeBufferConfiguration(std::string &source, const Config *rootConfig, const std::string &rootname = "root");
 void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string &encoding = DEFAULT_ENCODING);
 
 xmlChar * encodeString(const std::string &in, const std::string &encoding);

--- a/src/IO/configuration_XML.hpp
+++ b/src/IO/configuration_XML.hpp
@@ -42,7 +42,7 @@ void readBufferConfiguration(const std::string &source,  Config *rootConfig);
 void readNode(xmlNodePtr root, Config *config);
 
 void writeConfiguration(const std::string &filename, const std::string & rootname, int version, const Config *rootConfig);
-void writeBufferConfiguration(std::string &source, const Config *rootConfig, const std::string &rootname = "root");
+void writeBufferConfiguration(const Config *rootConfig, std::string &source, const std::string &rootname = "root");
 void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string &encoding = DEFAULT_ENCODING);
 
 xmlChar * encodeString(const std::string &in, const std::string &encoding);

--- a/test/integration_tests/IO/test_IO_00002.cpp
+++ b/test/integration_tests/IO/test_IO_00002.cpp
@@ -101,6 +101,61 @@ int subtest_001()
 }
 
 /*!
+* Subtest 002
+*
+* Testing configuration string parser, to absorb/flush json contents directly on string.
+*/
+int subtest_002()
+{
+    std::cout << std::endl;
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "Testing configuration JSON stringfication" << std::endl;
+    std::cout << std::endl;
+
+    //create a sample config tree.
+    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(true, true); //enable json format, enable multisection.
+    
+    //fill the writeStr tree with some data 
+    writeStr->set("ActivateOption", "1");
+    writeStr->set("Origin", "Albuquerque");
+    writeStr->set("Span", "180.0 48.0 46.0"); 
+    writeStr->set("Dimension", "5 7 3");
+    {
+        auto &subsect = writeStr->addSection("UserData");
+        subsect.set("Name","Walter");
+        subsect.set("Surname","White");
+        subsect.set("Nick","Heisenberg");
+        subsect.set("PassPhrase", "Say my name!");
+    } 
+    {
+        auto &subsect = writeStr->addSection("UserData");
+        subsect.set("Name","Jesse");
+        subsect.set("Surname","Pinkman");
+        subsect.set("Nick","Captain Cook");
+        subsect.set("PassPhrase", "Yo!");
+    } 
+    
+    std::string bufferJSON;
+    //write writeStr Content to the string buffer
+    writeStr->write(bufferJSON);
+    
+    std::cout<<bufferJSON<<std::endl;
+
+    //read buffer in another configstring parser
+    std::shared_ptr<bitpit::ConfigStringParser> parseStr=std::make_shared<bitpit::ConfigStringParser>(true, true); //enable json format, enable multisection.
+    parseStr->read(bufferJSON);
+
+    bool check = parseStr->hasSection("UserData");
+    check = check && parseStr->hasOption("Origin");
+    check = check && parseStr->getSections("UserData").size() == 2;
+
+
+    return int(!check);
+}
+
+/*!
 * Main program.
 */
 int main(int argc, char *argv[])
@@ -122,6 +177,7 @@ int main(int argc, char *argv[])
     int status;
     try {
         status = subtest_001();
+        status = std::max(status, subtest_002());
         if (status != 0) {
             return status;
         }

--- a/test/integration_tests/IO/test_IO_00002.cpp
+++ b/test/integration_tests/IO/test_IO_00002.cpp
@@ -115,7 +115,7 @@ int subtest_002()
     std::cout << std::endl;
 
     //create a sample config tree.
-    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(true, true); //enable json format, enable multisection.
+    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(ConfigStringParser::Format::JSON, true); //enable json format, enable multisection.
     
     //fill the writeStr tree with some data 
     writeStr->set("ActivateOption", "1");
@@ -144,7 +144,7 @@ int subtest_002()
     std::cout<<bufferJSON<<std::endl;
 
     //read buffer in another configstring parser
-    std::shared_ptr<bitpit::ConfigStringParser> parseStr=std::make_shared<bitpit::ConfigStringParser>(true, true); //enable json format, enable multisection.
+    std::shared_ptr<bitpit::ConfigStringParser> parseStr=std::make_shared<bitpit::ConfigStringParser>(ConfigStringParser::Format::JSON, true); //enable json format, enable multisection.
     parseStr->read(bufferJSON);
 
     bool check = parseStr->hasSection("UserData");

--- a/test/integration_tests/IO/test_IO_00004.cpp
+++ b/test/integration_tests/IO/test_IO_00004.cpp
@@ -109,6 +109,62 @@ int subtest_001()
     return 0;
 }
 
+
+/*!
+* Subtest 002
+*
+* Testing configuration string parser, to absorb/flush xml contents directly on string.
+*/
+int subtest_002()
+{
+    std::cout << std::endl;
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "Testing configuration XML stringfication" << std::endl;
+    std::cout << std::endl;
+
+    //create a sample config tree.
+    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(false, true); //enable xml format, enable multisection.
+    
+    //fill the writeStr tree with some data 
+    writeStr->set("ActivateOption", "1");
+    writeStr->set("Origin", "Albuquerque");
+    writeStr->set("Span", "180.0 48.0 46.0"); 
+    writeStr->set("Dimension", "5 7 3");
+    {
+        auto &subsect = writeStr->addSection("UserData");
+        subsect.set("Name","Walter");
+        subsect.set("Surname","White");
+        subsect.set("Nick","Heisenberg");
+        subsect.set("PassPhrase", "Say my name!");
+    } 
+    {
+        auto &subsect = writeStr->addSection("UserData");
+        subsect.set("Name","Jesse");
+        subsect.set("Surname","Pinkman");
+        subsect.set("Nick","Captain Cook");
+        subsect.set("PassPhrase", "Yo!");
+    } 
+    
+    std::string bufferXML;
+    //write writeStr Content to the string buffer
+    writeStr->write(bufferXML);
+    
+    std::cout<<bufferXML<<std::endl;
+
+    //read buffer in another configstring parser
+    std::shared_ptr<bitpit::ConfigStringParser> parseStr = std::make_shared<bitpit::ConfigStringParser>(false, true); //enable xml format, enable multisection.
+    parseStr->read(bufferXML);
+
+    bool check = parseStr->hasSection("UserData");
+    check = check && parseStr->hasOption("Origin");
+    check = check && parseStr->getSections("UserData").size() == 2;
+
+
+    return int(!check);
+}
+
 /*!
 * Main program.
 */
@@ -130,6 +186,7 @@ int main(int argc, char *argv[])
     int status;
     try {
         status = subtest_001();
+        status = std::max(status, subtest_002());
         if (status != 0) {
             return status;
         }

--- a/test/integration_tests/IO/test_IO_00004.cpp
+++ b/test/integration_tests/IO/test_IO_00004.cpp
@@ -125,7 +125,7 @@ int subtest_002()
     std::cout << std::endl;
 
     //create a sample config tree.
-    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(false, true); //enable xml format, enable multisection.
+    std::shared_ptr<bitpit::ConfigStringParser> writeStr = std::make_shared<bitpit::ConfigStringParser>(ConfigStringParser::Format::XML, true); //enable xml format, enable multisection.
     
     //fill the writeStr tree with some data 
     writeStr->set("ActivateOption", "1");
@@ -154,7 +154,7 @@ int subtest_002()
     std::cout<<bufferXML<<std::endl;
 
     //read buffer in another configstring parser
-    std::shared_ptr<bitpit::ConfigStringParser> parseStr = std::make_shared<bitpit::ConfigStringParser>(false, true); //enable xml format, enable multisection.
+    std::shared_ptr<bitpit::ConfigStringParser> parseStr = std::make_shared<bitpit::ConfigStringParser>(ConfigStringParser::Format::XML, true); //enable xml format, enable multisection.
     parseStr->read(bufferXML);
 
     bool check = parseStr->hasSection("UserData");


### PR DESCRIPTION
Added Config specialization class (ConfigStringParser) to read and write XML (or JSON) directly from and onto c++ string. The class is useful to exhange info without passing from filesystem each time.

Enhanced IO integration tests 2 e 4 to prove the capabilities of the new class.