### PR TITLE
IO/DGF: make sure the current position in the file is properly initialized

### DIFF
--- a/src/IO/DGF.cpp
+++ b/src/IO/DGF.cpp
@@ -1118,6 +1118,7 @@ err_code = 0;
 // CHECK DATA BLOCK                                                           //
 // ========================================================================== //
 word = "begin";
+current_pos = file_handle.tellg();
 while (!file_handle.eof()
     && ((word.compare("#") != 0)
     &&  (word.compare("VERTEX") != 0)
@@ -1126,8 +1127,8 @@ while (!file_handle.eof()
     &&  (word.compare("SIMPLEXDATA") != 0))) {
 
     // Get current line
-    current_pos = file_handle.tellg();
     getline(file_handle, line);
+    current_pos = file_handle.tellg();
     line = utils::string::trim(line);
     sline.clear();
     sline.str(line);


### PR DESCRIPTION
Fixes the following GCC warning:

In constructor ‘std::fpos<_StateT>::fpos(std::streamoff) [with _StateT = __mbstate_t]’,
    inlined from ‘unsigned int bitpit::dgf::checkData(std::ifstream&, int&)’ at /home/andrea/work/customers/optimad/present/20150716_bitpit/code/src/IO/DGF.cpp:1142:22:
/usr/include/c++/12/bits/postypes.h:104:9: warning: ‘current_pos’ may be used uninitialized [-Wmaybe-uninitialized]
  104 |       : _M_off(__off), _M_state() { }
      |         ^~~~~~~~~~~~~
/code/src/IO/DGF.cpp: In function ‘unsigned int bitpit::dgf::checkData(std::ifstream&, int&)’:
/code/src/IO/DGF.cpp:1100:17: note: ‘current_pos’ was declared here
 1100 | long int        current_pos;
      |                 ^~~~~~~~~~~