### PR TITLE
levelset: fix evaluation of levelset for surfaces that contain pixel elements

### DIFF
--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -189,8 +189,9 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
 
     default:
     {
+        ConstProxyVector<long> elementVertexIds = m_surface->getFacetOrderedVertexIds(segment);
         BITPIT_CREATE_WORKSPACE(segmentVertexCoors, std::array<double BITPIT_COMMA 3>, nSegmentVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);
-        m_surface->getElementVertexCoordinates(segment, segmentVertexCoors);
+        m_surface->getVertexCoords(elementVertexIds.size(), elementVertexIds.data(), segmentVertexCoors);
         pointProjectionVector -= CGElem::projectPointPolygon( pointCoords, nSegmentVertices, segmentVertexCoors, lambda );
 
         break;

--- a/src/patchkernel/element.tpp
+++ b/src/patchkernel/element.tpp
@@ -182,9 +182,9 @@ std::size_t ElementHalfItem<DerivedElement>::Hasher::operator()(const ElementHal
 		}
 	} else {
 		// Reversing the winding of pixel elements needs special handling. In
-		// pixel elements, vertices are ordered using a Z-order, wherase in
-		// all other elements ordering of the vertices is anti-clockwise.
-		if (item.m_element.getType() != ElementType::VOXEL) {
+		// pixel elements, vertices are ordered using the Z-order, whereas in
+		// all other elements vertices are ordered anti-clockwise.
+		if (item.m_element.getType() != ElementType::PIXEL) {
 			for (std::size_t i = nVertices; i > 0; --i) {
 				std::size_t k = (item.m_firstVertexId + i) % nVertices;
 				utils::hashing::hash_combine(hash, vertexIds[k]);

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -73,6 +73,8 @@ public:
     bool adjustCellOrientation(long id, bool invert = false);
     void flipCellOrientation(long id);
 
+    ConstProxyVector<long> getFacetOrderedVertexIds(const Cell &facet) const;
+
     void displayQualityStats(std::ostream&, unsigned int padding = 0) const;
     std::vector<double> computeHistogram(eval_f_ funct_, std::vector<double> &bins, long &count, int n_intervals = 8, unsigned short mask = SELECT_ALL) const;
 
@@ -97,7 +99,8 @@ protected:
     SurfaceKernel(int id, int dimension, bool expert);
 #endif
 
-    int getOrderedLocalVertexIds(const Cell &cell, long n) const;
+    bool areFacetVerticesOrdered(const Cell &facet) const;
+    int getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const;
 
 };
 


### PR DESCRIPTION
Connectivity of pixel elements does not list the vertices in anti-clockwise order. This needs to be properly taken into account when flipping the normal and when evaluating segment information.