### PR TITLE
voloctree: fix partitioning initialization

### DIFF
--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -3352,7 +3352,7 @@ namespace bitpit {
      * I.e. isghost[i] = true/false -> the mapper[i] = j-th old octant was a local/ghost octant.
      */
     void
-    ParaTree::getMapping(uint32_t & idx, u32vector & mapper, bvector & isghost) const {
+    ParaTree::getMapping(uint32_t idx, u32vector & mapper, bvector & isghost) const {
 
         if (idx >= m_mapIdx.size()){
             throw std::runtime_error ("Invalid value for input index in getMapping");
@@ -3402,7 +3402,7 @@ namespace bitpit {
      * I.e. isghost[i] = true/false -> the mapper[i] = j-th old octant was a local/ghost octant.
      */
     void
-    ParaTree::getMapping(uint32_t & idx, u32vector & mapper, bvector & isghost, ivector & rank) const {
+    ParaTree::getMapping(uint32_t idx, u32vector & mapper, bvector & isghost, ivector & rank) const {
 
         if (m_lastOp == OP_ADAPT_MAPPED){
             getMapping(idx, mapper, isghost);

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -4137,7 +4137,7 @@ namespace bitpit {
      * \param[in] weight Pointer to a vector of weights of the local octants (weight=NULL is uniform distribution).
      */
     void
-    ParaTree::loadBalance(dvector* weight){
+    ParaTree::loadBalance(const dvector* weight){
 
         //Write info on log
         (*m_log) << "---------------------------------------------" << endl;
@@ -4184,7 +4184,7 @@ namespace bitpit {
      * \param[in] weight Pointer to a vector of weights of the local octants (weight=NULL is uniform distribution).
      */
     void
-    ParaTree::loadBalance(uint8_t & level, dvector* weight){
+    ParaTree::loadBalance(uint8_t & level, const dvector* weight){
 
         //Write info on log
         (*m_log) << "---------------------------------------------" << endl;

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -3046,7 +3046,7 @@ namespace bitpit {
             return numeric_limits<uint32_t>::max();
         uint32_t idxtry = noctants/2;
         uint32_t x, y, z;
-        uint64_t morton, mortontry;
+        uint64_t morton;
         int powner = 0;
         //ParaTree works in [0,1] domain
         if (point[0] > 1+m_tol || point[1] > 1+m_tol || point[2] > 1+m_tol
@@ -3074,7 +3074,7 @@ namespace bitpit {
         int32_t jump = idxtry;
         while(abs(jump) > 0){
 
-            mortontry = m_octree.m_octants[idxtry].getMorton();
+            uint64_t mortontry = m_octree.m_octants[idxtry].getMorton();
             jump = ((mortontry<morton)-(mortontry>morton))*abs(jump)/2;
             idxtry += jump;
             if (idxtry > noctants-1){
@@ -3456,9 +3456,8 @@ namespace bitpit {
 
         //insert first ghost brothers if present
         {
-            int8_t marker;
             for (uint32_t id : m_octree.m_firstGhostBros){
-                marker = m_octree.m_ghosts[id].getMarker();
+                int8_t marker = m_octree.m_ghosts[id].getMarker();
                 idx.push_back(id);
                 markers.push_back(marker);
                 isghost.push_back(true);
@@ -3466,9 +3465,8 @@ namespace bitpit {
         }
 
         {
-            int8_t marker;
             for (uint32_t count = 0; count < m_octree.getNumOctants(); count++){
-                marker = m_octree.m_octants[count].getMarker();
+                int8_t marker = m_octree.m_octants[count].getMarker();
                 if (marker != 0){
                     idx.push_back(count);
                     markers.push_back(marker);
@@ -3479,9 +3477,8 @@ namespace bitpit {
 
         //insert last ghost brothers if present
         {
-            int8_t marker;
             for (uint32_t id : m_octree.m_lastGhostBros){
-                marker = m_octree.m_ghosts[id].getMarker();
+                int8_t marker = m_octree.m_ghosts[id].getMarker();
                 idx.push_back(id);
                 markers.push_back(marker);
                 isghost.push_back(true);

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -531,8 +531,8 @@ namespace bitpit {
         const u32vector & getGhostConnectivity(const Octant* oct) const;
         bool        check21Balance();
 #if BITPIT_ENABLE_MPI==1
-        void 		loadBalance(dvector* weight = NULL);
-        void 		loadBalance(uint8_t & level, dvector* weight = NULL);
+        void 		loadBalance(const dvector* weight = NULL);
+        void 		loadBalance(uint8_t & level, const dvector* weight = NULL);
 
         LoadBalanceRanges evalLoadBalanceRanges(dvector *weights);
         LoadBalanceRanges evalLoadBalanceRanges(uint8_t level, dvector *weights);

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -495,8 +495,8 @@ namespace bitpit {
         uint32_t 	getPointOwnerIdx(const dvector &point, bool & isghost) const;
         uint32_t 	getPointOwnerIdx(const darray3 &point) const;
         uint32_t 	getPointOwnerIdx(const darray3 &point, bool & isghost) const;
-        void 		getMapping(uint32_t & idx, u32vector & mapper, bvector & isghost) const;
-        void 		getMapping(uint32_t & idx, u32vector & mapper, bvector & isghost, ivector & rank) const;
+        void 		getMapping(uint32_t idx, u32vector & mapper, bvector & isghost) const;
+        void 		getMapping(uint32_t idx, u32vector & mapper, bvector & isghost, ivector & rank) const;
         void 		getPreMapping(u32vector & idx, std::vector<int8_t> & markers, std::vector<bool> & isghost);
         bool 		isNodeOnOctant(const Octant* nodeOctant, uint8_t nodeIndex, const Octant* octant) const;
         bool 		isEdgeOnOctant(const Octant* edgeOctant, uint8_t edgeIndex, const Octant* octant) const;

--- a/src/voloctree/voloctree_mapper.cpp
+++ b/src/voloctree/voloctree_mapper.cpp
@@ -954,9 +954,8 @@ void VolOctreeMapper::_mapMeshesSamePartition(const std::vector<OctantIR> *octan
         // reference octants
         uint64_t morton = referencePatch->getTree().getMorton(&octantsIRReference->at(*indRef).octant);
 
-        uint64_t mortonMapLastdesc;
         for (indMap = 0; indMap < nMap; ++indMap) {
-            mortonMapLastdesc = mappedPatch->getTree().getLastDescMorton(&octantsIRMapped->at(indMap).octant);
+            uint64_t mortonMapLastdesc = mappedPatch->getTree().getLastDescMorton(&octantsIRMapped->at(indMap).octant);
             if (mortonMapLastdesc >= morton) {
                 break;
             }

--- a/src/voloctree/voloctree_parallel.cpp
+++ b/src/voloctree/voloctree_parallel.cpp
@@ -45,12 +45,19 @@ void VolOctree::initializeTreePartitioning()
 	// Assigning a null weight to every octant but the last octant and then
 	// doing a load balance will have the effect of moving all the octants
 	// to the first process.
+	std::vector<double> octantWeightStorage;
+	const std::vector<double> *octantWeights;
+
 	std::size_t nOctants = m_tree->getNumOctants();
-	std::vector<double> octantWeights(nOctants, 0.);
-	if (nOctants > 0) {
-		octantWeights[nOctants - 1] = 1.;
+	if (nOctants > 1) {
+		octantWeightStorage.assign(nOctants, 0.);
+		octantWeightStorage[nOctants - 1] = 1.;
+		octantWeights = &octantWeightStorage;
+	} else {
+		octantWeights = nullptr;
 	}
-	m_tree->loadBalance(m_partitioningOctantWeights.get());
+
+	m_tree->loadBalance(octantWeights);
 }
 
 /*!


### PR DESCRIPTION
The container passed to the function that performs the initial load balance was not the container with the correct weights.