### PR TITLE
voloctree: reduce visibitiy of PABLO messages

### DIFF
--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -32,6 +32,8 @@
 #include <cmath>
 #include <iostream>
 
+namespace bitpit {
+
 /*!
  * Input stream operator for class Octant. Stream cell data from memory
  * input stream to container.
@@ -40,7 +42,7 @@
  * \param[in] octant is the octant object
  * \result Returns the same input stream received in input.
  */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Octant &octant)
+IBinaryStream& operator>>(IBinaryStream &buffer, Octant &octant)
 {
     uint8_t dimensions;
     buffer >> dimensions;
@@ -56,7 +58,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Octant 
 
     buffer >> octant.m_ghost;
 
-    for(int i = 0; i < bitpit::Octant::INFO_ITEM_COUNT; ++i){
+    for(int i = 0; i < Octant::INFO_ITEM_COUNT; ++i){
         bool value;
         buffer >> value;
         octant.m_info[i] = value;
@@ -73,7 +75,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Octant 
  * \param[in] octant is the octant object
  * \result Returns the same output stream received in input.
  */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::Octant &octant)
+OBinaryStream& operator<<(OBinaryStream  &buffer, const Octant &octant)
 {
     buffer << octant.m_dim;
     buffer << octant.m_level;
@@ -84,14 +86,12 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::
 
     buffer << octant.m_ghost;
 
-    for(int i = 0; i < bitpit::Octant::INFO_ITEM_COUNT; ++i){
+    for(int i = 0; i < Octant::INFO_ITEM_COUNT; ++i){
         buffer << (bool) octant.m_info[i];
     }
 
     return buffer;
 }
-
-namespace bitpit {
 
 // =================================================================================== //
 // NAME SPACES                                                                         //

--- a/src/PABLO/Octant.hpp
+++ b/src/PABLO/Octant.hpp
@@ -37,15 +37,6 @@
 
 namespace bitpit {
 
-class Octant;
-
-}
-
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Octant& octant);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::Octant& octant);
-
-namespace bitpit {
-
 // =================================================================================== //
 // TYPEDEFS
 // =================================================================================== //
@@ -59,6 +50,14 @@ typedef std::array<uint32_t, 3>              u32array3;
 typedef std::vector<std::vector<uint32_t>>   u32vector2D;
 typedef std::vector<std::vector<uint64_t>>   u64vector2D;
 typedef std::vector<u32array3>               u32arr3vector;
+
+// =================================================================================== //
+// STREAM OPERATORS
+// =================================================================================== //
+class Octant;
+
+IBinaryStream & operator>>(IBinaryStream &buffer, Octant& octant);
+OBinaryStream & operator<<(OBinaryStream &buffer, const Octant& octant);
 
 // =================================================================================== //
 // CLASS DEFINITION                                                                    //
@@ -98,8 +97,8 @@ class Octant{
     friend class ParaTree;
     friend class Global;
 
-    friend bitpit::OBinaryStream& (::operator<<) (bitpit::OBinaryStream& buf, const Octant& octant);
-    friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream& buf, Octant& octant);
+    friend OBinaryStream& (operator<<) (OBinaryStream& buf, const Octant& octant);
+    friend IBinaryStream& (operator>>) (IBinaryStream& buf, Octant& octant);
 
 
     // =================================================================================== //

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -114,8 +114,8 @@ LoggerBuffer::~LoggerBuffer()
 LoggerBuffer::int_type LoggerBuffer::overflow(int_type character)
 {
     if (character != traits_type::eof()) {
-        // Write the charater to the buffer and then increment pptr() by
-        // calling pbump(1). It's always safe to write thecharater to the
+        // Write the character to the buffer and then increment pptr() by
+        // calling pbump(1). It's always safe to write the charater to the
         // buffer because we reserved an extra char at the end of our buffer
         // in the constructor.
         assert(std::less_equal<char *>()(pptr(), epptr()));
@@ -1095,7 +1095,7 @@ void Logger::print(const std::string &message, log::Level severity, log::Visibil
     \ingroup common_logger
     \brief Manager for the loggers.
 
-    This class implements a manager for the loggers. The manager allowes the
+    This class implements a manager for the loggers. The manager allows the
     different loggers to work together.
 */
 
@@ -1160,7 +1160,7 @@ LoggerManager & LoggerManager::manager()
     Returns an instance of default logger.
 
     The default severity of the messages will be set to the specified level,
-    if no default severity is specified, the default sevirity will remain
+    if no default severity is specified, the default severity will remain
     unaltered.
 
     The default visibility of the messages will be set to the specified level,
@@ -1183,7 +1183,7 @@ Logger & LoggerManager::cout(log::Level defaultSeverity, log::Visibility default
     does not exists a new instance will be created.
 
     The default severity of the messages will be set to the specified level,
-    if no default severity is specified, the default sevirity will remain
+    if no default severity is specified, the default severity will remain
     unaltered.
 
     The default visibility of the messages will be set to the specified level,
@@ -1530,11 +1530,11 @@ void LoggerManager::create(const std::string &name, bool reset,
 /*!
     Destroys the specified logger.
 
-    The logger can be shared among differen users, a logger is destoryed
+    The logger can be shared among different users, a logger is destroyed
     only if it has no users.
 
     \param name is the name of the logger
-    \param force controls if the logger will be destory also if it still
+    \param force controls if the logger will be destroyed also if it still
     has users
     \result True if the logger has been destroyed, false otherwise.
 */
@@ -1585,7 +1585,7 @@ bool LoggerManager::exists(const std::string &name) const
     Checks if the logger manager has been initialized.
 
     Explicit initialization of the manager is done using the function
-    'initialize', implicit initialization happnes the first time a
+    'initialize', implicit initialization happens the first time a
     logger is created.
 
     \result Returns true if the logger manager has been initialized, false
@@ -1845,7 +1845,7 @@ namespace log {
         Returns an instance of the default logger.
 
         The default severity of the messages will be set to the specified
-        level, if no default severity is specified, the default sevirity
+        level, if no default severity is specified, the default severity
         will remain unaltered.
 
         The default visibility of the messages will be set to the specified
@@ -1864,7 +1864,7 @@ namespace log {
         Returns an instance of the specified logger.
 
         The default severity of the messages will be set to the specified
-        level, if no default severity is specified, the default sevirity
+        level, if no default severity is specified, the default severity
         will remain unaltered.
 
         The default visibility of the messages will be set to the specified
@@ -2166,7 +2166,7 @@ namespace log {
     }
 
     /*!
-        Set the visibility ofthe messages.
+        Set the visibility of the messages.
 
         \param logger is a reference pointing to the logger
         \param visibility is the visibility of the messages

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -30,10 +30,12 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <functional>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <type_traits>
 
 #include "fileHandler.hpp"
 #include "logger.hpp"
@@ -50,46 +52,43 @@ namespace bitpit{
 
 /*!
     Creates a new buffer.
+
+    \param nProcesses is the total number of processes in the communicator
+    \param rank is the parallel rank in the communicator
+    \param bufferSize is the size of the internal buffer
 */
-LoggerBuffer::LoggerBuffer(std::size_t bufferSize)
-    : m_buffer(bufferSize + 1), m_context(""), m_padding(""),
-      m_consoleEnabled(false), m_consoleTimestampEnabled(false), m_console(&std::cout), m_consolePrefix(""),
-      m_fileEnabled(false), m_fileTimestampEnabled(true), m_file(nullptr), m_filePrefix("")
+LoggerBuffer::LoggerBuffer(int nProcesses, int rank, std::size_t bufferSize)
+    : m_buffer(bufferSize + 1),
+      m_nProcesses(nProcesses), m_rank(rank),
+      m_consoleEnabled(false), m_console(&std::cout),
+      m_fileEnabled(false), m_file(nullptr),
+      m_settings(std::make_shared<Settings>())
 {
     // Set the buffer
     char *bufferBegin = &m_buffer.front();
     setp(bufferBegin, bufferBegin + m_buffer.size() - 1);
 
-    // Set console data
+    // Initialize console stream
     setConsoleEnabled(true);
 
-    // Set log file data
+    // Initialize file stream
     setFileEnabled(false);
-}
 
-/*!
-    Copy constructor.
+    // Set parallel data
+    if (m_nProcesses > 1) {
+        int nDigits = ceil(log10(m_nProcesses));
+        std::ostringstream convert;
+        convert << std::setw(nDigits) << m_rank;
+        m_rankPrefix = "#" + convert.str();
+    } else {
+        m_rankPrefix = "";
+    }
 
-    \param other is another logger buffer, whose contents will be used to
-    initialize the current logger buffer
-*/
-LoggerBuffer::LoggerBuffer(const LoggerBuffer &other)
-    : std::streambuf(),
-      m_buffer(other.m_buffer),
-      m_context(other.m_context),
-      m_padding(other.m_padding),
-      m_consoleEnabled(other.m_consoleEnabled),
-      m_consoleTimestampEnabled(other.m_consoleTimestampEnabled),
-      m_console(other.m_console),
-      m_consolePrefix(other.m_consolePrefix),
-      m_fileEnabled(other.m_fileEnabled),
-      m_fileTimestampEnabled(other.m_fileTimestampEnabled),
-      m_file(other.m_file),
-      m_filePrefix(other.m_filePrefix)
-{
-    // Set the buffer
-    char *bufferBegin = &m_buffer.front();
-    setp(bufferBegin, bufferBegin + m_buffer.size() - 1);
+    // Default settings
+    m_settings->context = "";
+    m_settings->indentation = 0;
+    m_settings->consoleTimestampEnabled = false;
+    m_settings->fileTimestampEnabled = false;
 }
 
 /*!
@@ -98,6 +97,26 @@ LoggerBuffer::LoggerBuffer(const LoggerBuffer &other)
 LoggerBuffer::~LoggerBuffer()
 {
     sync();
+}
+
+/*!
+    Count the number of processes in the communicator.
+
+    \result The number of processes in the communicator.
+*/
+int LoggerBuffer::getProcessCount() const
+{
+    return m_nProcesses;
+}
+
+/*!
+    Gets the rank in the communicator.
+
+    \result The rank in the communicator.
+*/
+int LoggerBuffer::getRank() const
+{
+    return m_rank;
 }
 
 /*!
@@ -150,92 +169,129 @@ int LoggerBuffer::sync()
 */
 int LoggerBuffer::flush(bool terminate)
 {
-    int status = 0;
-    if (pptr() == pbase()) {
-        return status;
+    // Get buffer information
+    const char *bufferBegin = pbase();
+    const char *bufferEnd   = pptr();
+    if (bufferBegin == bufferEnd) {
+        return 0;
     }
 
-    // Identify line breakers
-    std::vector<char *> linePointers;
-    linePointers.push_back(pbase());
-    for (char *p = pbase(), *e = pptr() - 1; p != e; ++p) {
-        if (*p == '\n') {
-            linePointers.push_back(p + 1);
+    // Flush buffer a line at the time
+    const char *lineBegin = nullptr;
+    const char *lineEnd   = bufferBegin;
+    while (lineEnd != bufferEnd) {
+        // Update line information
+        lineBegin = lineEnd;
+        for (lineEnd = lineBegin; lineEnd != bufferEnd; ++lineEnd) {
+            if (*lineEnd == '\n') {
+                lineEnd += 1;
+                break;
+            }
         }
-    }
-    linePointers.push_back(pptr());
 
-    // Detect if a new line must be added at the end
-    terminate = (terminate && *(linePointers.back() - 1) != '\n');
+        // Detect if a new line must be added at the end of the line
+        bool terminateLine = false;
+        if (terminate && (lineEnd == bufferEnd)) {
+            if (bufferBegin == bufferEnd) {
+                terminateLine = true;
+            } else if (*(bufferEnd - 1) != '\n') {
+                terminateLine = true;
+            }
+        }
 
-    // Move the internal pointer
-    std::ptrdiff_t nCharacters = pptr() - pbase();
-    pbump(- nCharacters);
+        // Get timestamp
+        std::string consoleTimestamp;
+        std::string fileTimestamp;
+        if (m_settings->consoleTimestampEnabled || m_settings->fileTimestampEnabled) {
+            std::string timestamp = getTimestamp();
+            if (m_settings->consoleTimestampEnabled) {
+                consoleTimestamp = timestamp;
+            }
+            if (m_settings->fileTimestampEnabled) {
+                fileTimestamp = timestamp;
+            }
+        }
 
-    // Write all lines
-    for (unsigned int i = 0; i < linePointers.size() - 1; ++i) {
-        char *firstCharacter = linePointers[i];
-        char *lastCharacter  = linePointers[i + 1];
-        std::ptrdiff_t lineSize = lastCharacter - firstCharacter;
-
-        // Write to the console
+        // Flush line to console
         if (m_console && m_consoleEnabled) {
-            if (m_consoleTimestampEnabled) {
-                *m_console << "[" + getTimestamp() + "] ";
-            }
-
-            if (!m_consolePrefix.empty()) {
-                *m_console << m_consolePrefix << " :: ";
-            }
-
-            if (!m_context.empty()) {
-                *m_console << m_context << " :: ";
-            }
-
-            if (!m_padding.empty()) {
-                *m_console << m_padding;
-            }
-
-            m_console->write(firstCharacter, lineSize);
-            if ((m_console->rdstate() & std::ifstream::failbit ) != 0) {
-                status = -1;
-            }
-
-            if (terminate && lastCharacter == linePointers.back()) {
-                *m_console << "\n";
+            int status = flushLine(*m_console, lineBegin, lineEnd, consoleTimestamp, terminateLine);
+            if (status != 0) {
+                return status;
             }
         }
 
-        // Write to file
+        // Flush line to file
         if (m_file && m_fileEnabled && m_file->is_open()) {
-            if (m_fileTimestampEnabled) {
-                *m_file << "[" + getTimestamp() + "] ";
-            }
-
-            if (!m_filePrefix.empty()) {
-                *m_file << m_filePrefix << " :: ";
-            }
-
-            if (!m_context.empty()) {
-                *m_file << m_context + " :: ";
-            }
-
-            if (!m_padding.empty()) {
-                *m_file << m_padding;
-            }
-
-            m_file->write(firstCharacter, lineSize);
-            if ((m_file->rdstate() & std::ifstream::failbit ) != 0) {
-                status = -1;
-            }
-
-            if (terminate && lastCharacter == linePointers.back()) {
-                *m_file << "\n";
+            int status = flushLine(*m_file, lineBegin, lineEnd, fileTimestamp, terminateLine);
+            if (status != 0) {
+                return status;
             }
         }
     }
 
-    return status;
+    // Reset the internal pointer
+    pbump(bufferBegin - bufferEnd);
+
+    return 0;
+}
+
+/*!
+    Flushes stream buffer.
+
+    \param stream is the steam the line will be flushed to
+    \param begin refers to the first character of the line
+    \param end refers to the past-the-last character of the line
+    \param timestamp if the timestamp that will be printed at the beginning
+    of the line, if an empty string is provided, no timestamp information
+    will be printed
+    \param terminate if set to true a new line character will be printed at
+    \the end of the line
+    \return Returns 0 to indicates success, -1 to indicate failure.
+*/
+int LoggerBuffer::flushLine(std::ostream &stream, const char *begin, const char *end,
+                            const std::string &timestamp, bool terminate)
+{
+    if (!timestamp.empty()) {
+        stream << "[" + timestamp + "] ";
+        if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+            return -1;
+        }
+    }
+
+    if (!m_rankPrefix.empty()) {
+        stream << m_rankPrefix << " :: ";
+        if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+            return -1;
+        }
+    }
+
+    if (!m_settings->context.empty()) {
+        stream << m_settings->context + " :: ";
+        if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+            return -1;
+        }
+    }
+
+    for (int i = 0; i < m_settings->indentation; ++i) {
+        stream << " ";
+        if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+            return -1;
+        }
+    }
+
+    stream.write(begin, end - begin);
+    if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+        return -1;
+    }
+
+    if (terminate) {
+        stream << "\n";
+        if ((stream.rdstate() & std::ifstream::failbit) != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 /*!
@@ -252,27 +308,6 @@ void LoggerBuffer::setConsoleEnabled(bool enabled)
     flush(true);
 
     m_consoleEnabled = enabled;
-}
-
-/*!
-    Returns true if the timestamp is enabled on the console, false otherwise.
-
-    \result Returns true if the timestamp is enabled on the console, false
-    otherwise.
-*/
-bool LoggerBuffer::isConsoleTimestampEnabled() const
-{
-    return m_consoleTimestampEnabled;
-}
-
-/*!
-    Enables the timestamp on the console.
-
-    \param enabled if set to true enables the timestamp on the console.
-*/
-void LoggerBuffer::setConsoleTimestampEnabled(bool enabled)
-{
-    m_consoleTimestampEnabled = enabled;
 }
 
 /*!
@@ -298,29 +333,6 @@ std::ostream & LoggerBuffer::getConsoleStream()
 }
 
 /*!
-    Sets the prefix for console output.
-
-    \param prefix is the prefix that will be prepended to every line of the
-    console output
-*/
-void LoggerBuffer::setConsolePrefix(const std::string &prefix)
-{
-    flush(true);
-
-    m_consolePrefix = prefix;
-}
-
-/*!
-    Gets the prefix for console output.
-
-    \result The prefix for console output.
-*/
-std::string LoggerBuffer::getConsolePrefix() const
-{
-    return m_consolePrefix;
-}
-
-/*!
     Enables the output on the log file.
 
     The output on the log file can be enabled only id the log file path has
@@ -338,27 +350,6 @@ void LoggerBuffer::setFileEnabled(bool enabled)
     flush(true);
 
     m_fileEnabled = enabled;
-}
-
-/*!
-    Returns true if the timestamp is enabled on the log file, false otherwise.
-
-    \result Returns true if the timestamp is enabled on the log file, false
-    otherwise.
-*/
-bool LoggerBuffer::isFileTimestampEnabled() const
-{
-    return m_fileTimestampEnabled;
-}
-
-/*!
-    Enables the timestamp on the log file.
-
-    \param enabled if set to true enables the timestamp on the log file
-*/
-void LoggerBuffer::setFileTimestampEnabled(bool enabled)
-{
-    m_fileTimestampEnabled = enabled;
 }
 
 /*!
@@ -384,57 +375,38 @@ std::ofstream & LoggerBuffer::getFileStream()
 }
 
 /*!
-    Sets the prefix for file output.
+    Get a constant pointer to the buffer settings.
 
-    \param prefix is the prefix that will be prepended to every line of the
-    file output
+    \result A constant pointer to the buffer settings.
 */
-void LoggerBuffer::setFilePrefix(const std::string &prefix)
+const LoggerBuffer::Settings * LoggerBuffer::getSettings() const
 {
+    return m_settings.get();
+}
+
+/*!
+    Sets buffer settings.
+
+    \param settings are the buffer settings
+*/
+void LoggerBuffer::setSettings(const std::shared_ptr<Settings> &settings)
+{
+    if (settings.get() == m_settings.get()) {
+        return;
+    }
+
     flush(true);
 
-    m_filePrefix = prefix;
+    m_settings = settings;
 }
 
 /*!
-    Gets the prefix for file output.
-
-    \result The prefix for file output.
+    Get current date/time, format is "YYYY-MM-DD HH:mm:ss".
 */
-std::string LoggerBuffer::getFilePrefix() const
+std::string LoggerBuffer::getTimestamp() const
 {
-    return m_filePrefix;
-}
+    static const std::string TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S";
 
-/*!
-    Sets the context of the output.
-
-    \param context is the context of the output
-*/
-void LoggerBuffer::setContext(const std::string &context)
-{
-    flush(true);
-
-    m_context = context;
-}
-
-/*!
-    Sets the padding to be prepended befor every message.
-
-    \param padding is the padding to be prepended befor every message
-*/
-void LoggerBuffer::setPadding(const std::string &padding)
-{
-    flush(true);
-
-    m_padding = padding;
-}
-
-/*!
-    Get current date/time, format is "YYYY-MM-DD.HH:mm:ss".
-*/
-const std::string LoggerBuffer::getTimestamp() const
-{
     auto currentClock = std::chrono::system_clock::now();
     std::time_t currentTime = std::chrono::system_clock::to_time_t(currentClock);
 
@@ -443,9 +415,9 @@ const std::string LoggerBuffer::getTimestamp() const
     std::ostringstream millisecsConverter;
     millisecsConverter << (millisecs.count());
 
-    char buffer[80];
-    strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", localtime(&currentTime));
-    std::string timestamp(buffer);
+    std::string timestamp;
+    timestamp.resize(TIMESTAMP_FORMAT.size());
+    strftime(&timestamp[0], timestamp.size(), TIMESTAMP_FORMAT.c_str(), localtime(&currentTime));
     timestamp += "." + millisecsConverter.str();
 
     return timestamp;
@@ -466,103 +438,22 @@ const std::string LoggerBuffer::getTimestamp() const
 
     The constructor is private so that it can not be called.
 */
-Logger::Logger(const std::string &name,
-               std::ostream *consoleStream, std::ofstream *fileStream,
-               int nProcesses, int rank)
-    : std::ios(nullptr), std::ostream(&m_buffer),
-      m_name(name), m_nProcesses(nProcesses), m_rank(rank), m_buffer(256),
-      m_indentation(0), m_context(""),
+Logger::Logger(const std::string &name, const std::shared_ptr<LoggerBuffer> &buffer)
+    : std::ios(nullptr), std::ostream(nullptr),
+      m_name(name),
+      m_buffer(buffer), m_bufferSettings(std::make_shared<LoggerBuffer::Settings>()),
       m_defaultSeverity(log::INFO), m_defaultVisibility(log::VISIBILITY_MASTER),
       m_consoleDisabledThreshold(log::NOTSET), m_consoleVerbosityThreshold(log::INFO),
       m_fileDisabledThreshold(log::NOTSET), m_fileVerbosityThreshold(log::INFO)
 {
-    // Set buffer data
-    setConsoleStream(consoleStream);
-    setFileStream(fileStream);
+    // St stream buffer
+    basic_ios<char>::rdbuf(m_buffer.get());
 
-    // Set parallel data
-    if (m_nProcesses > 1) {
-        int nDigits = ceil(log10(m_nProcesses));
-        std::ostringstream convert;
-        convert << std::setw(nDigits) << m_rank;
-        std::string rankPrefix = "#" + convert.str();
-
-        m_buffer.setConsolePrefix(rankPrefix);
-        m_buffer.setFilePrefix(rankPrefix);
-    } else {
-        m_buffer.setConsolePrefix("");
-        m_buffer.setFilePrefix("");
-    }
-
-    // Set default logger properties
-    setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
-    setFileEnabled(m_defaultSeverity, m_defaultVisibility);
-}
-
-/*!
-    Copy constructor.
-
-    \param other is another logger, whose configuration will be used to
-    initialize the current logger
-*/
-Logger::Logger(const Logger &other)
-    : std::ios(nullptr), std::ostream(&m_buffer),
-      m_name(other.m_name),
-      m_nProcesses(other.m_nProcesses), m_rank(other.m_rank),
-      m_buffer(other.m_buffer),
-      m_indentation(other.m_indentation), m_context(other.m_context),
-      m_defaultSeverity(other.m_defaultSeverity), m_defaultVisibility(other.m_defaultVisibility),
-      m_consoleDisabledThreshold(other.m_consoleDisabledThreshold),
-      m_consoleVerbosityThreshold(other.m_consoleVerbosityThreshold),
-      m_fileDisabledThreshold(other.m_fileDisabledThreshold),
-      m_fileVerbosityThreshold(other.m_fileVerbosityThreshold)
-{
-    // Copy buffer properties
-    copyfmt(other);
-    exceptions(other.exceptions());
-    clear(other.rdstate());
-    basic_ios<char>::rdbuf(other.rdbuf());
-}
-
-/*!
-    Sets the stream to be used for the output on the console.
-
-    \param console is the stream to be used for the output on the console
-*/
-void Logger::setConsoleStream(std::ostream *console)
-{
-    m_buffer.setConsoleStream(console);
-}
-
-/*!
-    Gets the stream to be used for the output on the console.
-
-    \result The stream to be used for the output on the console.
-*/
-std::ostream & Logger::getConsoleStream()
-{
-    return m_buffer.getConsoleStream();
-}
-
-/*!
-    Sets the stream to be used for the output on the file.
-
-    \param file is the stream to be used for the output on the file
-*/
-void Logger::setFileStream(std::ofstream *file)
-{
-    m_buffer.setFileStream(file);
-}
-
-
-/*!
-    Gets the stream to be used for the output on the file.
-
-    \result The stream to be used for the output on the file.
-*/
-std::ofstream & Logger::getFileStream()
-{
-    return m_buffer.getFileStream();
+    // Default settings
+    m_bufferSettings->context = "";
+    m_bufferSettings->indentation = 0;
+    m_bufferSettings->consoleTimestampEnabled = false;
+    m_bufferSettings->fileTimestampEnabled = true;
 }
 
 /*!
@@ -642,10 +533,6 @@ void Logger::setDefaultSeverity(log::Level severity)
     // Set default severity
     assert(severity != log::Level::NOTSET);
     m_defaultSeverity = severity;
-
-    // Set default logger properties
-    setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
-    setFileEnabled(m_defaultSeverity, m_defaultVisibility);
 }
 
 /*!
@@ -688,10 +575,6 @@ void Logger::setDefaultVisibility(log::Visibility visibility)
     // Set default visibility
     assert(visibility != log::VISIBILITY_NOTSET);
     m_defaultVisibility = visibility;
-
-    // Set default logger properties
-    setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
-    setFileEnabled(m_defaultSeverity, m_defaultVisibility);
 }
 
 /*!
@@ -760,7 +643,7 @@ void Logger::setTimestampEnabled(bool enabled)
 */
 bool Logger::isConsoleTimestampEnabled() const
 {
-    return m_buffer.isConsoleTimestampEnabled();
+    return m_bufferSettings->consoleTimestampEnabled;
 }
 
 /*!
@@ -770,7 +653,13 @@ bool Logger::isConsoleTimestampEnabled() const
 */
 void Logger::setConsoleTimestampEnabled(bool enabled)
 {
-    m_buffer.setConsoleTimestampEnabled(enabled);
+    if (m_bufferSettings->consoleTimestampEnabled == enabled) {
+        return;
+    }
+
+    m_buffer->flush(true);
+
+    m_bufferSettings->consoleTimestampEnabled = enabled;
 }
 
 /*!
@@ -786,28 +675,37 @@ void Logger::setConsoleVerbosity(log::Level threshold)
 {
     // Set verbosity threshold
     m_consoleVerbosityThreshold = threshold;
-
-    // Set default logger properties
-    setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
 }
 
 /*!
-    Enable or disable console logging.
+    Enable the buffer streams that will print a message with the specified properties.
 
     \param severity is the severity of the message to be printed
     \param visibility is the visibility of the message to be printed
 */
-void Logger::setConsoleEnabled(log::Level severity, log::Visibility visibility)
+void Logger::enableBufferStreams(log::Level severity, log::Visibility visibility)
 {
+    // Enable console stream
     bool isConsoleEnabled = true;
     if (severity <= m_consoleDisabledThreshold) {
         isConsoleEnabled = false;
-    } else if (visibility == log::VISIBILITY_MASTER && (m_rank != 0)) {
+    } else if (visibility == log::VISIBILITY_MASTER && (m_buffer->getRank() != 0)) {
         isConsoleEnabled = false;
     } else {
         isConsoleEnabled = (severity >= m_consoleVerbosityThreshold);
     }
-    m_buffer.setConsoleEnabled(isConsoleEnabled);
+    m_buffer->setConsoleEnabled(isConsoleEnabled);
+
+    // Enable file stream
+    bool isFileEnabled = true;
+    if (severity <= m_fileDisabledThreshold) {
+        isFileEnabled = false;
+    } else if (visibility == log::VISIBILITY_MASTER && (m_buffer->getRank() != 0)) {
+        isFileEnabled = false;
+    } else {
+        isFileEnabled = (severity >= m_fileVerbosityThreshold);
+    }
+    m_buffer->setFileEnabled(isFileEnabled);
 }
 
 /*!
@@ -825,16 +723,6 @@ log::Level Logger::getConsoleVerbosity()
 }
 
 /*!
-    Gets the prefix for the messages printed on the console.
-
-    \result The prefix for the messages printed on the console.
-*/
-std::string Logger::getConsolePrefix()
-{
-    return m_buffer.getConsolePrefix();
-}
-
-/*!
     Returns true if the timestamp is enabled on the log file, false otherwise.
 
     \result Returns true if the timestamp is enabled on the log file, false
@@ -842,7 +730,7 @@ std::string Logger::getConsolePrefix()
 */
 bool Logger::isFileTimestampEnabled() const
 {
-    return m_buffer.isFileTimestampEnabled();
+    return m_bufferSettings->fileTimestampEnabled;
 }
 
 /*!
@@ -852,7 +740,13 @@ bool Logger::isFileTimestampEnabled() const
 */
 void Logger::setFileTimestampEnabled(bool enabled)
 {
-    m_buffer.setFileTimestampEnabled(enabled);
+    if (m_bufferSettings->fileTimestampEnabled == enabled) {
+        return;
+    }
+
+    m_buffer->flush(true);
+
+    m_bufferSettings->fileTimestampEnabled = enabled;
 }
 
 /*!
@@ -868,9 +762,6 @@ void Logger::setFileVerbosity(log::Level threshold)
 {
     // Set verbosity threshold
     m_fileVerbosityThreshold = threshold;
-
-    // Set default logger properties
-    setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
 }
 
 /*!
@@ -886,44 +777,19 @@ log::Level Logger::getFileVerbosity()
 }
 
 /*!
-    Enable or disable file logging.
-
-    \param severity is the severity of the message to be printed
-    \param visibility is the visibility of the message to be printed
-*/
-void Logger::setFileEnabled(log::Level severity, log::Visibility visibility)
-{
-    bool isFileEnabled = true;
-    if (severity <= m_fileDisabledThreshold) {
-        isFileEnabled = false;
-    } else if (visibility == log::VISIBILITY_MASTER && (m_rank != 0)) {
-        isFileEnabled = false;
-    } else {
-        isFileEnabled = (severity >= m_fileVerbosityThreshold);
-    }
-    m_buffer.setFileEnabled(isFileEnabled);
-}
-
-/*!
-    Gets the prefix for the messages printed on the log file.
-
-    \result The prefix for the messages printed on the log file.
-*/
-std::string Logger::getFilePrefix()
-{
-    return m_buffer.getFilePrefix();
-}
-
-/*!
     Sets the context used when printing the messages.
 
     \param context is the context used when printing the messages.
 */
 void Logger::setContext(const std::string &context)
 {
-    m_context = context;
+    if (m_bufferSettings->context == context) {
+        return;
+    }
 
-    m_buffer.setContext(m_context);
+    m_buffer->flush(true);
+
+    m_bufferSettings->context = context;
 }
 
 /*!
@@ -933,7 +799,7 @@ void Logger::setContext(const std::string &context)
 */
 std::string Logger::getContext()
 {
-    return m_context;
+    return m_bufferSettings->context;
 }
 
 /*!
@@ -943,10 +809,13 @@ std::string Logger::getContext()
 */
 void Logger::setIndentation(int delta)
 {
-    m_indentation = std::max(m_indentation + delta, 0);
+    if (delta == 0) {
+        return;
+    }
 
-    std::string padding = std::string(m_indentation, ' ');
-    m_buffer.setPadding(padding);
+    m_buffer->flush(true);
+
+    m_bufferSettings->indentation += delta;
 }
 
 /*!
@@ -956,27 +825,7 @@ void Logger::setIndentation(int delta)
 */
 int Logger::getIndentation()
 {
-    return m_indentation;
-}
-
-/*!
-    Count the nuomber of processes in the communicator.
-
-    \result The number of processes in the communicator.
-*/
-int Logger::getProcessorCount()
-{
-    return m_nProcesses;
-}
-
-/*!
-    Gets the rank in the communicator.
-
-    \result The rank in the communicator.
-*/
-int Logger::getRank()
-{
-    return m_rank;
+    return m_bufferSettings->indentation;
 }
 
 /*!
@@ -1040,7 +889,7 @@ void Logger::println(const std::string &line, log::Level severity, log::Visibili
 */
 void Logger::print(const std::string &message)
 {
-    (*this) << message;
+    print(message, getDefaultSeverity(), getDefaultVisibility());
 }
 
 /*!
@@ -1074,20 +923,7 @@ void Logger::print(const std::string &message, log::Visibility visibility)
 */
 void Logger::print(const std::string &message, log::Level severity, log::Visibility visibility)
 {
-    // Set logger properties for the message that need to be printed
-    if (severity != m_defaultSeverity || visibility != m_defaultVisibility) {
-        setConsoleEnabled(severity, visibility);
-        setFileEnabled(severity, visibility);
-    }
-
-    // Print the line
-    (*this) << message;
-
-    // Reset default logger properties
-    if (severity != m_defaultSeverity || visibility != m_defaultVisibility) {
-        setConsoleEnabled(m_defaultSeverity, m_defaultVisibility);
-        setFileEnabled(m_defaultSeverity, m_defaultVisibility);
-    }
+    print<const std::string &>(message, severity, visibility);
 }
 
 /*!
@@ -1523,7 +1359,8 @@ void LoggerManager::create(const std::string &name, bool reset,
     if (m_mode == log::MODE_SEPARATE) {
         _create(name, reset, directory, nProcesses, rank);
     } else {
-        _create(name, cout(m_defaultName));
+        Logger &defaultLogger = cout(m_defaultName);
+        _create(name, defaultLogger.m_buffer);
     }
 }
 
@@ -1672,21 +1509,24 @@ void LoggerManager::_create(const std::string &name, bool reset,
     // Use cout as console stream
     std::ostream &consoleStream = std::cout;
 
+    // Create the buffer
+    std::shared_ptr<LoggerBuffer> buffer = std::make_shared<LoggerBuffer>(nProcesses, rank, 256);
+    buffer->setFileStream(&fileStream);
+    buffer->setConsoleStream(&consoleStream);
+
     // Create the logger
-    m_loggers[name]     = std::unique_ptr<Logger>(new Logger(name, &consoleStream, &fileStream, nProcesses, rank));
-    m_loggerUsers[name] = 1;
+    _create(name, buffer);
 }
 
 /*!
     Internal function to create a logger.
 
     \param name is the name for the logger
-    \param master is a reference to the logger from which the settings will
-    be copied from
+    \param buffer is the buffer that will be used for the logger
 */
-void LoggerManager::_create(const std::string &name, Logger &master)
+void LoggerManager::_create(const std::string &name, std::shared_ptr<LoggerBuffer> &buffer)
 {
-    m_loggers[name]     = std::unique_ptr<Logger>(new Logger(master));
+    m_loggers[name]     = std::unique_ptr<Logger>(new Logger(name,  buffer));
     m_loggerUsers[name] = 1;
 }
 

--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -137,7 +137,7 @@ friend class LoggerManager;
 public:
     Logger(const std::string &name,
            std::ostream *consoleStream, std::ofstream *fileStream,
-           int nProcessors = 1, int rank = 0);
+           int nProcesses = 1, int rank = 0);
 
     int getProcessorCount();
     int getRank();
@@ -197,7 +197,7 @@ public:
 
 private:
     std::string m_name;
-    int m_nProcessors;
+    int m_nProcesses;
     int m_rank;
     LoggerBuffer m_buffer;
 
@@ -251,21 +251,21 @@ public:
     Logger & debug(const std::string &name, log::Visibility visibility = log::VISIBILITY_NOTSET);
 
     void initialize(log::Mode mode, bool reset,
-                    int nProcessors, int rank);
+                    int nProcesses, int rank);
 
     void initialize(log::Mode mode, bool reset = false,
                     const std::string &directory = BITPIT_LOG_DIRECTORY,
-                    int nProcessors = 1, int rank = 0);
+                    int nProcesses = 1, int rank = 0);
 
     void initialize(log::Mode mode, const std::string &name,
                     bool reset = false, const std::string &directory = BITPIT_LOG_DIRECTORY,
-                    int nProcessors = 1, int rank = 0);
+                    int nProcesses = 1, int rank = 0);
 
     void create(const std::string &name, bool reset = false,
-                int nProcessors = 1, int rank = 0);
+                int nProcesses = 1, int rank = 0);
 
     void create(const std::string &name, bool reset, const std::string &directory,
-                int nProcessors = 1, int rank = 0);
+                int nProcesses = 1, int rank = 0);
 
     bool destroy(const std::string &name, bool force = false);
 
@@ -300,7 +300,7 @@ private:
     LoggerManager& operator=(LoggerManager const&) = delete;
 
     void _create(const std::string &name, bool reset, const std::string &directory,
-                int nProcessors, int rank);
+                int nProcesses, int rank);
     void _create(const std::string &name, Logger &master);
 
 };

--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -299,12 +299,10 @@ private:
     LoggerManager(LoggerManager const&) = delete;
     LoggerManager& operator=(LoggerManager const&) = delete;
 
-    void _create(const std::string &name, bool reset, const std::string &directory,
-                int nProcesses, int rank);
+    void _create(const std::string &name, bool reset, const std::string &directory, int nProcesses, int rank);
     void _create(const std::string &name, Logger &master);
 
 };
-
 
 /*!
     \ingroup common_logger

--- a/src/communications/communications_buffers.hpp
+++ b/src/communications/communications_buffers.hpp
@@ -35,12 +35,6 @@ namespace bitpit{
     class RecvBuffer;
 };
 
-template<typename T>
-bitpit::SendBuffer & operator<<(bitpit::SendBuffer &buffer, const T &value);
-
-template<typename T>
-bitpit::RecvBuffer & operator>>(bitpit::RecvBuffer &buffer, T &value);
-
 // Declaration of the communications buffers
 namespace bitpit {
 
@@ -48,6 +42,12 @@ class DataCommunicator;
 
 typedef OBinaryStream RawSendBuffer;
 typedef IBinaryStream RawRecvBuffer;
+
+template<typename T>
+SendBuffer & operator<<(SendBuffer &buffer, const T &value);
+
+template<typename T>
+RecvBuffer & operator>>(RecvBuffer &buffer, T &value);
 
 /*!
     \ingroup communications
@@ -92,7 +92,7 @@ class SendBuffer : public CommunicationBuffer<RawSendBuffer>
     friend DataCommunicator;
 
     template<typename T>
-    friend SendBuffer & (::operator<<) (SendBuffer &buffer, const T &value);
+    friend SendBuffer & (operator<<) (SendBuffer &buffer, const T &value);
 
 public:
     SendBuffer(size_t size = 0, bool doubleBuffer = false);
@@ -108,7 +108,7 @@ class RecvBuffer : public CommunicationBuffer<RawRecvBuffer>
     friend DataCommunicator;
 
     template<typename T>
-    friend RecvBuffer & (::operator>>) (RecvBuffer &buffer, T &value);
+    friend RecvBuffer & (operator>>) (RecvBuffer &buffer, T &value);
 
 public:
     RecvBuffer(size_t size = 0, bool doubleBuffer = false);

--- a/src/communications/communications_buffers.tpp
+++ b/src/communications/communications_buffers.tpp
@@ -28,6 +28,36 @@
 namespace bitpit {
 
 /*!
+    Output stream operator for the send buffer.
+
+    \param[in] buffer is the send buffer
+    \param[in] value is the value to be streamed
+    \result A reference of the buffer.
+*/
+template<typename T>
+bitpit::SendBuffer & operator<<(bitpit::SendBuffer &buffer, const T &value)
+{
+    buffer.getFront() << value;
+
+    return buffer;
+}
+
+/*!
+    Input stream operator for the receive buffer.
+
+    \param[in] buffer is the send buffer
+    \param[in] value is the value to be streamed
+    \result A reference of the buffer.
+*/
+template<typename T>
+bitpit::RecvBuffer & operator>>(bitpit::RecvBuffer &buffer, T &value)
+{
+    buffer.getFront() >> value;
+
+    return buffer;
+}
+
+/*!
     Create a new communication buffer
  */
 template<typename RawBufferType>
@@ -151,36 +181,6 @@ const std::vector<RawBufferType> & CommunicationBuffer<RawBufferType>::getBuffer
     return m_buffers;
 }
 
-}
-
-/*!
-    Output stream operator for the send buffer.
-
-    \param[in] buffer is the send buffer
-    \param[in] value is the value to be streamed
-    \result A reference of the buffer.
-*/
-template<typename T>
-bitpit::SendBuffer & operator<<(bitpit::SendBuffer &buffer, const T &value)
-{
-    buffer.getFront() << value;
-
-    return buffer;
-}
-
-/*!
-    Input stream operator for the receive buffer.
-
-    \param[in] buffer is the send buffer
-    \param[in] value is the value to be streamed
-    \result A reference of the buffer.
-*/
-template<typename T>
-bitpit::RecvBuffer & operator>>(bitpit::RecvBuffer &buffer, T &value)
-{
-    buffer.getFront() >> value;
-
-    return buffer;
 }
 
 # endif

--- a/src/containers/binary_stream.cpp
+++ b/src/containers/binary_stream.cpp
@@ -28,6 +28,8 @@
 
 #include "binary_stream.hpp"
 
+namespace bitpit {
+
 /*!
 * Stream a string from the binary stream.
 *
@@ -67,8 +69,6 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::stri
 
     return stream;
 }
-
-namespace bitpit {
 
 /*!
 * \class BinaryStream

--- a/src/containers/binary_stream.hpp
+++ b/src/containers/binary_stream.hpp
@@ -32,36 +32,31 @@
 #include <iostream>
 #include <stdexcept>
 
-// Forward declarations
 namespace bitpit {
 
+// Stream operators
 class IBinaryStream;
 class OBinaryStream;
 
-};
-
-// Stream operators
 template<typename T>
-bitpit::IBinaryStream & operator>>(bitpit::IBinaryStream &stream, T &value);
+IBinaryStream & operator>>(IBinaryStream &stream, T &value);
 
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::vector<T> &vector);
+IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &vector);
 
 template<>
-bitpit::IBinaryStream & operator>>(bitpit::IBinaryStream &stream, std::string &value);
+IBinaryStream & operator>>(IBinaryStream &stream, std::string &value);
 
 template<typename T>
-bitpit::OBinaryStream & operator<<(bitpit::OBinaryStream &stream, const T &value);
+OBinaryStream & operator<<(OBinaryStream &stream, const T &value);
 
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::vector<T> &vector);
+OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &vector);
 
 template<>
-bitpit::OBinaryStream & operator<<(bitpit::OBinaryStream &stream, const std::string &value);
+OBinaryStream & operator<<(OBinaryStream &stream, const std::string &value);
 
 // Binary stream
-namespace bitpit{
-
 class BinaryStream {
 
 public:
@@ -107,7 +102,7 @@ private:
 class IBinaryStream : public BinaryStream {
 
 template<typename T>
-friend IBinaryStream & (::operator>>)(IBinaryStream &stream, T &value);
+friend IBinaryStream & (operator>>)(IBinaryStream &stream, T &value);
 
 public:
     IBinaryStream(void);
@@ -125,7 +120,7 @@ public:
 class OBinaryStream : public BinaryStream {
 
 template<typename T>
-friend OBinaryStream & (::operator<<)(OBinaryStream &stream, const T &value);
+friend OBinaryStream & (operator<<)(OBinaryStream &stream, const T &value);
 
 public:
     OBinaryStream();

--- a/src/containers/binary_stream.tpp
+++ b/src/containers/binary_stream.tpp
@@ -22,6 +22,8 @@
  *
 \*---------------------------------------------------------------------------*/
 
+namespace bitpit {
+
 /*!
 * Read the specified value from the stream.
 *
@@ -30,7 +32,7 @@
 * \result Returns the updated input stream.
 */
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, T &value)
+IBinaryStream& operator>>(IBinaryStream &stream, T &value)
 {
     stream.read(reinterpret_cast<char *>(&value), sizeof(T));
 
@@ -48,7 +50,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, T &value)
 * \result Returns the updated input stream.
 */
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::vector<T> &vector)
+IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &vector)
 {
     std::size_t size;
     stream.read(reinterpret_cast<char *>(&size), sizeof(size));
@@ -67,7 +69,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::vector<T> 
 * \result Returns the updated output stream.
 */
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const T &value)
+OBinaryStream& operator<<(OBinaryStream &stream, const T &value)
 {
     stream.write(reinterpret_cast<const char *>(&value), sizeof(T));
 
@@ -84,7 +86,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const T &value)
 * \result Returns the updated output stream.
 */
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::vector<T> &vector)
+OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &vector)
 {
     std::size_t size = vector.size();
     stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
@@ -92,4 +94,6 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::vect
     stream.write(reinterpret_cast<const char *>(vector.data()), size * sizeof(T));
 
     return stream;
+}
+
 }

