### PR TITLE
patchkernel: fix collapse of coincident vertices

### DIFF
--- a/src/patchkernel/element.cpp
+++ b/src/patchkernel/element.cpp
@@ -1446,9 +1446,11 @@ ConstProxyVector<int> Element::getEdgeLocalVertexIds(int edge) const
 	remain unchanged.
 
 	\param map is the map that will be used for the renumbering
+	\result The number of vertices that have been renumbered
 */
-void Element::renumberVertices(const std::unordered_map<long, long> &map)
+int Element::renumberVertices(const std::unordered_map<long, long> &map)
 {
+	int nRenumberedVertices = 0;
 	switch (m_type) {
 
 	case ElementType::POLYGON:
@@ -1459,6 +1461,7 @@ void Element::renumberVertices(const std::unordered_map<long, long> &map)
 			auto mapItr = map.find(connectivity[k]);
 			if (mapItr != map.end()) {
 				connectivity[k] = mapItr->second;
+				++nRenumberedVertices;
 			}
 		}
 
@@ -1479,6 +1482,7 @@ void Element::renumberVertices(const std::unordered_map<long, long> &map)
 				auto mapItr = map.find(connectivity[k]);
 				if (mapItr != map.end()) {
 					connectivity[k] = mapItr->second;
+					++nRenumberedVertices;
 				}
 			}
 		}
@@ -1496,6 +1500,7 @@ void Element::renumberVertices(const std::unordered_map<long, long> &map)
 			auto mapItr = map.find(connectivity[k]);
 			if (mapItr != map.end()) {
 				connectivity[k] = mapItr->second;
+				++nRenumberedVertices;
 			}
 		}
 
@@ -1503,6 +1508,8 @@ void Element::renumberVertices(const std::unordered_map<long, long> &map)
 	}
 
 	}
+
+	return nRenumberedVertices;
 }
 
 /*!

--- a/src/patchkernel/element.hpp
+++ b/src/patchkernel/element.hpp
@@ -141,7 +141,7 @@ public:
 	ConstProxyVector<int> getEdgeLocalVertexIds(int edge) const;
 
 	int getVertexCount() const;
-	void renumberVertices(const std::unordered_map<long, long> &map);
+	int renumberVertices(const std::unordered_map<long, long> &map);
 	ConstProxyVector<long> getVertexIds() const;
 	long getVertexId(int vertex) const;
 	int findVertex(long vertexId) const;

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -2243,6 +2243,12 @@ std::vector<long> PatchKernel::collapseCoincidentVertices()
 			updateAdjacencies();
 		}
 
+		// Update interface
+		for (Interface &interface : m_interfaces) {
+			// Renumber interface vertices
+			interface.renumberVertices(vertexMap);
+		}
+
 		// Create the list of collapsed vertices
 		collapsedVertices.resize(vertexMap.size());
 


### PR DESCRIPTION
When coincident vertices are collapsed, interfaces and adjacencies need to be updated accordingly.