### PR TITLE
levelset: change synchronization method of narrowband cache 

### DIFF
--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -250,8 +250,10 @@ void LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>::swap(LevelS
 LevelSetNarrowBandCache<LevelSetInternalPiercedStorageManager>::LevelSetNarrowBandCache()
     : LevelSetInternalPiercedStorageManager(), LevelSetNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
 {
-    m_values    = addStorage<double>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
-    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    // It is faster to use a concurrent synchronization because items will be added/removed
+    // to the kernel one at the time.
+    m_values    = addStorage<double>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
+    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
 }
 
 /*!

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -542,8 +542,10 @@ const std::array<double, 3> & LevelSetSegmentationNarrowBandCache<LevelSetExtern
 LevelSetSegmentationNarrowBandCache<LevelSetInternalPiercedStorageManager>::LevelSetSegmentationNarrowBandCache()
     : LevelSetInternalPiercedStorageManager(), LevelSetNarrowBandCache<LevelSetInternalPiercedStorageManager>(), LevelSetSegmentationNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
 {
-    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
-    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    // It is faster to use a concurrent synchronization because items will be added/removed
+    // to the kernel one at the time.
+    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
+    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
 }
 
 /*!

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -1624,10 +1624,7 @@ VolOctree::StitchInfo VolOctree::deleteCells(const std::vector<DeleteInfo> &dele
 		// For now, all cell vertices will be listed. Later, the vertex of
 		// the dangling faces will be removed from the list.
 		ConstProxyVector<long> cellVertexIds = cell.getVertexIds();
-		for (int k = 0; k < nCellVertices; ++k) {
-			long vertexId = cellVertexIds[k];
-			deadVertices.insert(vertexId);
-		}
+		deadVertices.insert(cellVertexIds.cbegin(), cellVertexIds.cend());
 
 		// Remove patch-tree associations
 		const OctantInfo &octantInfo = getCellOctant(cellId);


### PR DESCRIPTION
The algorithm used for updating the narrow band adds the cell to the cache and immediately after it evaluates cache information. In this case using a concurrent synchronization for the PiercedStorages is faster than using a journaled synchronization.