### PR TITLE
cmake: add a compiler flag to warn about missing override keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1023,13 +1023,13 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "sanitize")
 endif()
 
 # Standard build types
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmessage-length=0")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmessage-length=0 -Wsuggest-override")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g")
 set(CMAKE_C_FLAGS_RELWITHSANITIZE "-O2 -g -fno-omit-frame-pointer -fno-common ${C_SANITIZE_MODULE_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmessage-length=0")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmessage-length=0 -Wsuggest-override")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 set(CMAKE_CXX_FLAGS_RELWITHSANITIZE "-O2 -g -fno-omit-frame-pointer -fno-common ${CXX_SANITIZE_MODULE_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")

--- a/src/levelset/levelSetUnstructuredKernel.hpp
+++ b/src/levelset/levelSetUnstructuredKernel.hpp
@@ -53,7 +53,7 @@ class LevelSetUnstructuredKernel : public LevelSetCachedKernel<LevelSetUnstructu
 
     LevelSetUnstructuredKernel( VolUnstructured & );
 
-    VolUnstructured *                           getMesh() const;
+    VolUnstructured *                           getMesh() const override;
 
     std::array<double, 3>                       computeCellCentroid(long) const override;
     double                                      computeCellTangentRadius(long) const override;

--- a/src/voloctree/voloctree_mapper.hpp
+++ b/src/voloctree/voloctree_mapper.hpp
@@ -47,16 +47,16 @@ public:
     VolOctreeMapper(VolOctree *referencePatch, VolOctree *mappedPatch);
 #endif
 
-    void adaptionPrepare(const std::vector<adaption::Info> &adaptionInfo, bool reference = true);
-    void adaptionAlter(const std::vector<adaption::Info> &adaptionInfo, bool reference = true, bool inverseFilled = false);
-    void adaptionCleanup();
+    void adaptionPrepare(const std::vector<adaption::Info> &adaptionInfo, bool reference = true) override;
+    void adaptionAlter(const std::vector<adaption::Info> &adaptionInfo, bool reference = true, bool inverseFilled = false) override;
+    void adaptionCleanup() override;
 
 #if BITPIT_ENABLE_MPI
-    bool checkPartition();
+    bool checkPartition() override;
     void clearPartitionMapping();
-    std::map<int, std::vector<long>> getReceivedMappedIds();
-    std::map<int, std::vector<long>> getSentMappedIds();
-    std::map<int, std::vector<long>> getSentReferenceIds();
+    std::map<int, std::vector<long>> getReceivedMappedIds() override;
+    std::map<int, std::vector<long>> getSentMappedIds() override;
+    std::map<int, std::vector<long>> getSentReferenceIds() override;
 #endif
 
 private:
@@ -156,7 +156,7 @@ private:
     PartitionMapper m_partitionIR;  /**< Partitioning info structure. */
 #endif
 
-    void _mapMeshes(bool fillInverse);
+    void _mapMeshes(bool fillInverse) override;
     void _mapMeshesSamePartition(const std::vector<OctantIR> * octantsReference, const std::vector<OctantIR> * octantsMapped,
                                  bool fillInverse, long *indRef);
 


### PR DESCRIPTION
Warn about overriding virtual functions that are not marked with the override keyword.