### PR TITLE
 discretization: fix logic to detect if polynomial storage should be resized

### DIFF
--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -530,6 +530,7 @@ void ReconstructionPolynomial::clear(bool release)
     m_nFields = 0;
 
     if (release) {
+        m_nCoeffs = 0;
         m_coeffs.reset();
     }
 }

--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -493,12 +493,11 @@ void ReconstructionPolynomial::initialize(uint8_t degree, uint8_t dimensions,
     assert(dimensions <= ReconstructionPolynomial::MAX_DIMENSIONS);
     m_dimensions = dimensions;
 
-    int currentStorageSize = m_nCoeffs;
-
-    m_nCoeffs = ReconstructionPolynomial::getCoefficientCount(m_degree, m_dimensions);
-
     if (nFields > 0) {
+        int currentStorageSize = m_nCoeffs * m_nFields;
+
         m_nFields = nFields;
+        m_nCoeffs = ReconstructionPolynomial::getCoefficientCount(m_degree, m_dimensions);
 
         int storageSize = m_nCoeffs * m_nFields;
 


### PR DESCRIPTION
The current storage size was not properly evaluated.

I've also updated the function that evaluates the polynomial coefficients: since the weight matrix is usually small, it's faster perform matrix vector multiplication using an ad-hoc code rather than using CBLAS functions..