### PR TITLE
PABLO: silence some "uninitialized variable" warnings reported by Coverity

### DIFF
--- a/src/PABLO/Map.cpp
+++ b/src/PABLO/Map.cpp
@@ -127,7 +127,7 @@ double Map::mapZ(uint32_t Z) const {
  * \return Coordinates in logical domain.
  */
 u32array3 Map::mapCoordinates(darray3 const & X) const {
-	u32array3 coords;
+	u32array3 coords = {{0, 0, 0}};
 	for (int i=0; i<3; ++i){
 		coords[i] = (uint32_t)(double(m_maxLength) * X[i]);
 	}

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -240,11 +240,7 @@ Octant::getDim() const{return m_dim;};
  */
 u32array3
 Octant::getLogicalCoordinates() const{
-	u32array3 coords;
-	coords[0] = getLogicalX();
-	coords[1] = getLogicalY();
-	coords[2] = getLogicalZ();
-	return coords;
+	return {{getLogicalX(), getLogicalY(), getLogicalZ()}};
 };
 
 /*! Get the coordinates of an octant, i.e. the coordinates of its node 0.
@@ -479,10 +475,8 @@ Octant::getLogicalVolume() const{
  */
 darray3
 Octant::getLogicalCenter() const{
-	double	dh;
-	darray3 center;
-
-	dh = double(getLogicalSize())*0.5;
+	double dh = double(getLogicalSize())*0.5;
+	darray3 center = {{0., 0., 0.}};
 	center[0] = getLogicalX() + dh;
 	center[1] = getLogicalY() + dh;
 	center[2] = getLogicalZ() + double(m_dim-2)*dh;
@@ -497,12 +491,10 @@ Octant::getLogicalCenter() const{
  */
 darray3
 Octant::getLogicalFaceCenter(uint8_t iface) const{
-	double	dh_2;
-	darray3 center;
-
 	assert(iface < m_dim*2);
 
-	dh_2 = double(getLogicalSize())*0.5;
+	double dh_2 = double(getLogicalSize())*0.5;
+	darray3 center = {{0., 0., 0.}};
 	center[0] = getLogicalX() + (double)sm_treeConstants[m_dim].faceDisplacements[iface][0] * dh_2;
 	center[1] = getLogicalY() + (double)sm_treeConstants[m_dim].faceDisplacements[iface][1] * dh_2;
 	center[2] = getLogicalZ() + double(m_dim-2) * (double)sm_treeConstants[m_dim].faceDisplacements[iface][2] * dh_2;
@@ -519,7 +511,7 @@ Octant::getLogicalFaceCenter(uint8_t iface) const{
 darray3
 Octant::getLogicalEdgeCenter(uint8_t iedge) const{
 	double	dh_2;
-	darray3 center;
+	darray3 center = {{0., 0., 0.}};
 
 	dh_2 = double(getLogicalSize())*0.5;
 	center[0] = getLogicalX() + (double)sm_treeConstants[m_dim].edgeDisplacements[iedge][0] * dh_2;
@@ -1864,7 +1856,7 @@ Octant Octant::computeEdgePeriodicOctant(uint8_t iedge) const {
  * \return Coordinates of octant considered as periodic ghost out of the logical domain.
  */
 array<int64_t,3> Octant::getPeriodicCoord(uint8_t iface) const {
-	array<int64_t,3> coord;
+	array<int64_t,3> coord = {{0, 0, 0}};
 	coord[0] = getLogicalX();
 	coord[1] = getLogicalY();
 	coord[2] = getLogicalZ();
@@ -1914,7 +1906,7 @@ array<int64_t,3> Octant::getPeriodicCoord(uint8_t iface) const {
  * \return Coordinates of octant considered as periodic ghost out of the logical domain.
  */
 array<int64_t,3> Octant::getNodePeriodicCoord(uint8_t inode) const {
-    array<int64_t,3> coord;
+    array<int64_t,3> coord = {{0, 0, 0}};
     coord[0] = getLogicalX();
     coord[1] = getLogicalY();
     coord[2] = getLogicalZ();
@@ -1987,7 +1979,7 @@ array<int64_t,3> Octant::getNodePeriodicCoord(uint8_t inode) const {
  * \return Coordinates of octant considered as periodic ghost out of the logical domain.
  */
 array<int64_t,3> Octant::getEdgePeriodicCoord(uint8_t iedge) const {
-    array<int64_t,3> coord;
+    array<int64_t,3> coord = {{0, 0, 0}};
     coord[0] = getLogicalX();
     coord[1] = getLogicalY();
     coord[2] = getLogicalZ();

--- a/src/PABLO/PabloUniform.cpp
+++ b/src/PABLO/PabloUniform.cpp
@@ -153,7 +153,7 @@ namespace bitpit {
     {
         ParaTree::restore(stream);
 
-        std::array<double, 3> origin;
+        std::array<double, 3> origin = {{0., 0., 0.}};
         utils::binary::read(stream, origin[0]);
         utils::binary::read(stream, origin[1]);
         utils::binary::read(stream, origin[2]);
@@ -244,8 +244,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getCoordinates(uint32_t idx) const {
-        darray3 coords, coords_;
-        coords_ = ParaTree::getCoordinates(idx);
+        darray3 coords  = {{0., 0., 0.}};
+        darray3 coords_ = ParaTree::getCoordinates(idx);
         for (int i=0; i<3; i++){
             coords[i] = m_origin[i] + m_L * coords_[i];
         }
@@ -333,7 +333,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getCenter(uint32_t idx) const {
-        darray3 center, center_ = ParaTree::getCenter(idx);
+        darray3 center  = {{0., 0., 0.}};
+        darray3 center_ = ParaTree::getCenter(idx);
         for (int i=0; i<3; i++){
             center[i] = m_origin[i] + m_L * center_[i];
         }
@@ -360,7 +361,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getFaceCenter(uint32_t idx, uint8_t iface) const {
-        darray3 center, center_ = ParaTree::getFaceCenter(idx, iface);
+        darray3 center  = {{0., 0., 0.}};
+        darray3 center_ = ParaTree::getFaceCenter(idx, iface);
         for (int i=0; i<3; i++){
             center[i] = m_origin[i] + m_L * center_[i];
         }
@@ -374,7 +376,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getNode(uint32_t idx, uint8_t inode) const {
-        darray3 node, node_ = ParaTree::getNode(idx, inode);
+        darray3 node  = {{0., 0., 0.}};
+        darray3 node_ = ParaTree::getNode(idx, inode);
         for (int i=0; i<3; i++){
             node[i] = m_origin[i] + m_L * node_[i];
         }
@@ -454,8 +457,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getCoordinates(const Octant* oct) const {
-        darray3 coords, coords_;
-        coords_ = ParaTree::getCoordinates(oct);
+        darray3 coords  = {{0., 0., 0.}};
+        darray3 coords_ = ParaTree::getCoordinates(oct);
         for (int i=0; i<3; i++){
             coords[i] = m_origin[i] + m_L * coords_[i];
         }
@@ -543,7 +546,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getCenter(const Octant* oct) const {
-        darray3 center, center_ = ParaTree::getCenter(oct);
+        darray3 center  = {{0., 0., 0.}};
+        darray3 center_ = ParaTree::getCenter(oct);
         for (int i=0; i<3; i++){
             center[i] = m_origin[i] + m_L * center_[i];
         }
@@ -570,7 +574,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getFaceCenter(const Octant* oct, uint8_t iface) const {
-        darray3 center, center_ = ParaTree::getFaceCenter(oct, iface);
+        darray3 center  = {{0., 0., 0.}};
+        darray3 center_ = ParaTree::getFaceCenter(oct, iface);
         for (int i=0; i<3; i++){
             center[i] = m_origin[i] + m_L * center_[i];
         }
@@ -584,7 +589,8 @@ namespace bitpit {
      */
     darray3
     PabloUniform::getNode(const Octant* oct, uint8_t inode) const {
-        darray3 node, node_ = ParaTree::getNode(oct, inode);
+        darray3 node  = {{0., 0., 0.}};
+        darray3 node_ = ParaTree::getNode(oct, inode);
         for (int i=0; i<3; i++){
             node[i] = m_origin[i] + m_L * node_[i];
         }
@@ -625,7 +631,8 @@ namespace bitpit {
      */
     darr3vector
     PabloUniform::getNodes(const Octant* oct) const {
-        darray3vector nodes, nodes_ = ParaTree::getNodes(oct);
+        darray3vector nodes  = {{{{0., 0., 0.}}, {{0., 0., 0.}}, {{0., 0., 0.}}}};
+        darray3vector nodes_ = ParaTree::getNodes(oct);
         nodes.resize(ParaTree::getNnodes());
         for (int j=0; j<ParaTree::getNnodes(); j++){
             for (int i=0; i<3; i++){

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -1333,7 +1333,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getCenter(uint32_t idx) const {
-        darray3 centerCoords;
+        darray3 centerCoords  = {{0., 0., 0.}};
         darray3 centerCoords_ = m_octree.m_octants[idx].getLogicalCenter();
         m_trans.mapCenter(centerCoords_, centerCoords);
         return centerCoords;
@@ -1346,7 +1346,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getFaceCenter(uint32_t idx, uint8_t face) const {
-        darray3 centerCoords;
+        darray3 centerCoords  = {{0., 0., 0.}};
         darray3 centerCoords_ = m_octree.m_octants[idx].getLogicalFaceCenter(face);
         m_trans.mapCenter(centerCoords_, centerCoords);
         return centerCoords;
@@ -1370,7 +1370,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getNode(uint32_t idx, uint8_t node) const {
-        darray3 nodeCoords;
+        darray3 nodeCoords    = {{0., 0., 0.}};
         u32array3 nodeCoords_ = m_octree.m_octants[idx].getLogicalNode(node);
         m_trans.mapNode(nodeCoords_, nodeCoords);
         return nodeCoords;
@@ -1430,8 +1430,8 @@ namespace bitpit {
      */
     darray3
     ParaTree::getNormal(uint32_t idx, uint8_t face) const {
-        darray3 normal;
-        i8array3 normal_;
+        darray3 normal   = {{0., 0., 0.}};
+        i8array3 normal_ = {{0, 0, 0}};
         m_octree.m_octants[idx].getNormal(face, normal_, m_treeConstants->normals);
         m_trans.mapNormals(normal_, normal);
         return normal;
@@ -1783,7 +1783,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getCenter(const Octant* oct) const {
-        darray3 centerCoords;
+        darray3 centerCoords  = {{0., 0., 0.}};
         darray3 centerCoords_ = oct->getLogicalCenter();
         m_trans.mapCenter(centerCoords_, centerCoords);
         return centerCoords;
@@ -1796,7 +1796,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getFaceCenter(const Octant* oct, uint8_t face) const {
-        darray3 centerCoords;
+        darray3 centerCoords  = {{0., 0., 0.}};
         darray3 centerCoords_ = oct->getLogicalFaceCenter(face);
         m_trans.mapCenter(centerCoords_, centerCoords);
         return centerCoords;
@@ -1820,7 +1820,7 @@ namespace bitpit {
      */
     darray3
     ParaTree::getNode(const Octant* oct, uint8_t node) const {
-        darray3 nodeCoords;
+        darray3 nodeCoords    = {{0., 0., 0.}};
         u32array3 nodeCoords_ = oct->getLogicalNode(node);
         m_trans.mapNode(nodeCoords_, nodeCoords);
         return nodeCoords;
@@ -1880,8 +1880,8 @@ namespace bitpit {
      */
     darray3
     ParaTree::getNormal(const Octant* oct, uint8_t face) const {
-        darray3 normal;
-        i8array3 normal_;
+        darray3 normal   = {{0., 0., 0.}};
+        i8array3 normal_ = {{0, 0, 0}};
         oct->getNormal(face, normal_, m_treeConstants->normals);
         m_trans.mapNormals(normal_, normal);
         return normal;
@@ -2382,13 +2382,14 @@ namespace bitpit {
      */
     darray3
     ParaTree::getCenter(const Intersection* inter) const {
-        darray3 center;
         Octant oct(m_dim);
         if(inter->m_finer && inter->m_isghost)
             oct = m_octree.extractGhostOctant(inter->m_owners[inter->m_finer]);
         else
             oct = m_octree.extractOctant(inter->m_owners[inter->m_finer]);
-        darray3  centerCoords_ = oct.getLogicalCenter();
+
+        darray3 center = {{0., 0., 0.}};
+        darray3 centerCoords_ = oct.getLogicalCenter();
         int sign = ( int(2*((inter->m_iface)%2)) - 1);
         double deplace = double (sign * int(oct.getLogicalSize())) / 2;
         centerCoords_[inter->m_iface/2] = uint32_t(int(centerCoords_[inter->m_iface/2]) + deplace);
@@ -2427,14 +2428,15 @@ namespace bitpit {
      */
     darray3
     ParaTree::getNormal(const Intersection* inter) const {
-        darray3 normal;
         Octant oct(m_dim);
         if(inter->m_finer && inter->m_isghost)
             oct = m_octree.extractGhostOctant(inter->m_owners[inter->m_finer]);
         else
             oct = m_octree.extractOctant(inter->m_owners[inter->m_finer]);
+
         uint8_t face = inter->m_iface;
-        i8array3 normal_;
+        darray3 normal = {{0., 0., 0.}};
+        i8array3 normal_ = {{0, 0, 0}};
         oct.getNormal(face, normal_, m_treeConstants->normals);
         m_trans.mapNormals(normal_, normal);
         return normal;

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -345,6 +345,9 @@ namespace bitpit {
         // Set the dimension to a dummy value
         setDim(dim);
 
+        // Initialize the global number of octants
+        m_globalNumOctants = 0;
+
         // Initialize the number of ghost layers
         m_nofGhostLayers = 1;
     }
@@ -371,11 +374,11 @@ namespace bitpit {
         _initializeSerialCommunicator();
 #endif
 
-        // Initialize partitions
-        _initializePartitions();
-
         // Initialized the tree
         _initialize(0, logfile);
+
+        // Initialize partitions
+        _initializePartitions();
     }
 
     /*! Initialize the octree
@@ -401,15 +404,15 @@ namespace bitpit {
         _initializeSerialCommunicator();
 #endif
 
-        // Initialize partitions
-        _initializePartitions();
-
         // Initialized the tree
         if (dim < 2 || dim > 3) {
             throw std::runtime_error ("Invalid value for the dimension");
         }
 
         _initialize(dim, logfile);
+
+        // Initialize partitions
+        _initializePartitions();
     }
 
     /*! Re-initializes the octree
@@ -418,15 +421,15 @@ namespace bitpit {
      */
     void
     ParaTree::reinitialize(uint8_t dim, const std::string &logfile) {
-        // Initialize partitions
-        _initializePartitions();
-
         // Initialized the tree
         if (dim < 2 || dim > 3) {
             throw std::runtime_error ("Invalid value for the dimension");
         }
 
         _initialize(dim, logfile);
+
+        // Initialize partitions
+        _initializePartitions();
     }
 
     /*! Initialize the logger

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -450,6 +450,8 @@ namespace bitpit {
 
 #if BITPIT_ENABLE_MPI==1
         void	_initializeCommunicator(MPI_Comm comm);
+#else
+        void	_initializeSerialCommunicator();
 #endif
         void	_initializePartitions();
         void	_initialize(uint8_t dim, const std::string &logfile);


### PR DESCRIPTION
They all seem false positive, with the exception for the initialization of the global number of octants.