### PR TITLE
LA: add a fast path for updating matrix values

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1109,8 +1109,8 @@ void SystemSolver::matrixUpdate(long nRows, const long *rows, const SystemMatrix
         petscRowValues = petscRowValuesStorage.data();
     }
 
-    ConstProxyVector<long> rowPattern;
-    ConstProxyVector<double> rowValues;
+    ConstProxyVector<long> rowPattern(maxRowNZ);
+    ConstProxyVector<double> rowValues(maxRowNZ);
     for (long n = 0; n < nRows; ++n) {
         // Get row information
         long row;

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1023,6 +1023,16 @@ void SystemSolver::matrixCreate(const SystemMatrixAssembler &assembler)
     MatCreateSeqAIJ(PETSC_COMM_SELF, nRows, nCols, 0, d_nnz.data(), &m_A);
 #endif
 
+    // Each process will only set values for its own rows
+    MatSetOption(m_A, MAT_NO_OFF_PROC_ENTRIES, PETSC_TRUE);
+
+#if PETSC_VERSION_GE(3, 12, 0)
+    // The first assembly will set a superset of the off-process entries
+    // required for all subsequent assemblies. This avoids a rendezvous
+    // step in the MatAssembly functions.
+    MatSetOption(m_A, MAT_SUBSET_OFF_PROC_ENTRIES, PETSC_TRUE);
+#endif
+
     // Cleanup
     if (m_rowPermutation) {
         ISRestoreIndices(m_rowPermutation, &rowRanks);

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1123,7 +1123,7 @@ void SystemSolver::matrixFill(const SystemMatrixAssembler &assembler)
  * elements.
  *
  * \param nRows is the number of rows that will be updated
- * \param rows are the indices of the rows that will be updated, if a
+ * \param rows are the local indices of the rows that will be updated, if a
  * null pointer is passed, the rows that will be updated are the rows
  * from 0 to (nRows - 1).
  * \param assembler is the matrix assembler for the rows that will be updated

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -70,7 +70,14 @@ struct KSPStatus {
 class SystemMatrixAssembler {
 
 public:
+    struct AssemblyOptions {
+        bool full; //!< Controls if the assembler is providing all the non-zero values of a row
+        bool sorted; //! Controls if the values provided by the assembler are sorted by ascending column
+    };
+
     virtual ~SystemMatrixAssembler() = default;
+
+    virtual AssemblyOptions getOptions() const = 0;
 
     virtual long getRowCount() const = 0;
     virtual long getColCount() const = 0;
@@ -99,6 +106,8 @@ class SystemSparseMatrixAssembler : public SystemMatrixAssembler {
 
 public:
     SystemSparseMatrixAssembler(const SparseMatrix *matrix);
+
+    AssemblyOptions getOptions() const override;
 
     long getRowCount() const override;
     long getColCount() const override;

--- a/src/common/commonUtils.hpp
+++ b/src/common/commonUtils.hpp
@@ -97,6 +97,9 @@ typename std::vector<T>::const_iterator findInOrderedVector(const T &value, cons
 template<typename T>
 void reorderVector(std::vector<size_t>& order, std::vector<T>& v, std::size_t size);
 
+template<typename OrderContainer, typename DataContainer>
+void reorderContainer(OrderContainer &order, DataContainer &v, std::size_t size);
+
 template <class T>
 void eraseValue(std::vector<T> &, const T&);
 

--- a/src/common/commonUtils.tpp
+++ b/src/common/commonUtils.tpp
@@ -102,23 +102,39 @@ typename std::vector<T>::const_iterator findInOrderedVector(const T &value, cons
 *
 * Order a vector according to a reordering vector.
 *
-* \tparam order_t is the type of data that needs to be reordered
-* \param order is a reference to the reording vector
+* \tparam T is the type of data that needs to be reordered
+* \param order is a reference to the reording vector, on output the contents of
+* the vector will be destroyed
 * \param v is a reference to the vector that will be reordered
 * \param size is the size of the vector that will be reordered
 */
 template<typename T>
-void reorderVector(std::vector<size_t>& order, std::vector<T>& v, std::size_t size)
+void reorderVector(std::vector<size_t> &order, std::vector<T> &v, std::size_t size)
 {
-    for (size_t i = 0; i < size; i++) {
-        size_t j;
+    reorderContainer(order, v, size);
+}
+
+/*!
+* \ingroup common_misc
+*
+* Order a container according to a reordering vector.
+*
+* \tparam OrderContainer is the type of container that stores ordering information
+* \tparam DataContainer is the type of container that stores the data
+* \param order is a reference to the reording container, on output the contents
+* of the container will be destroyed
+* \param v is a reference to the container that will be reordered
+* \param size is the size of the container that will be reordered
+*/
+template<typename OrderContainer, typename DataContainer>
+void reorderContainer(OrderContainer &order, DataContainer &v, std::size_t size)
+{
+    for (std::size_t i = 0; i < size; i++) {
+        std::size_t j;
         while (i != (j = order[i])) {
-            size_t k = order[j];
+            std::size_t k = order[j];
 
-            T temp = std::move(v[j]);
-            v[j] = std::move(v[k]);
-            v[k] = std::move(temp);
-
+            std::swap(v[j], v[k]);
             std::swap(order[i], order[j]);
         }
     }

--- a/src/discretization/stencil_solver.hpp
+++ b/src/discretization/stencil_solver.hpp
@@ -122,6 +122,8 @@ public:
     DiscretizationStencilSolverAssembler(MPI_Comm communicator, bool partitioned, const stencil_container_t *stencils);
 #endif
 
+    AssemblyOptions getOptions() const override;
+
     int getBlockSize() const;
 
     long getRowCount() const override;

--- a/src/discretization/stencil_solver.tpp
+++ b/src/discretization/stencil_solver.tpp
@@ -299,6 +299,21 @@ DiscretizationStencilSolverAssembler<stencil_t>::DiscretizationStencilSolverAsse
 }
 
 /*!
+ * Get the assembly options.
+ *
+ * \result The assembly options that will be used.
+ */
+template<typename stencil_t>
+SystemMatrixAssembler::AssemblyOptions DiscretizationStencilSolverAssembler<stencil_t>::getOptions() const
+{
+    AssemblyOptions options;
+    options.full   = true;
+    options.sorted = false;
+
+    return options;
+}
+
+/*!
  * Set block size.
  *
  * \param blockSize is the block size


### PR DESCRIPTION
The fast path will use the PETSc function MatSetValuesRow to update all the values of a row at once (without the need to get the row pattern).
    
Fast update can be performed if:
  - the matrix has already been assembled;
  - the assembler is providing all the values of the row;
  - values provided by the assembler are sorted by ascending column.