--- a/src/containers/flatVector2D.hpp
+++ b/src/containers/flatVector2D.hpp
@@ -33,17 +33,15 @@
 #include "binary_stream.hpp"
 
 namespace bitpit{
-    template<class T>
-    class FlatVector2D;
-}
 
 template<class T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::FlatVector2D<T> &vector);
+class FlatVector2D;
 
 template<class T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::FlatVector2D<T> &vector);
+OBinaryStream& operator<<(OBinaryStream &buffer, const FlatVector2D<T> &vector);
 
-namespace bitpit{
+template<class T>
+IBinaryStream& operator>>(IBinaryStream &buffer, FlatVector2D<T> &vector);
 
 /*!
     @ingroup containers
@@ -62,9 +60,9 @@ class FlatVector2D
 {
 
 template<class U>
-friend bitpit::OBinaryStream& (::operator<<) (bitpit::OBinaryStream &buffer, const FlatVector2D<U> &vector);
+friend OBinaryStream& (operator<<) (OBinaryStream &buffer, const FlatVector2D<U> &vector);
 template<class U>
-friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream &buffer, FlatVector2D<U> &vector);
+friend IBinaryStream& (operator>>) (IBinaryStream &buffer, FlatVector2D<U> &vector);
 
 public:
     FlatVector2D(bool initialize = true);

--- a/src/containers/flatVector2D.tpp
+++ b/src/containers/flatVector2D.tpp
@@ -32,10 +32,7 @@
 
 #include "binary_stream.hpp"
 
-namespace bitpit{
-    template<class T>
-    class FlatVector2D;
-}
+namespace bitpit {
 
 /*!
     Stream operator from class FlatVector2D to communication buffer.
@@ -46,7 +43,7 @@ namespace bitpit{
     \result Returns the same output stream received in input.
 */
 template<class T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::FlatVector2D<T> &vector)
