### PR TITLE
IO: add missing PCells section in VTK parallel files

### DIFF
--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -560,6 +560,15 @@ void VTKUnstructuredGrid::writeCollection( ){
     writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::POINTS)] ) ;
     str << "      </PPoints>" << std::endl;
 
+    str << "      <PCells>" << std::endl;
+    writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::OFFSETS)] ) ;
+    writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::TYPES)] ) ;
+    writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::CONNECTIVITY)] ) ;
+    if (m_nFaceStreamEntries) {
+        writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::FACE_STREAMS)] ) ;
+        writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::FACE_OFFSETS)] ) ;
+    }
+    str << "      </PCells>" << std::endl;
 
     for( int i=0; i<m_procs; i++){
         fho.setBlock(i) ;

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -558,7 +558,6 @@ void VTKUnstructuredGrid::writeCollection( ){
     //Wring Geometry Information
     str << "      <PPoints>" << std::endl;
     writePDataArray( str, m_geometry[getFieldGeomId(VTKUnstructuredField::POINTS)] ) ;
-    str << std::endl ;
     str << "      </PPoints>" << std::endl;
 
 


### PR DESCRIPTION
It seems that pvtu files should contain a PCells section. I wasn't able to find any documentation about which sections are required in those files. What I did, was adding a PCells section with a list of cell-related arrays that will be contained in the vtu files associated with the collection. 

I'm not able to properly test the changes, because ParaView is able to open the pvtu files generated by bitpit even without these changes.