### PR TITLE
patchkernel: fix evaluation of partitioning information

### DIFF
--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -3938,8 +3938,6 @@ bool PatchKernel::arePartitioningInfoDirty(bool global) const
 {
 	if (!isPartitioned()) {
 		return false;
-	} else if (getProcessorCount() == 1) {
-		return false;
 	}
 
 	bool partitioningInfoDirty = m_partitioningInfoDirty;
@@ -3959,8 +3957,6 @@ bool PatchKernel::arePartitioningInfoDirty(bool global) const
 void PatchKernel::setPartitioningInfoDirty(bool dirty)
 {
 	if (dirty && !isPartitioned()) {
-		return;
-	} else if (getProcessorCount() == 1) {
 		return;
 	}
 

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -208,12 +208,13 @@ bool PatchKernel::isDistributed(bool allowDirty) const
 */
 int PatchKernel::getOwner(bool allowDirty) const
 {
-	assert(allowDirty || arePartitioningInfoDirty(false));
-	if (!allowDirty || !arePartitioningInfoDirty(true)) {
-		return m_owner;
-	} else {
+	if (allowDirty) {
 		return evalOwner();
 	}
+
+	assert(!arePartitioningInfoDirty(false));
+
+	return m_owner;
 }
 
 /*!


### PR DESCRIPTION
The assert in Patchkernel::getOwner was wrong, additionally partitioning information status should be tracked also when there is only one processor.

Close #311 