### PR TITLE
external/git: quote argument passed to function

### DIFF
--- a/external/git/cmake/GetGitRevisionDescription.cmake
+++ b/external/git/cmake/GetGitRevisionDescription.cmake
@@ -68,7 +68,7 @@ function(_git_find_closest_git_dir _start_dir _git_dir_var)
     while(NOT EXISTS "${git_dir}")
         # .git dir not found, search parent directories
         set(git_previous_parent "${cur_dir}")
-        get_filename_component(cur_dir ${cur_dir} DIRECTORY)
+        get_filename_component(cur_dir "${cur_dir}" DIRECTORY)
         if(cur_dir STREQUAL git_previous_parent)
             # We have reached the root directory, we are not in git
             set(${_git_dir_var}


### PR DESCRIPTION
This allows to properly support directory with spaces.

Fixes #357.