+OBinaryStream& operator<<(OBinaryStream &buffer, const FlatVector2D<T> &vector)
 {
     buffer << vector.m_index;
     buffer << vector.m_v;
@@ -63,15 +60,13 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::F
     \result Returns the same input stream received in input.
 */
 template<class T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::FlatVector2D<T> &vector)
+IBinaryStream& operator>>(IBinaryStream &buffer, FlatVector2D<T> &vector)
 {
     buffer >> vector.m_index;
     buffer >> vector.m_v;
 
     return buffer;
 }
-
-namespace bitpit{
 
 /*!
     Default constructor.

--- a/src/discretization/stencil.hpp
+++ b/src/discretization/stencil.hpp
@@ -32,22 +32,17 @@
 #include "bitpit_common.hpp"
 #include "bitpit_containers.hpp"
 
-// Stream operators for the stencil class
 namespace bitpit {
 
+// Stream operators for the stencil class
 template<typename weight_t>
 class DiscreteStencil;
 
-}
+template<typename weight_t>
+OBinaryStream & operator<<(OBinaryStream &buffer, const DiscreteStencil<weight_t> &stencil);
 
 template<typename weight_t>
-bitpit::OBinaryStream & operator<<(bitpit::OBinaryStream &buffer, const bitpit::DiscreteStencil<weight_t> &stencil);
-
-template<typename weight_t>
-bitpit::IBinaryStream & operator>>(bitpit::IBinaryStream &buffer, bitpit::DiscreteStencil<weight_t> &stencil);
-
-// Declaration of the stencil class
-namespace bitpit {
+IBinaryStream & operator>>(IBinaryStream &buffer, DiscreteStencil<weight_t> &stencil);
 
 /**
 * \ingroup discretization
@@ -60,9 +55,9 @@ template <typename weight_t>
 class DiscreteStencil {
 
 template<typename U>
-friend bitpit::OBinaryStream & (::operator<<) (bitpit::OBinaryStream &buffer, const DiscreteStencil<U> &stencil);
+friend OBinaryStream & (operator<<) (OBinaryStream &buffer, const DiscreteStencil<U> &stencil);
 template<typename U>
-friend bitpit::IBinaryStream & (::operator>>) (bitpit::IBinaryStream &buffer, DiscreteStencil<U> &stencil);
+friend IBinaryStream & (operator>>) (IBinaryStream &buffer, DiscreteStencil<U> &stencil);
 
 public:
     long NULL_ID = - std::numeric_limits<long>::max();

--- a/src/discretization/stencil.tpp
+++ b/src/discretization/stencil.tpp
@@ -25,6 +25,8 @@
 #ifndef __BITPIT_STENCIL_TPP__
 #define __BITPIT_STENCIL_TPP__
 
+namespace bitpit {
+
 /*!
 * Output stream operator from class DiscreteStencil to communication buffer.
 *
@@ -33,7 +35,7 @@
 * \result Returns the same output stream received in input.
 */
 template<typename weight_t>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::DiscreteStencil<weight_t> &stencil)
