### PR TITLE
common: msvc porting miscellaneous fixes

### DIFF
--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -81,7 +81,7 @@ do {                  \
 #   define BITPIT_DEPRECATED_FOR(func, replacement) func __attribute__ ((deprecated(" Use " #replacement)))
 #elif defined(_MSC_VER)
 #   define BITPIT_DEPRECATED(func) __declspec(deprecated) func
-#   define BITPIT_DEPRECATED_FOR(func, replacement), replacement __declspec(deprecated(" Use " #replacement)) func
+#   define BITPIT_DEPRECATED_FOR(func, replacement) __declspec(deprecated(" Use " #replacement)) func
 #else
 #   pragma message("WARNING: macros to declare functions as deprecated are not implemented for this compiler")
 #   define BITPIT_DEPRECATED(func) func

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -415,7 +415,7 @@ std::string LoggerBuffer::getTimestamp() const
     auto seconds = std::chrono::duration_cast<std::chrono::seconds>(currentClock.time_since_epoch());
     auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(currentClock.time_since_epoch() - seconds);
     std::array<char, 11> millisecsBuffer;
-    std::snprintf(millisecsBuffer.data(), millisecsBuffer.size(), "%03u", static_cast<uint>(millisecs.count()));
+    std::snprintf(millisecsBuffer.data(), millisecsBuffer.size(), "%03u", static_cast<unsigned int>(millisecs.count()));
 
     std::string timestamp;
     timestamp.resize(23);


### PR DESCRIPTION
Fixed a couple of minor bugs that raises errors during msvc compilation.
- unsupported uint fixed with unsigned int
- fixed wrong expansion of BITPIT_DEPRECATED_FOR in MSC_VER case