### PR TITLE
cmake: fix compilation when clang-format is not available

### DIFF
--- a/external/clang-format/cmake/ClangFormat.cmake
+++ b/external/clang-format/cmake/ClangFormat.cmake
@@ -80,13 +80,13 @@ endfunction()
 # Specifies sources to be formatted by the target
 function(ClangFormatTargetSources TARGET FILE_PATHS)
     # Early return if clang-formt is not available
-    if (NOT TARGET ${TARGET})
-        message(FATAL_ERROR "Target ${TARGET} is not valid.")
-    endif()
-
-    # Early return if clang-formt is not available
     if (NOT CLANG_FORMAT_EXECUTABLE)
         return()
+    endif()
+
+    # Early return if target is not valid
+    if (NOT TARGET ${TARGET})
+        message(FATAL_ERROR "Target ${TARGET} is not valid.")
     endif()
 
     # Add files to the target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,11 +86,13 @@ function(configureModule MODULE_NAME)
     endif ()
 
     # Configure source formatting
-    set(MODULE_CLANG_FORMAT_TARGET "clang-format-${MODULE_NAME}")
-    ClangFormatAddTarget("${MODULE_CLANG_FORMAT_TARGET}")
-    ClangFormatTargetSources("${MODULE_CLANG_FORMAT_TARGET}" "${${UPPER_MODULE_NAME}_SOURCES}")
-    ClangFormatTargetSources("${MODULE_CLANG_FORMAT_TARGET}" "${${UPPER_MODULE_NAME}_HEADERS}")
-    add_dependencies(${CLANG_FORMAT_TARGET} "${MODULE_CLANG_FORMAT_TARGET}")
+    if (CLANG_FORMAT_EXECUTABLE)
+        set(MODULE_CLANG_FORMAT_TARGET "clang-format-${MODULE_NAME}")
+        ClangFormatAddTarget("${MODULE_CLANG_FORMAT_TARGET}")
+        ClangFormatTargetSources("${MODULE_CLANG_FORMAT_TARGET}" "${${UPPER_MODULE_NAME}_SOURCES}")
+        ClangFormatTargetSources("${MODULE_CLANG_FORMAT_TARGET}" "${${UPPER_MODULE_NAME}_HEADERS}")
+        add_dependencies(${CLANG_FORMAT_TARGET} "${MODULE_CLANG_FORMAT_TARGET}")
+    endif()
 
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,10 +186,12 @@ function(addTest TEST_NAME TEST_TYPE TEST_LIBRARIES WORKING_DIRECTORY N_PROCS PA
     endif()
 
     # Configure source formatting
-    set(TEST_CLANG_FORMAT_TARGET "clang-format-${TEST_TARGET_NAME}")
-    ClangFormatAddTarget("${TEST_CLANG_FORMAT_TARGET}")
-    ClangFormatTargetSources("${TEST_CLANG_FORMAT_TARGET}" "${TEST_NAME}.cpp")
-    add_dependencies(${CLANG_FORMAT_TARGET} "${TEST_CLANG_FORMAT_TARGET}")
+    if (CLANG_FORMAT_EXECUTABLE)
+        set(TEST_CLANG_FORMAT_TARGET "clang-format-${TEST_TARGET_NAME}")
+        ClangFormatAddTarget("${TEST_CLANG_FORMAT_TARGET}")
+        ClangFormatTargetSources("${TEST_CLANG_FORMAT_TARGET}" "${TEST_NAME}.cpp")
+        add_dependencies(${CLANG_FORMAT_TARGET} "${TEST_CLANG_FORMAT_TARGET}")
+    endif()
 
     # Add test
     add_test(NAME "${TEST_TARGET_NAME}" COMMAND ${TEST_EXEC} ${TEST_ARGS} WORKING_DIRECTORY "${WORKING_DIRECTORY}")


### PR DESCRIPTION
We need to check if clang-format executable has been found before using it.