### PR TITLE
patchkernel: allow to build more than one layer of ghost cells

### DIFF
--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -389,9 +389,9 @@ const std::unordered_map<long, long> & PatchNumberingInfo::getCellGlobalMap() co
 */
 int PatchNumberingInfo::getCellOwnerFromLocal(long id) const
 {
-	auto ghostCellOwnerItr = m_patch->m_ghostCellOwners.find(id);
-	if (ghostCellOwnerItr != m_patch->m_ghostCellOwners.end()) {
-		return ghostCellOwnerItr->second;
+	auto ghostCellOwnerItr = m_patch->m_ghostCellInfo.find(id);
+	if (ghostCellOwnerItr != m_patch->m_ghostCellInfo.end()) {
+		return ghostCellOwnerItr->second.owner;
 	} else {
 		return m_patch->getRank();
 	}

--- a/src/patchkernel/patch_info.cpp
+++ b/src/patchkernel/patch_info.cpp
@@ -387,7 +387,7 @@ const std::unordered_map<long, long> & PatchNumberingInfo::getCellGlobalMap() co
 	\param id is the local id of the cell
 	\return The rank of the specified cell.
 */
-int PatchNumberingInfo::getCellRankFromLocal(long id) const
+int PatchNumberingInfo::getCellOwnerFromLocal(long id) const
 {
 	auto ghostCellOwnerItr = m_patch->m_ghostCellOwners.find(id);
 	if (ghostCellOwnerItr != m_patch->m_ghostCellOwners.end()) {
@@ -403,7 +403,7 @@ int PatchNumberingInfo::getCellRankFromLocal(long id) const
 	\param id is the consecutive id of the cell
 	\return The rank of the specified cell.
 */
-int PatchNumberingInfo::getCellRankFromConsecutive(long id) const
+int PatchNumberingInfo::getCellOwnerFromConsecutive(long id) const
 {
 	if (!m_patch->isPartitioned()) {
 		return m_patch->getRank();
@@ -426,10 +426,10 @@ int PatchNumberingInfo::getCellRankFromConsecutive(long id) const
 	\param id is the global id of the cell
 	\return The rank of the specified cell.
 */
-int PatchNumberingInfo::getCellRankFromGlobal(long id) const
+int PatchNumberingInfo::getCellOwnerFromGlobal(long id) const
 {
     // Global ids and consecutive ids are the same
-    return getCellRankFromConsecutive(id);
+    return getCellOwnerFromConsecutive(id);
 }
 #endif
 

--- a/src/patchkernel/patch_info.hpp
+++ b/src/patchkernel/patch_info.hpp
@@ -74,9 +74,9 @@ public:
 	long getCellGlobalId(long id) const;
 	const std::unordered_map<long, long> & getCellGlobalMap() const;
 
-	int getCellRankFromLocal(long id) const;
-	int getCellRankFromConsecutive(long id) const;
-	int getCellRankFromGlobal(long id) const;
+	int getCellOwnerFromLocal(long id) const;
+	int getCellOwnerFromConsecutive(long id) const;
+	int getCellOwnerFromGlobal(long id) const;
 #endif
 
 protected:

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -240,10 +240,10 @@ PatchKernel::PatchKernel(const PatchKernel &other)
       m_partitioningOutgoings(other.m_partitioningOutgoings),
       m_partitioningGlobalExchanges(other.m_partitioningGlobalExchanges),
       m_partitioningInfoDirty(other.m_partitioningInfoDirty),
-      m_ghostVertexOwners(other.m_ghostVertexOwners),
+      m_ghostVertexInfo(other.m_ghostVertexInfo),
       m_ghostVertexExchangeTargets(other.m_ghostVertexExchangeTargets),
       m_ghostVertexExchangeSources(other.m_ghostVertexExchangeSources),
-      m_ghostCellOwners(other.m_ghostCellOwners),
+      m_ghostCellInfo(other.m_ghostCellInfo),
       m_ghostCellExchangeTargets(other.m_ghostCellExchangeTargets),
       m_ghostCellExchangeSources(other.m_ghostCellExchangeSources)
 #endif
@@ -330,10 +330,10 @@ PatchKernel::PatchKernel(PatchKernel &&other)
       m_partitioningOutgoings(std::move(other.m_partitioningOutgoings)),
       m_partitioningGlobalExchanges(std::move(other.m_partitioningGlobalExchanges)),
       m_partitioningInfoDirty(std::move(other.m_partitioningInfoDirty)),
-      m_ghostVertexOwners(std::move(other.m_ghostVertexOwners)),
+      m_ghostVertexInfo(std::move(other.m_ghostVertexInfo)),
       m_ghostVertexExchangeTargets(std::move(other.m_ghostVertexExchangeTargets)),
       m_ghostVertexExchangeSources(std::move(other.m_ghostVertexExchangeSources)),
-      m_ghostCellOwners(std::move(other.m_ghostCellOwners)),
+      m_ghostCellInfo(std::move(other.m_ghostCellInfo)),
       m_ghostCellExchangeTargets(std::move(other.m_ghostCellExchangeTargets)),
       m_ghostCellExchangeSources(std::move(other.m_ghostCellExchangeSources))
 #endif
@@ -419,10 +419,10 @@ PatchKernel & PatchKernel::operator=(PatchKernel &&other)
 	m_partitioningOutgoings = std::move(other.m_partitioningOutgoings);
 	m_partitioningGlobalExchanges = std::move(other.m_partitioningGlobalExchanges);
 	m_partitioningInfoDirty = std::move(other.m_partitioningInfoDirty);
-	m_ghostVertexOwners = std::move(other.m_ghostVertexOwners);
+	m_ghostVertexInfo = std::move(other.m_ghostVertexInfo);
 	m_ghostVertexExchangeTargets = std::move(other.m_ghostVertexExchangeTargets);
 	m_ghostVertexExchangeSources = std::move(other.m_ghostVertexExchangeSources);
-	m_ghostCellOwners = std::move(other.m_ghostCellOwners);
+	m_ghostCellInfo = std::move(other.m_ghostCellInfo);
 	m_ghostCellExchangeTargets = std::move(other.m_ghostCellExchangeTargets);
 	m_ghostCellExchangeSources = std::move(other.m_ghostCellExchangeSources);
 #endif
@@ -1027,8 +1027,8 @@ void PatchKernel::resetCells()
 #endif
 
 #if BITPIT_ENABLE_MPI==1
-	clearGhostCellOwners();
-	clearGhostVertexOwners();
+	clearGhostCellsInfo();
+	clearGhostVerticesInfo();
 #endif
 
 	resetAdjacencies();

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -4811,10 +4811,10 @@ void PatchKernel::dumpVertices(std::ostream &stream) const
 	for (const Vertex &vertex : m_vertices) {
 		utils::binary::write(stream, vertex.getId());
 #if BITPIT_ENABLE_MPI==1
-		utils::binary::write(stream, getVertexRank(vertex.getId()));
+		utils::binary::write(stream, getVertexOwner(vertex.getId()));
 #else
-		int dummyRank = 0;
-		utils::binary::write(stream, dummyRank);
+		int dummyOwner = 0;
+		utils::binary::write(stream, dummyOwner);
 #endif
 
 		const std::array<double, 3> &coords = vertex.getCoords();
@@ -4854,11 +4854,11 @@ void PatchKernel::restoreVertices(std::istream &stream)
 		utils::binary::read(stream, id);
 
 #if BITPIT_ENABLE_MPI==1
-		int rank;
-		utils::binary::read(stream, rank);
+		int owner;
+		utils::binary::read(stream, owner);
 #else
-		int dummyRank;
-		utils::binary::read(stream, dummyRank);
+		int dummyOwner;
+		utils::binary::read(stream, dummyOwner);
 #endif
 
 		std::array<double, 3> coords;
@@ -4867,7 +4867,7 @@ void PatchKernel::restoreVertices(std::istream &stream)
 		utils::binary::read(stream, coords[2]);
 
 #if BITPIT_ENABLE_MPI==1
-		restoreVertex(std::move(coords), rank, id);
+		restoreVertex(std::move(coords), owner, id);
 #else
 		restoreVertex(std::move(coords), id);
 #endif
@@ -4904,10 +4904,10 @@ void PatchKernel::dumpCells(std::ostream &stream) const
 		utils::binary::write(stream, cell.getPID());
 		utils::binary::write(stream, cell.getType());
 #if BITPIT_ENABLE_MPI==1
-		utils::binary::write(stream, getCellRank(cell.getId()));
+		utils::binary::write(stream, getCellOwner(cell.getId()));
 #else
-		int dummyRank = 0;
-		utils::binary::write(stream, dummyRank);
+		int dummyOwner = 0;
+		utils::binary::write(stream, dummyOwner);
 #endif
 
 		int cellConnectSize = cell.getConnectSize();
@@ -4956,11 +4956,11 @@ void PatchKernel::restoreCells(std::istream &stream)
 		utils::binary::read(stream, type);
 
 #if BITPIT_ENABLE_MPI==1
-		int rank;
-		utils::binary::read(stream, rank);
+		int owner;
+		utils::binary::read(stream, owner);
 #else
-		int dummyRank;
-		utils::binary::read(stream, dummyRank);
+		int dummyOwner;
+		utils::binary::read(stream, dummyOwner);
 #endif
 
 		int cellConnectSize;
@@ -4973,7 +4973,7 @@ void PatchKernel::restoreCells(std::istream &stream)
 
 		CellIterator iterator;
 #if BITPIT_ENABLE_MPI==1
-		iterator = restoreCell(type, std::move(cellConnect), rank, id);
+		iterator = restoreCell(type, std::move(cellConnect), owner, id);
 #else
 		iterator = restoreCell(type, std::move(cellConnect), id);
 #endif
@@ -7831,7 +7831,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 		}
 	} else if (name == "cellRank") {
 		for (const Cell &cell : getVTKCellWriteRange()) {
-			genericIO::flushBINARY(stream, getCellRank(cell.getId()));
+			genericIO::flushBINARY(stream, getCellOwner(cell.getId()));
 		}
 	} else if (name == "vertexRank") {
 		VertexConstIterator endItr = vertexConstEnd();
@@ -7839,7 +7839,7 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 			std::size_t vertexRawId = itr.getRawIndex();
 			long vertexVTKId = m_vtkVertexMap.rawAt(vertexRawId);
 			if (vertexVTKId != Vertex::NULL_ID) {
-				genericIO::flushBINARY(stream, getVertexRank(itr.getId()));
+				genericIO::flushBINARY(stream, getVertexOwner(itr.getId()));
 			}
 		}
 #endif

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -573,6 +573,7 @@ void PatchKernel::initialize()
 #if BITPIT_ENABLE_MPI==1
 	m_vtk.addData<long>("cellGlobalIndex", VTKFieldType::SCALAR, VTKLocation::CELL, this);
 	m_vtk.addData<int>("cellRank", VTKFieldType::SCALAR, VTKLocation::CELL, this);
+	m_vtk.addData<int>("cellHaloLayer", VTKFieldType::SCALAR, VTKLocation::CELL, this);
 	m_vtk.addData<int>("vertexRank", VTKFieldType::SCALAR, VTKLocation::POINT, this);
 #endif
 }
@@ -4903,11 +4904,16 @@ void PatchKernel::dumpCells(std::ostream &stream) const
 		utils::binary::write(stream, cell.getId());
 		utils::binary::write(stream, cell.getPID());
 		utils::binary::write(stream, cell.getType());
+
 #if BITPIT_ENABLE_MPI==1
 		utils::binary::write(stream, getCellOwner(cell.getId()));
+		utils::binary::write(stream, getCellHaloLayer(cell.getId()));
 #else
 		int dummyOwner = 0;
 		utils::binary::write(stream, dummyOwner);
+
+		int dummyHaloLayer = 0;
+		utils::binary::write(stream, dummyHaloLayer);
 #endif
 
 		int cellConnectSize = cell.getConnectSize();
@@ -4958,9 +4964,15 @@ void PatchKernel::restoreCells(std::istream &stream)
 #if BITPIT_ENABLE_MPI==1
 		int owner;
 		utils::binary::read(stream, owner);
+
+		int haloLayer;
+		utils::binary::read(stream, haloLayer);
 #else
 		int dummyOwner;
 		utils::binary::read(stream, dummyOwner);
+
+		int dummyHaloLayer;
+		utils::binary::read(stream, dummyHaloLayer);
 #endif
 
 		int cellConnectSize;
@@ -4973,7 +4985,7 @@ void PatchKernel::restoreCells(std::istream &stream)
 
 		CellIterator iterator;
 #if BITPIT_ENABLE_MPI==1
-		iterator = restoreCell(type, std::move(cellConnect), owner, id);
+		iterator = restoreCell(type, std::move(cellConnect), owner, haloLayer, id);
 #else
 		iterator = restoreCell(type, std::move(cellConnect), id);
 #endif
@@ -7832,6 +7844,10 @@ void PatchKernel::flushData(std::fstream &stream, const std::string &name, VTKFo
 	} else if (name == "cellRank") {
 		for (const Cell &cell : getVTKCellWriteRange()) {
 			genericIO::flushBINARY(stream, getCellOwner(cell.getId()));
+		}
+	} else if (name == "cellHaloLayer") {
+		for (const Cell &cell : getVTKCellWriteRange()) {
+			genericIO::flushBINARY(stream, getCellHaloLayer(cell.getId()));
 		}
 	} else if (name == "vertexRank") {
 		VertexConstIterator endItr = vertexConstEnd();

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1127,6 +1127,9 @@ private:
 
 	void replaceVTKStreamer(const VTKBaseStreamer *original, VTKBaseStreamer *updated);
 
+	template<typename Selector, typename Function, typename SeedContainer>
+	void processCellsNeighbours(const SeedContainer &seeds, int nLayers, Selector isSelected, Function function);
+
 };
 
 }

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -926,6 +926,15 @@ protected:
 	virtual bool isSameFace(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 private:
+	struct GhostVertexInfo {
+		int owner;
+	};
+
+	struct GhostCellInfo {
+		int owner;
+		int haloLayer;
+	};
+
 	std::unique_ptr<IndexGenerator<long>> m_vertexIdGenerator;
 	std::unique_ptr<IndexGenerator<long>> m_interfaceIdGenerator;
 	std::unique_ptr<IndexGenerator<long>> m_cellIdGenerator;
@@ -995,21 +1004,21 @@ private:
 
 	bool m_partitioningInfoDirty;
 
-	std::unordered_map<long, int> m_ghostVertexOwners;
+	std::unordered_map<long, GhostVertexInfo> m_ghostVertexInfo;
 	std::unordered_map<int, std::vector<long>> m_ghostVertexExchangeTargets;
 	std::unordered_map<int, std::vector<long>> m_ghostVertexExchangeSources;
 
-	std::unordered_map<long, int> m_ghostCellOwners;
+	std::unordered_map<long, GhostCellInfo> m_ghostCellInfo;
 	std::unordered_map<int, std::vector<long>> m_ghostCellExchangeTargets;
 	std::unordered_map<int, std::vector<long>> m_ghostCellExchangeSources;
 
-	void setGhostVertexOwner(long id, int owner);
-	void unsetGhostVertexOwner(long id);
-	void clearGhostVertexOwners();
+	void setGhostVertexInfo(long id, int owner);
+	void unsetGhostVertexInfo(long id);
+	void clearGhostVerticesInfo();
 
-	void setGhostCellOwner(long id, int owner);
-	void unsetGhostCellOwner(long id);
-	void clearGhostCellOwners();
+	void setGhostCellInfo(long id, int owner);
+	void unsetGhostCellInfo(long id);
+	void clearGhostCellsInfo();
 
 	void _partitioningAlter_deleteGhosts();
 

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -498,18 +498,18 @@ public:
 	CellIterator addCell(ElementType type, const std::vector<long> &connectivity, long id = Element::NULL_ID);
 	CellIterator addCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id = Element::NULL_ID);
 #if BITPIT_ENABLE_MPI==1
-	CellIterator addCell(const Cell &source, int rank, long id = Element::NULL_ID);
-	CellIterator addCell(Cell &&source, int rank, long id = Element::NULL_ID);
-	CellIterator addCell(ElementType type, int rank, long id = Element::NULL_ID);
-	CellIterator addCell(ElementType type, const std::vector<long> &connectivity, int rank, long id = Element::NULL_ID);
-	CellIterator addCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank, long id = Element::NULL_ID);
+	CellIterator addCell(const Cell &source, int owner, long id = Element::NULL_ID);
+	CellIterator addCell(Cell &&source, int owner, long id = Element::NULL_ID);
+	CellIterator addCell(ElementType type, int owner, long id = Element::NULL_ID);
+	CellIterator addCell(ElementType type, const std::vector<long> &connectivity, int owner, long id = Element::NULL_ID);
+	CellIterator addCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int owner, long id = Element::NULL_ID);
 #endif
 	bool deleteCell(long id);
 	template<typename IdStorage>
 	bool deleteCells(const IdStorage &ids);
 #if BITPIT_ENABLE_MPI==1
 	CellIterator ghostCell2InternalCell(long id);
-	CellIterator internalCell2GhostCell(long id, int ownerRank);
+	CellIterator internalCell2GhostCell(long id, int owner);
 #endif
 	virtual double evalCellSize(long id) const = 0;
 	BITPIT_DEPRECATED(long countFreeCells() const);
@@ -700,10 +700,12 @@ public:
 	void setHaloSize(std::size_t haloSize);
 	std::size_t getHaloSize() const;
 
-	int getCellRank(long id) const;
+	int getCellOwner(long id) const;
+	BITPIT_DEPRECATED(int getCellRank(long id) const);
 	virtual int getCellHaloLayer(long id) const;
 
-	int getVertexRank(long id) const;
+	int getVertexOwner(long id) const;
+	BITPIT_DEPRECATED(int getVertexRank(long id) const);
 
 	bool isRankNeighbour(int rank);
 	std::vector<int> getNeighbourRanks();
@@ -795,7 +797,7 @@ protected:
 #endif
 
 #if BITPIT_ENABLE_MPI==1
-	CellIterator restoreCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank, long id);
+	CellIterator restoreCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int owner, long id);
 #else
 	CellIterator restoreCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id);
 #endif