+OBinaryStream& operator<<(OBinaryStream &buffer, const DiscreteStencil<weight_t> &stencil)
 {
     buffer << stencil.m_zero;
 
@@ -60,7 +62,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const bitpit::D
 * \result Returns the same input stream received in input.
 */
 template<typename weight_t>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::DiscreteStencil<weight_t> &stencil)
+IBinaryStream& operator>>(IBinaryStream &buffer, DiscreteStencil<weight_t> &stencil)
 {
     buffer >> stencil.m_zero;
 
@@ -79,8 +81,6 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Discret
 
     return buffer;
 }
-
-namespace bitpit {
 
 /*!
 * Constructor

--- a/src/operators/Operators.hpp
+++ b/src/operators/Operators.hpp
@@ -50,7 +50,10 @@
 # include <iomanip>
 # include <iostream>
 # include <algorithm>
-# include <functional> 
+# include <functional>
+
+// bitpit
+# include "bitpit_common.hpp"
 
 // ================================================================================== //
 // FUNCTION PROTOTYPES                                                                //
@@ -244,6 +247,18 @@ std::ofstream& operator<< (                                                     
         std::ofstream                           &,                                    // (input) output file stream
         const std::vector< T >                  &                                     // (input) std::vector to be streamed
         );
+
+namespace bitpit {
+
+using ::operator<<;
+
+template <class T>
+Logger& operator<< (                                                                  // INSERTION OPERATOR
+        Logger                                  &,                                    // (input) output file stream
+        const std::vector< T >                  &                                     // (input) std::vector to be streamed
+        );
+
+}
 
 // Input operators ------------------------------------------------------------------ //
 template <class T>
@@ -619,6 +634,18 @@ std::ofstream& operator<< (                                                     
         std::ofstream                           &,                                    // (input) output file stream
         const std::array<T, d>                  &                                     // (input) std::array to be streamed
         );
+
+namespace bitpit {
+
+using ::operator<<;
+
+template <class T, size_t d>
+Logger& operator<< (                                                                  // INSERTION OPERATOR
+        Logger                                  &,                                    // (input) logger
+        const std::array<T, d>                  &                                     // (input) std::array to be streamed
+        );
+
+}
 
 // Input operators ------------------------------------------------------------------ //
 template <class T, size_t d>

--- a/src/operators/Operators_array.tpp
+++ b/src/operators/Operators_array.tpp
@@ -1387,6 +1387,49 @@ out << x[d-1];
 
 return(out); };
 
+namespace bitpit {
+
+// ---------------------------------------------------------------------------------- //
+/*!
+    Insertion operator for std::array.
+
+    Flush the content of std::array to std::ofstream.
+    The content of the input array is flushed with the following format:
+    x[0] x[1] x[2] ... x[d-1] where d = x.size();
+    (i.e. array elements are separated by blank spaces).
+    Template parameter T can be any type such that operator<< is defined.
+
+    \param[in,out] out output file stream
+    \param[in] x argument of insertion operator
+
+    \result reference to the stream (allows concatenation)
+*/
+template <class T, size_t d>
+Logger& operator<< (
+    Logger                                      &out,
+    const std::array<T, d>                      &x
+) {
+
+// ================================================================================== //
+// VARIABLES DECLARATION                                                              //
+// ================================================================================== //
+// none
+
+// ================================================================================== //
+// OUTPUT ARRAY CONTENT                                                               //
+// ================================================================================== //
+if (d == 0) {
+    return(out);
+}
+for (size_t i = 0; i < d-1; i++) {
+    out << x[i] << " ";
+} //next i
+out << x[d-1];
+
+return(out); };
+
+}
+
 // Input operator =================================================================== //
 
 // ---------------------------------------------------------------------------------- //

