### PR TITLE
patchkernel: simplify initialization of the patch

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -243,7 +243,6 @@ PatchKernel::PatchKernel(const PatchKernel &other)
       m_boxMaxCounter(other.m_boxMaxCounter),
       m_adjacenciesBuildStrategy(other.m_adjacenciesBuildStrategy),
       m_interfacesBuildStrategy(other.m_interfacesBuildStrategy),
-      m_spawnStatus(other.m_spawnStatus),
       m_adaptionMode(other.m_adaptionMode),
       m_adaptionStatus(other.m_adaptionStatus),
       m_dimension(other.m_dimension),
@@ -330,7 +329,6 @@ PatchKernel::PatchKernel(PatchKernel &&other)
       m_boxMaxCounter(std::move(other.m_boxMaxCounter)),
       m_adjacenciesBuildStrategy(std::move(other.m_adjacenciesBuildStrategy)),
       m_interfacesBuildStrategy(std::move(other.m_interfacesBuildStrategy)),
-      m_spawnStatus(std::move(other.m_spawnStatus)),
       m_adaptionMode(std::move(other.m_adaptionMode)),
       m_adaptionStatus(std::move(other.m_adaptionStatus)),
       m_id(std::move(other.m_id)),
@@ -420,7 +418,6 @@ PatchKernel & PatchKernel::operator=(PatchKernel &&other)
 	m_boxMaxCounter = std::move(other.m_boxMaxCounter);
 	m_adjacenciesBuildStrategy = std::move(other.m_adjacenciesBuildStrategy);
 	m_interfacesBuildStrategy = std::move(other.m_interfacesBuildStrategy);
-	m_spawnStatus = std::move(other.m_spawnStatus);
 	m_adaptionMode = std::move(other.m_adaptionMode);
 	m_adaptionStatus = std::move(other.m_adaptionStatus);
 	m_id = std::move(other.m_id);
@@ -523,12 +520,6 @@ void PatchKernel::initialize()
 
 	// Set interfaces build strategy
 	setInterfacesBuildStrategy(INTERFACES_NONE);
-
-	// Set the spawn as unneeded
-	//
-	// Specific implementation will set the appropriate status during their
-	// initialization.
-	setSpawnStatus(SPAWN_UNNEEDED);
 
 	// Set the adaption as clean
 	setAdaptionStatus(ADAPTION_CLEAN);