@@ -803,7 +805,7 @@ protected:
 	InterfaceIterator restoreInterface(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id);
 
 #if BITPIT_ENABLE_MPI==1
-	VertexIterator restoreVertex(const std::array<double, 3> &coords, int rank, long id);
+	VertexIterator restoreVertex(const std::array<double, 3> &coords, int owner, long id);
 #else
 	VertexIterator restoreVertex(const std::array<double, 3> &coords, long id);
 #endif
@@ -813,7 +815,7 @@ protected:
 	bool deleteVertices(const IdStorage &ids);
 #if BITPIT_ENABLE_MPI==1
 	VertexIterator ghostVertex2InternalVertex(long id);
-	VertexIterator internalVertex2GhostVertex(long id, int ownerRank);
+	VertexIterator internalVertex2GhostVertex(long id, int owner);
 #endif
 
 	void dumpVertices(std::ostream &stream) const;
@@ -1001,11 +1003,11 @@ private:
 	std::unordered_map<int, std::vector<long>> m_ghostCellExchangeTargets;
 	std::unordered_map<int, std::vector<long>> m_ghostCellExchangeSources;
 
-	void setGhostVertexOwner(long id, int rank);
+	void setGhostVertexOwner(long id, int owner);
 	void unsetGhostVertexOwner(long id);
 	void clearGhostVertexOwners();
 