--- a/src/operators/Operators_vector.tpp
+++ b/src/operators/Operators_vector.tpp
@@ -1420,6 +1420,54 @@ out << x[n-1];
 
 return(out); };
 
+namespace bitpit {
+
+// Output operator ================================================================== //
+
+// ---------------------------------------------------------------------------------- //
+/*!
+    Insertion operator for std::vector.
+
+    Flush the content of std::vector to std::ostream.
+    The content of the input vector is flushed with the following format:
+    x[0] x[1] x[2] ... x[n-1] where n = x.size();
+    (i.e. vector elements are separated by blank spaces).
+    Template parameter T can be any type such that operator<< is defined.
+
+    \param[in,out] out output stream
+    \param[in] x argument of insertion operator
+
+    \result reference to the stream (allows concatenation)
+*/
+template <class T>
+Logger& operator<< (
+    Logger                                      &out,
+    const std::vector< T >                      &x
+) {
+
+    // ================================================================================== //
+// VARIABLES DECLARATION                                                              //
+// ================================================================================== //
+
+// Local variables
+size_t               n = x.size();
+
+// Counters
+// none
+
+// ================================================================================== //
+// OUTPUT VECTOR CONTENT                                                              //
+// ================================================================================== //
+if (n == 0) return(out);
+for (size_t i = 0; i < n-1; i++) {
+    out << x[i] << " ";
+} //next i
+out << x[n-1];
+
+return(out); };
+
+}
+
 // Input operator =================================================================== //
 
 // ---------------------------------------------------------------------------------- //

