### PR TITLE
discretization: add some fast paths for constant polynomials

### DIFF
--- a/src/discretization/reconstruction.cpp
+++ b/src/discretization/reconstruction.cpp
@@ -2768,9 +2768,9 @@ void ReconstructionKernel::computeGradientLimitedWeights(uint8_t degree, const s
 
     // Explicitly zero unused components
     if (dimensions != ReconstructionPolynomial::MAX_DIMENSIONS) {
-        for (int i = 0; i < nEquations; ++i) {
+        for (int j = 0; j < nEquations; ++j) {
             for (int d = dimensions; d < ReconstructionPolynomial::MAX_DIMENSIONS; ++d) {
-                gradientWeights[i][d] = 0.;
+                gradientWeights[j][d] = 0.;
             }
         }
     }

--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -222,6 +222,7 @@ protected:
     void applyLimiter(uint8_t degree, const double *limiters, double *coeffs) const;
 
 private:
+    static const bool ENABLE_FAST_PATH_OPTIMIZATIONS;
     static const int MAX_STACK_WORKSPACE_SIZE;
 
     std::unique_ptr<double[]> m_weights;


### PR DESCRIPTION
It is possible to optimize the evaluation of constant polynomials taking advantage of the fact that basis value is 1 and basis derivative is 0. 

This kind of optimization was already done for the evaluation of the polynomial value and gradient. Let's extend it also for the update of the polynomials and for the evaluation of the weights.