### PR TITLE
common: add message to deprecated macros

### DIFF
--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -80,8 +80,8 @@ do {                  \
 #   define BITPIT_DEPRECATED(func) func __attribute__ ((deprecated))
 #   define BITPIT_DEPRECATED_FOR(func, replacement) func __attribute__ ((deprecated(" Use " #replacement)))
 #elif defined(_MSC_VER)
-    #define BITPIT_DEPRECATED(func) __declspec(deprecated) func
-    #define BITPIT_DEPRECATED_FOR(func, replacement), replacement __declspec(deprecated(" Use " #replacement)) func
+#   define BITPIT_DEPRECATED(func) __declspec(deprecated) func
+#   define BITPIT_DEPRECATED_FOR(func, replacement), replacement __declspec(deprecated(" Use " #replacement)) func
 #else
 #   pragma message("WARNING: macros to declare functions as deprecated are not implemented for this compiler")
 #   define BITPIT_DEPRECATED(func) func

--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -75,13 +75,17 @@ do {                  \
  */
 #if defined __GNUC__
 #   define BITPIT_DEPRECATED(func) func __attribute__ ((deprecated))
+#   define BITPIT_DEPRECATED_FOR(func, replacement) func __attribute__ ((deprecated(" Use " #replacement)))
 #elif defined __clang__
 #   define BITPIT_DEPRECATED(func) func __attribute__ ((deprecated))
+#   define BITPIT_DEPRECATED_FOR(func, replacement) func __attribute__ ((deprecated(" Use " #replacement)))
 #elif defined(_MSC_VER)
     #define BITPIT_DEPRECATED(func) __declspec(deprecated) func
+    #define BITPIT_DEPRECATED_FOR(func, replacement), replacement __declspec(deprecated(" Use " #replacement)) func
 #else
-#   pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#   pragma message("WARNING: You need to implement DEPRECATED and DEPRECATED_FOR for this compiler")
 #   define BITPIT_DEPRECATED(func) func
+#   define BITPIT_DEPRECATED_FOR(func, replacement) func
 #endif
 
 

--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -83,7 +83,7 @@ do {                  \
     #define BITPIT_DEPRECATED(func) __declspec(deprecated) func
     #define BITPIT_DEPRECATED_FOR(func, replacement), replacement __declspec(deprecated(" Use " #replacement)) func
 #else
-#   pragma message("WARNING: You need to implement DEPRECATED and DEPRECATED_FOR for this compiler")
+#   pragma message("WARNING: macros to declare functions as deprecated are not implemented for this compiler")
 #   define BITPIT_DEPRECATED(func) func
 #   define BITPIT_DEPRECATED_FOR(func, replacement) func
 #endif


### PR DESCRIPTION
Added new macro to define functions as deprecated with message as input argument.

With this new macros BITPIT_DEPRECATED_FOR (one for each supported compiler as the original ones) is possibile to pass a message to indicate wich method has to be used instead.

Currently compiled and tested only for GNUC case. 