--- a/src/patchkernel/cell.cpp
+++ b/src/patchkernel/cell.cpp
@@ -29,6 +29,8 @@
 #include "vertex.hpp"
 #include "cell.hpp"
 
+namespace bitpit {
+
 /*!
 	Input stream operator for class Cell. Stream cell data from memory
 	input stream to container.
@@ -37,10 +39,10 @@
 	\param[in] cell is the cell object
 	\result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Cell &cell)
+IBinaryStream& operator>>(IBinaryStream &buffer, Cell &cell)
 {
 	// Write connectivity data ---------------------------------------------- //
-	bitpit::Element &element(cell);
+	Element &element(cell);
 	buffer >> element;
 
 	// Write interface data ------------------------------------------------- //
@@ -60,10 +62,10 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Cell &c
 	\param[in] cell is the cell object
 	\result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::Cell &cell)
+OBinaryStream& operator<<(OBinaryStream  &buffer, const Cell &cell)
 {
 	// Write connectivity data ---------------------------------------------- //
-	const bitpit::Element &element(cell);
+	const Element &element(cell);
 	buffer << element;
 
 	// Write interface data ------------------------------------------------- //
@@ -74,8 +76,6 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::
 
 	return buffer;
 }
-
-namespace bitpit {
 
 /*!
 	\class Cell

--- a/src/patchkernel/cell.hpp
+++ b/src/patchkernel/cell.hpp
@@ -32,21 +32,19 @@
 #include "element.hpp"
 
 namespace bitpit {
-	class Cell;
-	class PatchKernel;
-}
 
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, bitpit::Cell& cell);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const bitpit::Cell& cell);
+class Cell;
+class PatchKernel;
 
-namespace bitpit {
+IBinaryStream & operator>>(IBinaryStream &buf, Cell& cell);
+OBinaryStream & operator<<(OBinaryStream &buf, const Cell& cell);
 
 class Cell : public Element {
 
 friend class PatchKernel;
 
-friend bitpit::OBinaryStream& (::operator<<) (bitpit::OBinaryStream& buf, const Cell& cell);
-friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream& buf, Cell& cell);
+friend OBinaryStream& (operator<<) (OBinaryStream& buf, const Cell& cell);
+friend IBinaryStream& (operator>>) (IBinaryStream& buf, Cell& cell);
 
 public:
 	Cell();

--- a/src/patchkernel/element.cpp
+++ b/src/patchkernel/element.cpp
@@ -32,6 +32,8 @@
 
 #include "element.hpp"
 
+namespace bitpit {
+
 /*!
 	Input stream operator for class Element
 
@@ -39,17 +41,17 @@
 	\param[in] element is the element to be streamed
 	\result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Element &element)
+IBinaryStream& operator>>(IBinaryStream &buffer, Element &element)
 {
 	// Initialize the element
-	bitpit::ElementType type;
+	ElementType type;
 	buffer >> type;
 
 	long id;
 	buffer >> id;
 
 	int connectSize;
-	if (bitpit::ReferenceElementInfo::hasInfo(type)) {
+	if (ReferenceElementInfo::hasInfo(type)) {
 		element._initialize(id, type);
 		connectSize = element.getConnectSize();
 	} else {
@@ -76,13 +78,13 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, bitpit::Element
 	\param[in] element is the element to be streamed
 	\result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::Element &element)
+OBinaryStream& operator<<(OBinaryStream  &buffer, const Element &element)
 {
 	buffer << element.getType();
 	buffer << element.getId();
 
 	int connectSize = element.getConnectSize();
-	if (!bitpit::ReferenceElementInfo::hasInfo(element.m_type)) {
+	if (!ReferenceElementInfo::hasInfo(element.m_type)) {
 		buffer << connectSize;
 	}
 
@@ -92,8 +94,6 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const bitpit::
 
 	return buffer;
 }
-
-namespace bitpit {
 
 /*!
 	\class Tesselation

--- a/src/patchkernel/element.hpp
+++ b/src/patchkernel/element.hpp
@@ -36,18 +36,16 @@
 #include "element_reference.hpp"
 
 namespace bitpit {
-	class Element;
-}
 
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, bitpit::Element& element);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const bitpit::Element& element);
+class Element;
 
-namespace bitpit {
+IBinaryStream & operator>>(IBinaryStream &buf, Element& element);
+OBinaryStream & operator<<(OBinaryStream &buf, const Element& element);
 
 class Element {
 
-friend bitpit::OBinaryStream& (::operator<<) (bitpit::OBinaryStream& buf, const Element& element);
-friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream& buf, Element& element);
+friend OBinaryStream& (operator<<) (OBinaryStream& buf, const Element& element);
+friend IBinaryStream& (operator>>) (IBinaryStream& buf, Element& element);
 
 public:
 	/*!

--- a/src/patchkernel/vertex.cpp
+++ b/src/patchkernel/vertex.cpp
@@ -28,6 +28,8 @@
 
 #include "vertex.hpp"
 
+namespace bitpit {
+
 /*!
 	Output stream operator for class Vertex. Stream vertex coordinates from
 	object to communication buffer.
@@ -36,7 +38,7 @@
 	\param[in] vertex is the vertex to be streamed
 	\result updated output stream
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &out_stream, const bitpit::Vertex &vertex)
+OBinaryStream& operator<<(OBinaryStream &out_stream, const Vertex &vertex)
 {
 	out_stream << vertex.m_id;
 	out_stream << vertex.m_coords;
@@ -53,7 +55,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &out_stream, const bitpi
 	\param[in] vertex is the vertex to be streamed
 	\result updated output stream
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &in_stream, bitpit::Vertex &vertex)
+IBinaryStream& operator>>(IBinaryStream &in_stream, Vertex &vertex)
 {
 	in_stream >> vertex.m_id;
 	in_stream >> vertex.m_coords;
@@ -61,9 +63,6 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &in_stream, bitpit::Vert
 
 	return in_stream;
 }
-
-
-namespace bitpit {
 
 /*!
 	\class Vertex

--- a/src/patchkernel/vertex.hpp
+++ b/src/patchkernel/vertex.hpp
@@ -31,21 +31,19 @@
 #include "bitpit_containers.hpp"
 
 namespace bitpit {
-	class Vertex;
-	class PatchKernel;
-}
 
-bitpit::OBinaryStream& operator<< (bitpit::OBinaryStream &out, const bitpit::Vertex &vertex);
-bitpit::IBinaryStream& operator>> (bitpit::IBinaryStream &in, bitpit::Vertex &vertex);
+class Vertex;
+class PatchKernel;
 
-namespace bitpit {
+OBinaryStream& operator<< (OBinaryStream &out, const Vertex &vertex);
+IBinaryStream& operator>> (IBinaryStream &in, Vertex &vertex);
 
 class Vertex {
 
 friend class PatchKernel;
 
-friend bitpit::OBinaryStream& (::operator<<) (bitpit::OBinaryStream&, const Vertex &);
-friend bitpit::IBinaryStream& (::operator>>) (bitpit::IBinaryStream&, Vertex &);
+friend OBinaryStream& (operator<<) (OBinaryStream&, const Vertex &);
+friend IBinaryStream& (operator>>) (IBinaryStream&, Vertex &);
 
 public:
 	enum Coordinate {

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -27,6 +27,7 @@
 
 #include "bitpit_common.hpp"
 
+#include "logger.hpp"
 #include "voloctree.hpp"
 
 namespace bitpit {
@@ -445,6 +446,11 @@ void VolOctree::initializeTree(std::unique_ptr<PabloUniform> *adopter, std::size
 void VolOctree::initializeTree(std::unique_ptr<PabloUniform> *adopter)
 #endif
 {
+	// Initialize logger
+#ifdef NDEBUG
+	m_tree->getLog().setVerbosities(log::WARNING);
+#endif
+
 #if BITPIT_ENABLE_MPI==1
 	// Initialize partitioning
     if (isCommunicatorSet()) {


### PR DESCRIPTION
In release mode, VolOctree patch will display PABLO messages only when their severity is WARNING or higher.

To achieve this I had to rework a bit the logger: loggers that were sharing the same buffer were sharing also the visibility settings, but this was not the intended behaviour. Other than fixing this problem, the reworked logger should be faster.