### PR TITLE
PABLO: explicitly cast bitset::reference to bool

### DIFF
--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -5696,7 +5696,7 @@ namespace bitpit {
             for(std::size_t i = 0; i < nRankBorders; ++i){
                 const Octant &octant = m_octree.m_octants[rankBordersPerProc[i]];
                 sendBuffer << octant.getMarker();
-                sendBuffer << octant.m_info[Octant::INFO_AUX];
+                sendBuffer << static_cast<bool>(octant.m_info[Octant::INFO_AUX]);
             }
         }
 


### PR DESCRIPTION
Fixes an error when compiling bitpit with libc++ (resolves #348).