### PR TITLE
patchkernel: change the condition that defines if a patch is partitioned

### DIFF
--- a/src/patchkernel/patch_kernel_parallel.cpp
+++ b/src/patchkernel/patch_kernel_parallel.cpp
@@ -1676,13 +1676,16 @@ void PatchKernel::partitioningCleanup()
 }
 
 /*!
-	Checks if the patch has been partitioned.
+	Checks if the patch is partitioned.
 
-	\result Returns true if the patch has been partitioned, false otherwise.
+	A patch is considered partitioned if its MPI communicator spans multiple
+	processes.
+
+	\result Returns true if the patch is partitioned, false otherwise.
 */
 bool PatchKernel::isPartitioned() const
 {
-	return isCommunicatorSet();
+	return (getProcessorCount() > 1);
 }
 
 /*!


### PR DESCRIPTION
A patch is now considered partitioned if its MPI communicator spans multiple processes.

I did some tests with an application that uses bitpit and I haven't found any problems.

Superseeds #336 (the function getProcessorCount can be used to get the number of processes associated with the patch).