### PR TITLE
patchkernel: consolidate initialization of the communicator

### DIFF
--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -1032,6 +1032,7 @@ private:
 	void freeCommunicator();
 #else
 	void initialize();
+    void initializeSerialCommunicator();
 #endif
 
 	void finalizeAlterations(bool squeezeStorage = false);

--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -1798,6 +1798,10 @@ std::vector<adaption::Info> PatchKernel::_partitioningPrepare(const std::unorder
 
 	return _partitioningPrepare(cellRanks, trackPartitioning);
 #else
+	BITPIT_UNUSED(cellWeights);
+	BITPIT_UNUSED(defaultWeight);
+	BITPIT_UNUSED(trackPartitioning);
+
 	throw std::runtime_error("METIS library is required for automatic patch partitioning.");
 #endif
 }


### PR DESCRIPTION
There is now a function to initialize a dummy communicator when MPI support is disabled.