-	void setGhostCellOwner(long id, int rank);
+	void setGhostCellOwner(long id, int owner);
 	void unsetGhostCellOwner(long id);
 	void clearGhostCellOwners();
 
@@ -1085,7 +1087,7 @@ private:
 
 	void _restoreInternalVertex(const VertexIterator &iterator, const std::array<double, 3> &coords);
 #if BITPIT_ENABLE_MPI==1
-	void _restoreGhostVertex(const VertexIterator &iterator, const std::array<double, 3> &coords, int rank);
+	void _restoreGhostVertex(const VertexIterator &iterator, const std::array<double, 3> &coords, int owner);
 #endif
 
 	void _deleteInternalVertex(long id);
@@ -1095,12 +1097,12 @@ private:
 
 	CellIterator _addInternalCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, long id);
 #if BITPIT_ENABLE_MPI==1
-	CellIterator _addGhostCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank, long id);
+	CellIterator _addGhostCell(ElementType type, std::unique_ptr<long[]> &&connectStorage, int owner, long id);
 #endif
 
 	void _restoreInternalCell(const CellIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage);
 #if BITPIT_ENABLE_MPI==1
-	void _restoreGhostCell(const CellIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage, int rank);
+	void _restoreGhostCell(const CellIterator &iterator, ElementType type, std::unique_ptr<long[]> &&connectStorage, int owner);
 #endif
 
 	void _deleteInternalCell(long id);

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -284,8 +284,9 @@ void PatchKernel::initializeHaloSize(std::size_t haloSize)
 */
 void PatchKernel::setHaloSize(std::size_t haloSize)
 {
-	if (isPartitioned()) {
-		throw std::runtime_error ("Halo size can only be set before partitionig the patch.");
+
+	if (isDistributed()) {
+		throw std::runtime_error ("Halo size can only be set when the patch is all on a single process");
 	}
 
 	if (m_haloSize == haloSize) {

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2609,7 +2609,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
 
         verticesBuffer << (long) vertexSendList.size();
         for (long vertexId : vertexSendList) {
-            // Cell information
+            // Vertex information
             bool isFrame = (frameVertices.count(vertexId) > 0);
             bool isHalo  = (haloVertices.count(vertexId) > 0);
 
@@ -3127,7 +3127,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
 
         verticesMap.clear();
         for (long i = 0; i < nRecvVertices; ++i) {
-            // Cell data
+            // Vertex data
             bool isFrame;
             verticesBuffer >> isFrame;
 

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -2712,6 +2712,9 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
         }
 
         // Delete outgoing cells not in the frame
+        //
+        // Frame cells cannot be deleted just now, because they may be ghost cells
+        // for other processes.
         std::vector<long> deleteList;
 
         deleteList.reserve(nOutgoingCells - frameCells.size());
@@ -2781,9 +2784,9 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
         // Loop over all the ghosts and keep only the cells that have at least
         // one internal neighbour that is still on this process.
         //
-        // Stale ghosts have to be deleted after processing frame cells,
-        // because some of the frame cells moved into ghosts may be stale
-        // ghosts.
+        // Stale ghosts have to be deleted after processing frame cells, that's
+        // because some stale ghosts will become such only after deleting the
+        // unneeded frame cells.
         std::vector<long> neighIds;
 
         deleteList.clear();
@@ -4431,7 +4434,7 @@ std::vector<long> PatchKernel::_findGhostCellExchangeSources(int rank)
 {
 	// Get targets for the specified rank
 	//
-	// If there are no targets, there will be no soruces either.
+	// If there are no targets, there will be no sources either.
 	auto ghostExchangeTargetsItr = m_ghostCellExchangeTargets.find(rank);
 	if (ghostExchangeTargetsItr == m_ghostCellExchangeTargets.end()) {
 		return std::vector<long>();

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -374,7 +374,7 @@ PatchKernel::VertexIterator PatchKernel::internalVertex2GhostVertex(long id, int
 	}
 
 	// Set ghost owner
-	setGhostVertexOwner(id, owner);
+	setGhostVertexInfo(id, owner);
 
 	// Return the iterator to the new position
 	return iterator;
@@ -417,7 +417,7 @@ PatchKernel::VertexIterator PatchKernel::ghostVertex2InternalVertex(long id)
 	}
 
 	// Unset ghost owner
-	unsetGhostVertexOwner(id);
+	unsetGhostVertexInfo(id);
 
 	// Return the iterator to the new position
 	return iterator;
@@ -510,7 +510,7 @@ void PatchKernel::_restoreGhostVertex(const VertexIterator &iterator, const std:
 	addPointToBoundingBox(vertex.getCoords());
 
 	// Set owner
-	setGhostVertexOwner(vertex.getId(), owner);
+	setGhostVertexInfo(vertex.getId(), owner);
 }
 
 /*!
@@ -521,7 +521,7 @@ void PatchKernel::_restoreGhostVertex(const VertexIterator &iterator, const std:
 void PatchKernel::_deleteGhostVertex(long id)
 {
 	// Unset ghost owner
-	unsetGhostVertexOwner(id);
+	unsetGhostVertexInfo(id);
 
 	// Update the bounding box
 	const Vertex &vertex = m_vertices[id];
@@ -639,8 +639,8 @@ PatchKernel::CellIterator PatchKernel::internalCell2GhostCell(long id, int owner
 		m_lastInternalCellId = m_cells.getSizeMarker(m_nInternalCells - 1, Cell::NULL_ID);
 	}
 
-	// Set ghost owner
-	setGhostCellOwner(id, owner);
+	// Set ghost information
+	setGhostCellInfo(id, owner);
 
 	// Return the iterator to the new position
 	return iterator;
@@ -682,8 +682,8 @@ PatchKernel::CellIterator PatchKernel::ghostCell2InternalCell(long id)
 		m_firstGhostCellId = firstGhostCellIterator->getId();
 	}
 
-	// Unset ghost owner
-	unsetGhostCellOwner(id);
+	// Unset ghost information
+	unsetGhostCellInfo(id);
 
 	// Return the iterator to the new position
 	return iterator;
@@ -958,8 +958,8 @@ PatchKernel::CellIterator PatchKernel::_addGhostCell(ElementType type, std::uniq
 		m_firstGhostCellId = id;
 	}
 
-	// Set owner
-	setGhostCellOwner(id, owner);
+	// Set ghost information
+	setGhostCellInfo(id, owner);
 
 	// Set the alteration flags of the cell
 	setAddedCellAlterationFlags(id);
@@ -1034,8 +1034,8 @@ void PatchKernel::_restoreGhostCell(const CellIterator &iterator, ElementType ty
 	cell.initialize(iterator.getId(), type, std::move(connectStorage), false, storeInterfaces, storeAdjacencies);
 	m_nGhostCells++;
 
-	// Set owner
-	setGhostCellOwner(cellId, owner);
+	// Set ghost information
+	setGhostCellInfo(cellId, owner);
 
 	// Set the alteration flags of the cell
 	setRestoredCellAlterationFlags(cellId);
@@ -1048,8 +1048,8 @@ void PatchKernel::_restoreGhostCell(const CellIterator &iterator, ElementType ty
 */
 void PatchKernel::_deleteGhostCell(long id)
 {
-	// Unset ghost owner
-	unsetGhostCellOwner(id);
+	// Unset ghost information
+	unsetGhostCellInfo(id);
 
 	// Set the alteration flags of the cell
 	setDeletedCellAlterationFlags(id);
@@ -1830,7 +1830,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningPrepare(const std::unorder
 		}
 
 		long cellId = entry.first;
-		if (m_ghostCellOwners.count(cellId) > 0) {
+		if (m_ghostCellInfo.count(cellId) > 0) {
 			continue;
 		}
 
@@ -2098,7 +2098,7 @@ std::unordered_map<long, int> PatchKernel::_partitioningAlter_evalGhostCellOwner
             int finalOwner;
             buffer >> finalOwner;
 
-            if (finalOwner != m_ghostCellOwners.at(id)) {
+            if (finalOwner != m_ghostCellInfo.at(id).owner) {
                 ghostCellOwnershipChanges[id] = finalOwner;
             }
         }
@@ -2129,7 +2129,8 @@ void PatchKernel::_partitioningAlter_applyGhostCellOwnershipChanges(int sendRank
     for (auto itr = ghostCellOwnershipChanges->begin(); itr != ghostCellOwnershipChanges->end();) {
         // Consider only ghosts previously owned by the sender
         long ghostCellId = itr->first;
-        int previousGhostCellOwner = m_ghostCellOwners.at(ghostCellId);
+        const GhostCellInfo &ghostCellInfo = m_ghostCellInfo.at(ghostCellId);
+        int previousGhostCellOwner = ghostCellInfo.owner;
         if (previousGhostCellOwner != sendRank) {
             ++itr;
             continue;
@@ -2137,7 +2138,7 @@ void PatchKernel::_partitioningAlter_applyGhostCellOwnershipChanges(int sendRank
 
         // Update ghost owner
         int finalGhostCellOwner = itr->second;
-        setGhostCellOwner(ghostCellId, finalGhostCellOwner);
+        setGhostCellInfo(ghostCellId, finalGhostCellOwner);
         itr = ghostCellOwnershipChanges->erase(itr);
     }
 }
@@ -2149,8 +2150,8 @@ void PatchKernel::_partitioningAlter_deleteGhosts()
 {
     // Delete ghost cells
     std::vector<long> cellsDeleteList;
-    cellsDeleteList.reserve(m_ghostCellOwners.size());
-    for (const auto &entry : m_ghostCellOwners) {
+    cellsDeleteList.reserve(m_ghostCellInfo.size());
+    for (const auto &entry : m_ghostCellInfo) {
         long cellId = entry.first;
         cellsDeleteList.emplace_back(cellId);
     }
@@ -2656,8 +2657,8 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                 int cellOwnerOnReceiver;
                 if (m_partitioningOutgoings.count(cellId) > 0) {
                     cellOwnerOnReceiver = m_partitioningOutgoings.at(cellId);
-                } else if (m_ghostCellOwners.count(cellId) > 0) {
-                    cellOwnerOnReceiver = m_ghostCellOwners.at(cellId);
+                } else if (m_ghostCellInfo.count(cellId) > 0) {
+                    cellOwnerOnReceiver = m_ghostCellInfo.at(cellId).owner;
                 } else {
                     cellOwnerOnReceiver = m_rank;
                 }
@@ -2790,7 +2791,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
         std::vector<long> neighIds;
 
         deleteList.clear();
-        for (const auto &entry : m_ghostCellOwners) {
+        for (const auto &entry : m_ghostCellInfo) {
             long cellId = entry.first;
             bool keep = false;
 
@@ -2800,7 +2801,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
             int nCellAdjacencies = cell.getAdjacencyCount();
             for (int i = 0; i < nCellAdjacencies; ++i) {
                 long neighId = adjacencies[i];
-                if (m_ghostCellOwners.count(neighId) > 0) {
+                if (m_ghostCellInfo.count(neighId) > 0) {
                     continue;
                 } else if (m_partitioningOutgoings.count(neighId) > 0) {
                     continue;
@@ -2816,7 +2817,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_sendCells(const std:
                 neighIds.clear();
                 findCellNeighs(cellId, &neighIds);
                 for (long neighId : neighIds) {
-                    if (m_ghostCellOwners.count(neighId) > 0) {
+                    if (m_ghostCellInfo.count(neighId) > 0) {
                         continue;
                     } else if (m_partitioningOutgoings.count(neighId) > 0) {
                         continue;
@@ -3011,7 +3012,7 @@ std::vector<adaption::Info> PatchKernel::_partitioningAlter_receiveCells(const s
         // so we need to build the list on the fly. THe list will contain ghost
         // cells (target) and their neighbours (sources).
         duplicateCellsCandidates.clear();
-        for (auto &entry : m_ghostCellOwners) {
+        for (auto &entry : m_ghostCellInfo) {
             long ghostCellId = entry.first;
 
             duplicateCellsCandidates.insert(ghostCellId);
@@ -3504,11 +3505,11 @@ void PatchKernel::_partitioningCleanup()
 */
 int PatchKernel::getCellRank(long id) const
 {
-	auto cellOwner = m_ghostCellOwners.find(id);
-	if (cellOwner == m_ghostCellOwners.end()) {
+	auto cellInfoItr = m_ghostCellInfo.find(id);
+	if (cellInfoItr == m_ghostCellInfo.end()) {
 		return m_rank;
 	} else {
-		return cellOwner->second;
+		return cellInfoItr->second.owner;
 	}
 }
 
@@ -3520,11 +3521,11 @@ int PatchKernel::getCellRank(long id) const
 */
 int PatchKernel::getCellOwner(long id) const
 {
-	auto cellOwner = m_ghostCellOwners.find(id);
-	if (cellOwner == m_ghostCellOwners.end()) {
+	auto cellInfoItr = m_ghostCellInfo.find(id);
+	if (cellInfoItr == m_ghostCellInfo.end()) {
 		return m_rank;
 	} else {
-		return cellOwner->second;
+		return cellInfoItr->second.owner;
 	}
 }
 
@@ -3536,11 +3537,11 @@ int PatchKernel::getCellOwner(long id) const
 */
 int PatchKernel::getCellHaloLayer(long id) const
 {
-	const Cell &cell = getCell(id);
-	if (cell.isInterior()) {
-		return 0;
-	} else {
+	auto cellInfoItr = m_ghostCellInfo.find(id);
+	if (cellInfoItr == m_ghostCellInfo.end()) {
 		return -1;
+	} else {
+		return cellInfoItr->second.haloLayer;
 	}
 }
 
@@ -3552,11 +3553,11 @@ int PatchKernel::getCellHaloLayer(long id) const
 */
 int PatchKernel::getVertexRank(long id) const
 {
-	auto vertexOwner = m_ghostVertexOwners.find(id);
-	if (vertexOwner == m_ghostVertexOwners.end()) {
+	auto vertexInfoItr = m_ghostVertexInfo.find(id);
+	if (vertexInfoItr == m_ghostVertexInfo.end()) {
 		return m_rank;
 	} else {
-		return vertexOwner->second;
+		return vertexInfoItr->second.owner;
 	}
 }
 
@@ -3568,11 +3569,11 @@ int PatchKernel::getVertexRank(long id) const
 */
 int PatchKernel::getVertexOwner(long id) const
 {
-	auto vertexOwner = m_ghostVertexOwners.find(id);
-	if (vertexOwner == m_ghostVertexOwners.end()) {
+	auto vertexInfoItr = m_ghostVertexInfo.find(id);
+	if (vertexInfoItr == m_ghostVertexInfo.end()) {
 		return m_rank;
 	} else {
-		return vertexOwner->second;
+		return vertexInfoItr->second.owner;
 	}
 }
 
@@ -3867,13 +3868,15 @@ const std::vector<long> & PatchKernel::getGhostExchangeSources(int rank) const
 	\param id is the id of the ghost vertex
 	\param owner is the rank of the process that owns the ghost vertex
 */
-void PatchKernel::setGhostVertexOwner(long id, int owner)
+void PatchKernel::setGhostVertexInfo(long id, int owner)
 {
-	auto ghostVertexOwnerItr = m_ghostVertexOwners.find(id);
-	if (ghostVertexOwnerItr != m_ghostVertexOwners.end()) {
-		ghostVertexOwnerItr->second = owner;
+	auto ghostVertexInfoItr = m_ghostVertexInfo.find(id);
+	if (ghostVertexInfoItr != m_ghostVertexInfo.end()) {
+		ghostVertexInfoItr->second.owner = owner;
 	} else {
-		m_ghostVertexOwners.insert({id, owner});
+		GhostVertexInfo ghostVertexInfo;
+		ghostVertexInfo.owner = owner;
+		m_ghostVertexInfo.insert({id, std::move(ghostVertexInfo)});
 	}
 
 	setPartitioningInfoDirty(true);
@@ -3884,14 +3887,14 @@ void PatchKernel::setGhostVertexOwner(long id, int owner)
 
 	\param id is the id of the ghost vertex
 */
-void PatchKernel::unsetGhostVertexOwner(long id)
+void PatchKernel::unsetGhostVertexInfo(long id)
 {
-	auto ghostVertexOwnerItr = m_ghostVertexOwners.find(id);
-	if (ghostVertexOwnerItr == m_ghostVertexOwners.end()) {
+	auto ghostVertexInfoItr = m_ghostVertexInfo.find(id);
+	if (ghostVertexInfoItr == m_ghostVertexInfo.end()) {
 		return;
 	}
 
-	m_ghostVertexOwners.erase(ghostVertexOwnerItr);
+	m_ghostVertexInfo.erase(ghostVertexInfoItr);
 
 	setPartitioningInfoDirty(true);
 }
@@ -3901,56 +3904,56 @@ void PatchKernel::unsetGhostVertexOwner(long id)
 
 	\param updateExchangeInfo if set to true exchange info will be updated
 */
-void PatchKernel::clearGhostVertexOwners()
+void PatchKernel::clearGhostVerticesInfo()
 {
-	m_ghostVertexOwners.clear();
+	m_ghostVertexInfo.clear();
 
 	setPartitioningInfoDirty(true);
 }
 
 /*!
-	Sets the owner of the specified ghost.
+	Sets the information of the specified ghost.
 
 	\param id is the id of the ghost cell
 	\param owner is the rank of the process that owns the ghost cell
 */
-void PatchKernel::setGhostCellOwner(long id, int owner)
+void PatchKernel::setGhostCellInfo(long id, int owner)
 {
-	auto ghostCellOwnerItr = m_ghostCellOwners.find(id);
-	if (ghostCellOwnerItr != m_ghostCellOwners.end()) {
-		ghostCellOwnerItr->second = owner;
+	auto ghostCellInfoItr = m_ghostCellInfo.find(id);
+	if (ghostCellInfoItr != m_ghostCellInfo.end()) {
+		ghostCellInfoItr->second.owner = owner;
 	} else {
-		m_ghostCellOwners.insert({id, owner});
+		GhostCellInfo ghostCellInfo;
+		ghostCellInfo.owner = owner;
+		m_ghostCellInfo.insert({id, std::move(ghostCellInfo)});
 	}
 
 	setPartitioningInfoDirty(true);
 }
 
 /*!
-	Unsets the owner of the specified ghost.
+	Unsets the information of the specified ghost.
 
 	\param id is the id of the ghost cell
 */
-void PatchKernel::unsetGhostCellOwner(long id)
+void PatchKernel::unsetGhostCellInfo(long id)
 {
-	auto ghostCellOwnerItr = m_ghostCellOwners.find(id);
-	if (ghostCellOwnerItr == m_ghostCellOwners.end()) {
+	auto ghostCellInfoItr = m_ghostCellInfo.find(id);
+	if (ghostCellInfoItr == m_ghostCellInfo.end()) {
 		return;
 	}
 
-	m_ghostCellOwners.erase(ghostCellOwnerItr);
+	m_ghostCellInfo.erase(ghostCellInfoItr);
 
 	setPartitioningInfoDirty(true);
 }
 
 /*!
-	Clear the owners of all the ghosts.
-
-	\param updateExchangeInfo if set to true exchange info will be updated
+	Clear the information of all the ghosts.
 */
-void PatchKernel::clearGhostCellOwners()
+void PatchKernel::clearGhostCellsInfo()
 {
-	m_ghostCellOwners.clear();
+	m_ghostCellInfo.clear();
 
 	setPartitioningInfoDirty(true);
 }
@@ -4114,7 +4117,7 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 	for (VertexConstIterator vertexItr = beginItr; vertexItr != endItr; ++vertexItr) {
 		long vertexId = vertexItr->getId();
 		int vertexOwner = exchangeVertexOwners.at(vertexId);
-		setGhostVertexOwner(vertexId, vertexOwner);
+		setGhostVertexInfo(vertexId, vertexOwner);
 	}
 
 	// Create new ghosts
@@ -4140,8 +4143,8 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 	m_ghostVertexExchangeTargets.clear();
 
 	// Update targets
-	for (const auto &entry : m_ghostVertexOwners) {
-		int ghostVertexOwner = entry.second;
+	for (const auto &entry : m_ghostVertexInfo) {
+		int ghostVertexOwner = entry.second.owner;
 		long ghostVertexId = entry.first;
 		m_ghostVertexExchangeTargets[ghostVertexOwner].push_back(ghostVertexId);
 	}
@@ -4222,7 +4225,7 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 			ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
 			for (long vertexId : cellVertexIds) {
 				// Ghost vertices are not sources.
-				if (m_ghostVertexOwners.count(vertexId) > 0) {
+				if (m_ghostVertexInfo.count(vertexId) > 0) {
 					continue;
 				}
 
@@ -4258,7 +4261,7 @@ void PatchKernel::updateGhostVertexExchangeInfo()
 			ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
 			for (long vertexId : cellVertexIds) {
 				// Ghost vertices are not sources.
-				if (m_ghostVertexOwners.count(vertexId) > 0) {
+				if (m_ghostVertexInfo.count(vertexId) > 0) {
 					continue;
 				}
 
@@ -4421,8 +4424,8 @@ void PatchKernel::updateGhostCellExchangeInfo()
 	m_ghostCellExchangeTargets.clear();
 
 	// Update targets
-	for (const auto &entry : m_ghostCellOwners) {
-		int ghostOwner = entry.second;
+	for (const auto &entry : m_ghostCellInfo) {
+		int ghostOwner = entry.second.owner;
 		long ghostCellId = entry.first;
 		m_ghostCellExchangeTargets[ghostOwner].push_back(ghostCellId);
 	}
@@ -4484,7 +4487,7 @@ std::vector<long> PatchKernel::_findGhostCellExchangeSources(int rank)
 		neighIds.clear();
 		findCellNeighs(ghostCellId, &neighIds);
 		for (long neighId : neighIds) {
-			if (m_ghostCellOwners.count(neighId) > 0) {
+			if (m_ghostCellInfo.count(neighId) > 0) {
 				continue;
 			}
 

--- a/src/patchkernel/patch_kernel_parallel.tpp
+++ b/src/patchkernel/patch_kernel_parallel.tpp
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2022 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+#if BITPIT_ENABLE_MPI==1
+
+namespace bitpit {
+
+/**
+ * Confirm that the specified halo layer is the halo layer of the given cell.
+ *
+ * The check is performed looping the neighbours and searching a negihbour that belongs
+ * to the previous layer. If that neguhbour is found, the halo layer is confirmed.
+ *
+ * \param cell is the cell that will be check
+ * \param haloLayer is the halo layer the cell supposedly belongs to
+ * \param excludeList is a list of cells that will not be considered when processing the
+ * neighbours
+ * \result Return true if the cell belongs to the specified halo layer, false otherwise.
+ */
+template<typename ExcludeList>
+bool PatchKernel::confirmCellHaloLayer(const Cell &cell, int haloLayer, const ExcludeList &excludeList) const
+{
+	// Search if a face neighbour is in the previous halo layer
+	//
+	// We first search in the face neighbours only, because its faster than
+	// searching among all the neighbours.
+	//
+	// Searching for neighbours in the previous layer works also for ghosts in
+	// the first layer, because inner cells has a layer equal to minus one.
+	const long *adjacencies = cell.getAdjacencies();
+	int nCellAdjacencies = cell.getAdjacencyCount();
+	for (int i = 0; i < nCellAdjacencies; ++i) {
+		long neighId = adjacencies[i];
+		if (excludeList.count(neighId) > 0) {
+			continue;
+		} else if (getCellHaloLayer(neighId) == (haloLayer - 1)) {
+			return true;
+		}
+	}
+
+	// Search if a generic neighbour is in the previous halo layer
+	//
+	// If we haven't found a cell in the previous layer among the face neighbours,
+	// we perform a more expensive search among all the neighbours. a search among
+	// all the neighbours.
+	//
+	// Searching for neighbours in the previous layer works also for ghosts in the
+	// first layer, because inner cells has a layer equal to minus one.
+	std::vector<long> neighIds;
+	findCellNeighs(cell.getId(), &neighIds);
+	for (long neighId : neighIds) {
+		if (excludeList.count(neighId) > 0) {
+			continue;
+		} else if (getCellHaloLayer(neighId) == (haloLayer - 1)) {
+			return true;
+		}
+	}
+
+	// There are no neighbours in the previous halo layer
+	return false;
+}
+
+}
+
+#endif

--- a/src/patchkernel/surface_skd_tree.cpp
+++ b/src/patchkernel/surface_skd_tree.cpp
@@ -732,7 +732,7 @@ long SurfaceSkdTree::findPointClosestGlobalCell(int nPoints, const std::array<do
 
         // Set cell rank
         if (cellId != Cell::NULL_ID) {
-            cellRank = patch.getCellRank(cellId);
+            cellRank = patch.getCellOwner(cellId);
         }
     }
 

--- a/src/surfunstructured/surfunstructured.cpp
+++ b/src/surfunstructured/surfunstructured.cpp
@@ -49,9 +49,11 @@ namespace bitpit {
 
 	\param communicator is the communicator to be used for exchanging data
 	among the processes
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-SurfUnstructured::SurfUnstructured(MPI_Comm communicator)
-	: SurfaceKernel(communicator, 1, true)
+SurfUnstructured::SurfUnstructured(MPI_Comm communicator, std::size_t haloSize)
+	: SurfaceKernel(communicator, haloSize, true)
 #else
 /*!
 	Creates an uninitialized serial patch.
@@ -73,9 +75,11 @@ SurfUnstructured::SurfUnstructured()
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
 	among the processes
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-SurfUnstructured::SurfUnstructured(int dimension, MPI_Comm communicator)
-	: SurfaceKernel(PatchManager::AUTOMATIC_ID, dimension, communicator, 1, true)
+SurfUnstructured::SurfUnstructured(int dimension, MPI_Comm communicator, std::size_t haloSize)
+	: SurfaceKernel(PatchManager::AUTOMATIC_ID, dimension, communicator, haloSize, true)
 #else
 /*!
 	Creates a patch.
@@ -100,9 +104,11 @@ SurfUnstructured::SurfUnstructured(int dimension)
 	\param dimension is the dimension of the patch
 	\param communicator is the communicator to be used for exchanging data
 	among the processes
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-SurfUnstructured::SurfUnstructured(int id, int dimension, MPI_Comm communicator)
-	: SurfaceKernel(id, dimension, communicator, 1, true)
+SurfUnstructured::SurfUnstructured(int id, int dimension, MPI_Comm communicator, std::size_t haloSize)
+	: SurfaceKernel(id, dimension, communicator, haloSize, true)
 #else
 /*!
 	Creates a patch.
@@ -126,9 +132,11 @@ SurfUnstructured::SurfUnstructured(int id, int dimension)
 	\param stream is the stream to read from
 	\param communicator is the communicator to be used for exchanging data
 	among the processes
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-SurfUnstructured::SurfUnstructured(std::istream &stream, MPI_Comm communicator)
-	: SurfaceKernel(communicator, 1, false)
+SurfUnstructured::SurfUnstructured(std::istream &stream, MPI_Comm communicator, std::size_t haloSize)
+	: SurfaceKernel(communicator, haloSize, false)
 #else
 /*!
 	Creates a patch restoring the patch saved in the specified stream.

--- a/src/surfunstructured/surfunstructured.hpp
+++ b/src/surfunstructured/surfunstructured.hpp
@@ -40,10 +40,10 @@ public:
 
     // Constructors
 #if BITPIT_ENABLE_MPI==1
-    SurfUnstructured(MPI_Comm communicator);
-    SurfUnstructured(int dimension, MPI_Comm communicator);
-    SurfUnstructured(int id, int dimension, MPI_Comm communicator);
-    SurfUnstructured(std::istream &stream, MPI_Comm communicator);
+    SurfUnstructured(MPI_Comm communicator, std::size_t haloSize = 1);
+    SurfUnstructured(int dimension, MPI_Comm communicator, std::size_t haloSize = 1);
+    SurfUnstructured(int id, int dimension, MPI_Comm communicator, std::size_t haloSize = 1);
+    SurfUnstructured(std::istream &stream, MPI_Comm communicator, std::size_t haloSize = 1);
 #else
     SurfUnstructured();
     SurfUnstructured(int dimension);

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1876,13 +1876,16 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 			uint64_t globalTreeId = m_tree->getGhostGlobalIdx(octantInfo.id);
 			owner = m_tree->getOwnerRank(globalTreeId);
 		}
+
+		// Cell halo layer
+		int haloLayer = m_tree->getGhostLayer(octant);
 #endif
 
 		// Add cell
 		long cellId;
 		if (!restoreStream) {
 #if BITPIT_ENABLE_MPI==1
-			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect), owner);
+			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect), owner, haloLayer);
 #else
 			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect));
 #endif
@@ -1891,7 +1894,7 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 			utils::binary::read(*restoreStream, cellId);
 
 #if BITPIT_ENABLE_MPI==1
-			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), owner, cellId);
+			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), owner, haloLayer, cellId);
 #else
 			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), cellId);
 #endif

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1869,12 +1869,12 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 
 #if BITPIT_ENABLE_MPI==1
 		// Cell owner
-		int rank;
+		int owner;
 		if (octantInfo.internal) {
-			rank = getRank();
+			owner = getRank();
 		} else {
 			uint64_t globalTreeId = m_tree->getGhostGlobalIdx(octantInfo.id);
-			rank = m_tree->getOwnerRank(globalTreeId);
+			owner = m_tree->getOwnerRank(globalTreeId);
 		}
 #endif
 
@@ -1882,7 +1882,7 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 		long cellId;
 		if (!restoreStream) {
 #if BITPIT_ENABLE_MPI==1
-			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect), rank);
+			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect), owner);
 #else
 			CellIterator cellIterator = addCell(m_cellTypeInfo->type, std::move(cellConnect));
 #endif
@@ -1891,7 +1891,7 @@ std::vector<long> VolOctree::importCells(const std::vector<OctantInfo> &octantIn
 			utils::binary::read(*restoreStream, cellId);
 
 #if BITPIT_ENABLE_MPI==1
-			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), rank, cellId);
+			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), owner, cellId);
 #else
 			restoreCell(m_cellTypeInfo->type, std::move(cellConnect), cellId);
 #endif

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -2319,7 +2319,7 @@ void VolOctree::_dump(std::ostream &stream) const
 			if (dumpedVertices.count(vertexId) == 0) {
 				utils::binary::write(stream, vertexId);
 #if BITPIT_ENABLE_MPI==1
-				utils::binary::write(stream, getVertexRank(vertexId));
+				utils::binary::write(stream, getVertexOwner(vertexId));
 #else
 				int dummyRank = 0;
 				utils::binary::write(stream, dummyRank);

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -126,10 +126,6 @@ public:
 	void setLength(double length);
 	void scale(const std::array<double, 3> &scaling, const std::array<double, 3> &center) override;
 
-#if BITPIT_ENABLE_MPI==1
-	int getCellHaloLayer(long id) const override;
-#endif
-
 protected:
 	VolOctree(const VolOctree &other);
 

--- a/src/voloctree/voloctree_parallel.cpp
+++ b/src/voloctree/voloctree_parallel.cpp
@@ -79,24 +79,6 @@ void VolOctree::setCommunicator(MPI_Comm communicator)
 }
 
 /*!
-	Gets the halo layer of the specified cell.
-
-	\param id is the id of the requested cell
-	\result The halo layer of the specified cell.
-*/
-int VolOctree::getCellHaloLayer(long id) const
-{
-	OctantInfo octantInfo = getCellOctant(id);
-	if (octantInfo.internal) {
-		return -1;
-	}
-
-	const Octant *octant = getOctantPointer(octantInfo);
-
-	return m_tree->getGhostLayer(octant);
-}
-
-/*!
 	Gets the maximum allowed size, expressed in number of layers, of the ghost
 	cells halo.
 

--- a/src/volunstructured/volunstructured.cpp
+++ b/src/volunstructured/volunstructured.cpp
@@ -50,9 +50,11 @@ namespace bitpit {
 	\param communicator is the communicator to be used for exchanging data
 	among the processes. If a null comunicator is provided, a serial patch
 	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-VolUnstructured::VolUnstructured(MPI_Comm communicator)
-	: VolumeKernel(communicator, 1, true)
+VolUnstructured::VolUnstructured(MPI_Comm communicator, std::size_t haloSize)
+	: VolumeKernel(communicator, haloSize, true)
 #else
 /*!
 	Creates an uninitialized serial patch.
@@ -75,9 +77,11 @@ VolUnstructured::VolUnstructured()
 	\param communicator is the communicator to be used for exchanging data
 	among the processes. If a null comunicator is provided, a serial patch
 	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-VolUnstructured::VolUnstructured(int dimension, MPI_Comm communicator)
-	: VolUnstructured(PatchManager::AUTOMATIC_ID, dimension, communicator)
+VolUnstructured::VolUnstructured(int dimension, MPI_Comm communicator, std::size_t haloSize)
+	: VolUnstructured(PatchManager::AUTOMATIC_ID, dimension, communicator, haloSize)
 #else
 /*!
 	Creates a patch.
@@ -103,9 +107,11 @@ VolUnstructured::VolUnstructured(int dimension)
 	\param communicator is the communicator to be used for exchanging data
 	among the processes. If a null comunicator is provided, a serial patch
 	will be created
+	\param haloSize is the size, expressed in number of layers, of the ghost
+	cells halo
 */
-VolUnstructured::VolUnstructured(int id, int dimension, MPI_Comm communicator)
-	: VolumeKernel(id, dimension, communicator, 1, true)
+VolUnstructured::VolUnstructured(int id, int dimension, MPI_Comm communicator, std::size_t haloSize)
+	: VolumeKernel(id, dimension, communicator, haloSize, true)
 #else
 /*!
 	Creates a patch.

--- a/src/volunstructured/volunstructured.hpp
+++ b/src/volunstructured/volunstructured.hpp
@@ -39,9 +39,9 @@ public:
 	using PatchKernel::locatePoint;
 
 #if BITPIT_ENABLE_MPI==1
-	VolUnstructured(MPI_Comm communicator);
-	VolUnstructured(int dimension, MPI_Comm communicator);
-	VolUnstructured(int id, int dimension, MPI_Comm communicator);
+	VolUnstructured(MPI_Comm communicator, std::size_t haloSize = 1);
+	VolUnstructured(int dimension, MPI_Comm communicator, std::size_t haloSize = 1);
+	VolUnstructured(int id, int dimension, MPI_Comm communicator, std::size_t haloSize = 1);
 #else
 	VolUnstructured();
 	VolUnstructured(int dimension);

--- a/test/integration_tests/surfunstructured/test_surfunstructured_parallel_00008.cpp
+++ b/test/integration_tests/surfunstructured/test_surfunstructured_parallel_00008.cpp
@@ -69,16 +69,16 @@ int subtest_001(int rank)
         mesh.addVertex({{5., 0., 0.00000000}}, 10);
         mesh.addVertex({{5., 1., 0.00000000}}, 11);
 
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 0,  3,  1}}), 0, 0);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 0,  2,  3}}), 0, 1);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 2,  5,  3}}), 0, 2);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 2,  4,  5}}), 0, 3);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 4,  7,  5}}), 0, 4);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 4,  6,  7}}), 0, 5);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  9,  7}}), 0, 6);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  8,  9}}), 0, 7);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 11,  9}}), 1, 8);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 10, 11}}), 1, 9);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 0,  3,  1}}), 0, -1, 0);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 0,  2,  3}}), 0, -1, 1);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 2,  5,  3}}), 0, -1, 2);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 2,  4,  5}}), 0, -1, 3);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 4,  7,  5}}), 0, -1, 4);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 4,  6,  7}}), 0, -1, 5);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  9,  7}}), 0, -1, 6);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  8,  9}}), 0, -1, 7);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 11,  9}}), 1,  0, 8);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 10, 11}}), 1,  0, 9);
     } else if (rank == 1) {
         mesh.addVertex({{3., 0., 0.00000000}},  6);
         mesh.addVertex({{3., 1., 0.00000000}},  7);
@@ -93,13 +93,13 @@ int subtest_001(int rank)
         mesh.addVertex({{8., 0., 0.00000000}}, 16);
         mesh.addVertex({{8., 1., 0.00000000}}, 17);
 
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  9,  7}}), 0,  8);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  8,  9}}), 0,  9);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 11,  9}}), 1, 10);
-        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 10, 11}}), 1, 11);
-        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{10, 12, 11, 13}}), 1, 12);
-        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{12, 14, 13, 15}}), 1, 13);
-        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{14, 16, 15, 17}}), 2, 14);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  9,  7}}),     0,  0,  8);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 6,  8,  9}}),     0,  0,  9);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 11,  9}}),     1, -1, 10);
+        mesh.addCell(ElementType::TRIANGLE, std::vector<long>({{ 8, 10, 11}}),     1, -1, 11);
+        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{10, 12, 11, 13}}), 1, -1, 12);
+        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{12, 14, 13, 15}}), 1, -1, 13);
+        mesh.addCell(ElementType::PIXEL,    std::vector<long>({{14, 16, 15, 17}}), 2,  0, 14);
     } else if (rank == 2) {
         mesh.addVertex({{ 6., 0., 0.00000000}}, 12);
         mesh.addVertex({{ 6., 1., 0.00000000}}, 13);
@@ -112,10 +112,10 @@ int subtest_001(int rank)
         mesh.addVertex({{10., 0., 0.00000000}}, 20);
         mesh.addVertex({{10., 1., 0.00000000}}, 21);
 
-        mesh.addCell(ElementType::PIXEL, std::vector<long>({{12, 14, 13, 15}}), 1, 13);
-        mesh.addCell(ElementType::PIXEL, std::vector<long>({{14, 16, 15, 17}}), 2, 14);
-        mesh.addCell(ElementType::PIXEL, std::vector<long>({{16, 18, 17, 19}}), 2, 15);
-        mesh.addCell(ElementType::PIXEL, std::vector<long>({{18, 20, 19, 21}}), 2, 16);
+        mesh.addCell(ElementType::PIXEL, std::vector<long>({{12, 14, 13, 15}}), 1,  0, 13);
+        mesh.addCell(ElementType::PIXEL, std::vector<long>({{14, 16, 15, 17}}), 2, -1, 14);
+        mesh.addCell(ElementType::PIXEL, std::vector<long>({{16, 18, 17, 19}}), 2, -1, 15);
+        mesh.addCell(ElementType::PIXEL, std::vector<long>({{18, 20, 19, 21}}), 2, -1, 16);
     }
 
     mesh.update();

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
@@ -46,7 +46,7 @@ int subtest_001(int rank, VolUnstructured *patch_2D, VolUnstructured *patch_2D_r
     // Create the patch
     log::cout() << "Creating 2D patch..." << std::endl;
 
-    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD);
+    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD, 2);
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
     patch_2D->setVertexAutoIndexing(false);
@@ -323,7 +323,7 @@ int subtest_002(int rank, VolUnstructured *patch_3D, VolUnstructured *patch_3D_r
     // Create the patch
     log::cout() << "\n\n:: 3D unstructured mesh ::\n";
 
-    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD);
+    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD, 2);
     patch_3D->getVTK().setName("unstructured_patch_3D");
 
     patch_3D->setVertexAutoIndexing(false);

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
@@ -44,9 +44,9 @@ void fillMesh(VolUnstructured *mesh)
     double heightbottom = -1.0;
     double heighttop    =  1.0;
 
-    int nr = 47;
-    int nt = 55;
-    int nh = 50;
+    int nr = 4;
+    int nt = 5;
+    int nh = 7;
 
     double deltar = (radiusout - radiusin) / double(nr);
     double deltat = (azimuthout - azimuthin) / double(nt);
@@ -112,7 +112,7 @@ int subtest_001(int rank)
     // Create the patch
     log::cout() << "Creating patch..." << std::endl;
 
-    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD));
+    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD, 3));
     if (rank == 0) {
         fillMesh(patch.get());
     }


### PR DESCRIPTION
It is now possible to build more than one layer of ghost cells.

Draft because it needs more testing.