### PR TITLE
test: fix volunstructured tests

### DIFF
--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
@@ -46,7 +46,7 @@ int subtest_001(int rank, VolUnstructured *patch_2D, VolUnstructured *patch_2D_r
     // Create the patch
     log::cout() << "Creating 2D patch..." << std::endl;
 
-    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD, 2);
+    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD, 2ul);
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
     patch_2D->setVertexAutoIndexing(false);
@@ -323,7 +323,7 @@ int subtest_002(int rank, VolUnstructured *patch_3D, VolUnstructured *patch_3D_r
     // Create the patch
     log::cout() << "\n\n:: 3D unstructured mesh ::\n";
 
-    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD, 2);
+    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD, 2ul);
     patch_3D->getVTK().setName("unstructured_patch_3D");
 
     patch_3D->setVertexAutoIndexing(false);

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
@@ -112,7 +112,7 @@ int subtest_001(int rank)
     // Create the patch
     log::cout() << "Creating patch..." << std::endl;
 
-    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD, 3));
+    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD, 3ul));
     if (rank == 0) {
         fillMesh(patch.get());
     }

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00005.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00005.cpp
@@ -52,7 +52,7 @@ int subtest_001()
     //
     // Create the patch
     //
-    int haloLayers = 2;
+    std::size_t haloLayers = 2;
     std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(2, MPI_COMM_WORLD, haloLayers));
     patch->getVTK().setName("test_00005_mesh");
     patch->setVertexAutoIndexing(false);


### PR DESCRIPTION
Fix VolUnstructured tests for MPICH implementation.

When using MPICH as MPI implementation the MPI_Comm is a typedef of integer.

The overloaded constructors of VolUnstrunctured are ambiguous when the argument are not explicitly casted. 

  