### PR TITLE
cmake: properly search for git application before using it

### DIFF
--- a/external/git/cmake/GetGitRevisionDescription.cmake
+++ b/external/git/cmake/GetGitRevisionDescription.cmake
@@ -84,6 +84,18 @@ function(_git_find_closest_git_dir _start_dir _git_dir_var)
 endfunction()
 
 function(get_git_head_revision _refspecvar _hashvar)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    if(NOT GIT_FOUND)
+        set(${_refspecvar}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        set(${_hashvar}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+    endif()
+
     _git_find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
 
     if(${ARGC} GREATER 2})
@@ -178,13 +190,14 @@ function(git_describe _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"
             PARENT_SCOPE)
         return()
     endif()
+
+    get_git_head_revision(refspec hash)
     if(NOT hash)
         set(${_var}
             "HEAD-HASH-NOTFOUND"
@@ -221,13 +234,14 @@ function(git_describe_working_tree _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"
             PARENT_SCOPE)
         return()
     endif()
+
+    get_git_head_revision(refspec hash)
     if(NOT hash)
         set(${_var}
             "HEAD-HASH-NOTFOUND"
@@ -261,13 +275,14 @@ function(git_local_changes _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"
             PARENT_SCOPE)
         return()
     endif()
+
+    get_git_head_revision(refspec hash)
     if(NOT hash)
         set(${_var}
             "HEAD-HASH-NOTFOUND"
@@ -296,13 +311,14 @@ function(git_get_branch _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"
             PARENT_SCOPE)
         return()
     endif()
+
+    get_git_head_revision(refspec hash)
     if(NOT hash)
         set(${_var}
             "HEAD-HASH-NOTFOUND"
@@ -329,13 +345,14 @@ function(git_get_short_hash _var)
     if(NOT GIT_FOUND)
         find_package(Git QUIET)
     endif()
-    get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
         set(${_var}
             "GIT-NOTFOUND"
             PARENT_SCOPE)
         return()
     endif()
+
+    get_git_head_revision(refspec hash)
     if(NOT hash)
         set(${_var}
             "HEAD-HASH-NOTFOUND"


### PR DESCRIPTION
The main issue was that the function get_git_head_revision was calling find_package(Git).