### PR TITLE
patchkernel: silence some "uninitialized variable" warnings reported by Coverity

### DIFF
--- a/src/patchkernel/element_reference.cpp
+++ b/src/patchkernel/element_reference.cpp
@@ -64,7 +64,7 @@ ReferenceElementInfo::ReferenceElementInfo(int _dimension, ElementType _type, in
     }
 
     edgeTypeStorage.fill(ElementType::UNDEFINED);
-    for (int i = 0; i < MAX_ELEM_FACES; ++i) {
+    for (int i = 0; i < MAX_ELEM_EDGES; ++i) {
         edgeConnectStorage[i].fill(-1);
     }
 }

--- a/src/patchkernel/interface.cpp
+++ b/src/patchkernel/interface.cpp
@@ -198,7 +198,7 @@ std::array<std::array<double, 3>, 3> Interface::evalRotationFromCartesian(std::a
 	//          R =   | [y_int] |
 	//                | [z_int] |
 	//
-	std::array<std::array<double, 3>, 3> R;
+	std::array<std::array<double, 3>, 3> R = {{{{0., 0., 0.}}, {{0., 0., 0.}}, {{0., 0., 0.}}}};
 
 	// x-interface axis
 	for (int k = 0; k < 3; ++k) {
@@ -267,7 +267,7 @@ std::array<std::array<double, 3>, 3> Interface::evalRotationInverse(const std::a
 */
 std::array<std::array<double, 3>, 3> Interface::evalRotationTranspose(const std::array<std::array<double, 3>, 3> &R)
 {
-	std::array<std::array<double, 3>, 3> R_transposed;
+	std::array<std::array<double, 3>, 3> R_transposed = {{{{0., 0., 0.}}, {{0., 0., 0.}}, {{0., 0., 0.}}}};
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
 			R_transposed[j][i] = R[i][j];
@@ -377,11 +377,7 @@ int Interface::getNeighFace() const
 */
 std::array<long, 2> Interface::getOwnerNeigh() const
 {
-	std::array<long, 2> cells;
-	cells[0] = m_owner;
-	cells[1] = m_neigh;
-
-	return cells;
+	return {{m_owner, m_neigh}};
 }
 
 /*!

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -87,8 +87,6 @@ private:
     bool haveSameOrientation(const Cell &cell_A, int face_A, const Cell &cell_B, int face_B) const;
 
 protected:
-    int m_spaceDim;
-
 #if BITPIT_ENABLE_MPI==1
     SurfaceKernel(MPI_Comm communicator, std::size_t haloSize, bool expert);
     SurfaceKernel(int dimension, MPI_Comm communicator, std::size_t haloSize, bool expert);


### PR DESCRIPTION
They all seem false positive, with the exception for the initialization of ReferenceElementInfo::edgeConnectStorag.