@@ -646,12 +637,6 @@ std::vector<adaption::Info> PatchKernel::update(bool trackAdaption, bool squeeze
 	// Finalize alterations
 	finalizeAlterations(squeezeStorage);
 
-	// Spawn
-	bool spawnNeeed = (getSpawnStatus() == SPAWN_NEEDED);
-	if (spawnNeeed) {
-		mergeAdaptionInfo(spawn(trackAdaption), updateInfo);
-	}
-
 	// Adaption
 	bool adaptionDirty = (getAdaptionStatus(true) == ADAPTION_DIRTY);
 	if (adaptionDirty) {
@@ -679,44 +664,6 @@ void PatchKernel::simulateCellUpdate(const long id, adaption::Marker marker, std
 	BITPIT_UNUSED(virtualVertices);
 
 	throw std::runtime_error ("This function has not been implemented for the specified patch.");
-}
-
-/*!
-	Generates the patch.
-
-	\param trackSpawn if set to true the changes to the patch will be tracked
-	\result Returns a vector of adaption::Info that can be used to track
-	the changes done during the spawn.
-*/
-std::vector<adaption::Info> PatchKernel::spawn(bool trackSpawn)
-{
-	std::vector<adaption::Info> spawnInfo;
-
-#if BITPIT_ENABLE_MPI==1
-	// This is a collevtive operation and should be called by all processes
-	if (isPartitioned()) {
-		const auto &communicator = getCommunicator();
-		MPI_Barrier(communicator);
-	}
-#endif
-
-	// Check spawn status
-	SpawnStatus spawnStatus = getSpawnStatus();
-	if (spawnStatus == SPAWN_UNNEEDED || spawnStatus == SPAWN_DONE) {
-		return spawnInfo;
-	}
-
-	// Spawn the patch
-	spawnInfo = _spawn(trackSpawn);
-
-	// Finalize patch alterations
-	finalizeAlterations(true);
-
-	// Spwan is done
-	setSpawnStatus(SPAWN_DONE);
-
-	// Done
-	return spawnInfo;
 }
 
 /*!
@@ -1336,33 +1283,6 @@ void PatchKernel::_writeFinalize()
 }
 
 /*!
-	Returns the current spawn status.
-
-	Span functionality is obsolete. The patch dosn't need to be spawned
-	anymore.
-
-	\return The current spawn status.
-*/
-PatchKernel::SpawnStatus PatchKernel::getSpawnStatus() const
-{
-	// There is no need to check the spawn status globally because the spawn
-	// status will always be the same on all the processes.
-
-	return m_spawnStatus;
-}
-
-/*!
-	Set the current spawn status.
-
-	\param status is the spawn status that will be set
-*/
-void PatchKernel::setSpawnStatus(SpawnStatus status)
-{
-	m_spawnStatus = status;
-}
-
-
-/*!
 	Checks if the patch supports adaption.
 
 	\return Returns true if the patch supports adaption, false otherwise.
@@ -1468,10 +1388,6 @@ bool PatchKernel::isDirty(bool global) const
 	if (!isDirty) {
 		isDirty |= areInterfacesDirty(false);
 		assert(isDirty || m_alteredInterfaces.empty());
-	}
-
-	if (!isDirty) {
-		isDirty |= (getSpawnStatus() == SPAWN_NEEDED);
 	}
 
 	if (!isDirty) {
@@ -5266,24 +5182,6 @@ void PatchKernel::restoreInterfaces(std::istream &stream)
 }
 
 /*!
-	Generates the patch.
-
-	Default implementation is a no-op function.
-
-	\param trackSpawn if set to true the changes to the patch will be tracked
-	\result Returns a vector of adaption::Info that can be used to track
-	the changes done during the spawn.
-*/
-std::vector<adaption::Info> PatchKernel::_spawn(bool trackSpawn)
-{
-	BITPIT_UNUSED(trackSpawn);
-
-	assert(false && "The patch needs to implement _spawn");
-
-	return std::vector<adaption::Info>();
-}
-
-/*!
 	Prepares the patch for performing the adaption.
 
 	Default implementation is a no-op function.
@@ -8345,9 +8243,6 @@ bool PatchKernel::dump(std::ostream &stream) const
 	utils::binary::write(stream, 0);
 #endif
 
-	// Spawn status
-	utils::binary::write(stream, m_spawnStatus);
-
 	// Adaption information
 	utils::binary::write(stream, m_adaptionMode);
 	utils::binary::write(stream, m_adaptionStatus);
@@ -8445,9 +8340,6 @@ void PatchKernel::restore(std::istream &stream, bool reregister)
 	int dummyHaloSize;
 	utils::binary::read(stream, dummyHaloSize);
 #endif
-
-	// Spawn status
-	utils::binary::read(stream, m_spawnStatus);
 
 	// Adaption information
 	utils::binary::read(stream, m_adaptionMode);

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -330,15 +330,6 @@ public:
 	};
 
 	/*!
-		Spawn status
-	*/
-	enum SpawnStatus {
-		SPAWN_UNNEEDED = -1,
-		SPAWN_NEEDED,
-		SPAWN_DONE
-	};
-
-	/*!
 		Adaption mode
 	*/
 	enum AdaptionMode {
@@ -402,9 +393,6 @@ public:
 	std::vector<adaption::Info> update(bool trackAdaption = true, bool squeezeStorage = false);
 
 	virtual void simulateCellUpdate(const long id, adaption::Marker marker, std::vector<Cell> *virtualCells, PiercedVector<Vertex, long> *virtualVertices) const;
-
-	SpawnStatus getSpawnStatus() const;
-	std::vector<adaption::Info> spawn(bool trackSpawn);
 
 	bool isAdaptionSupported() const;
 	AdaptionMode getAdaptionMode() const;
@@ -917,9 +905,6 @@ protected:
 
 	bool testAlterationFlags(AlterationFlags availableFlags, AlterationFlags requestedFlags) const;
 
-	void setSpawnStatus(SpawnStatus status);
-	virtual std::vector<adaption::Info> _spawn(bool trackAdaption);
-
 	void setAdaptionMode(AdaptionMode mode);
 	void setAdaptionStatus(AdaptionStatus status);
 	virtual std::vector<adaption::Info> _adaptionPrepare(bool trackAdaption);
@@ -1026,8 +1011,6 @@ private:
 	AdjacenciesBuildStrategy m_adjacenciesBuildStrategy;
 
 	InterfacesBuildStrategy m_interfacesBuildStrategy;
-
-	SpawnStatus m_spawnStatus;
 
 	AdaptionMode m_adaptionMode;
 	AdaptionStatus m_adaptionStatus;

--- a/src/volcartesian/volcartesian.hpp
+++ b/src/volcartesian/volcartesian.hpp
@@ -149,8 +149,6 @@ public:
 	long getCellFaceNeighsLinearId(long id, int face) const;
 
 protected:
-	std::vector<adaption::Info> _spawn(bool trackSpawn) override;
-
 	void _updateAdjacencies() override;
 
 	void _updateInterfaces() override;

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -482,12 +482,15 @@ void VolOctree::initialize()
 {
 	log::cout() << ">> Initializing Octree mesh" << std::endl;
 
+	// Set the adaption as clean
+	//
+	// Setting the adaptation as dirty guarantees that, at the first patch
+	// updated, all the data structures will be properly initialized.
+	setAdaptionStatus(ADAPTION_DIRTY);
+
 	// Reset the cell and interface type info
 	m_cellTypeInfo      = nullptr;
 	m_interfaceTypeInfo = nullptr;
-
-	// This patch need to be spawn
-	setSpawnStatus(SPAWN_NEEDED);
 
 	// Initialize the tolerance
 	//
@@ -923,26 +926,6 @@ int VolOctree::getCellFamilySplitLocalVertex(long id) const
 }
 
 /*!
-	Generates the patch.
-
-	\param trackSpawn if set to true the changes to the patch will be tracked
-	\result Returns a vector of adaption::Info that can be used to track
-	the changes done during the update.
-*/
-std::vector<adaption::Info> VolOctree::_spawn(bool trackSpawn)
-{
-	std::vector<adaption::Info> updateInfo;
-
-	// Perform initial import
-	if (empty()) {
-		m_tree->adapt();
-		updateInfo = sync(trackSpawn);
-	}
-
-	return updateInfo;
-}
-
-/*!
 	Prepares the patch for performing the adaption.
 
 	NOTE: only cells are tracked.
@@ -956,10 +939,6 @@ std::vector<adaption::Info> VolOctree::_spawn(bool trackSpawn)
 std::vector<adaption::Info> VolOctree::_adaptionPrepare(bool trackAdaption)
 {
 	BITPIT_UNUSED(trackAdaption);
-
-	if (getSpawnStatus() == SPAWN_NEEDED) {
-		throw std::runtime_error ("The initial import has not been performed.");
-	}
 
 	// Call pre-adapt routine
 	m_tree->preadapt();

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -131,8 +131,6 @@ protected:
 	void setCommunicator(MPI_Comm communicator) override;
 #endif
 
-	std::vector<adaption::Info> _spawn(bool trackSpawn) override;
-
 	void _updateAdjacencies() override;
 
 	std::vector<adaption::Info> _adaptionPrepare(bool trackAdaption) override;


### PR DESCRIPTION
The function "spawn" is now obsolete, the first update of the patch will take care of the initialization.

Depends on #371 and #370.