### PR TITLE
patchkernel: declare SkdNode constructors as public

### DIFF
--- a/src/patchkernel/patch_skd_tree.cpp
+++ b/src/patchkernel/patch_skd_tree.cpp
@@ -1182,7 +1182,7 @@ void PatchSkdTree::clear(bool release)
     m_nMaxLeafCells = 0;
 
     if (release) {
-        std::vector<SkdNode, SkdNode::Allocator>().swap(m_nodes);
+        std::vector<SkdNode>().swap(m_nodes);
         std::vector<std::size_t>().swap(m_cellRawIds);
     } else {
         m_nodes.clear();

--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -107,6 +107,9 @@ public:
         CHILD_END   = 2
     };
 
+    SkdNode();
+    SkdNode(const SkdPatchInfo *patchInfo, std::size_t cellRangeBegin, std::size_t cellRangeEnd);
+
     std::size_t getCellCount() const;
     std::vector<long> getCells() const;
     long getCell(std::size_t n) const;
@@ -124,22 +127,6 @@ public:
 
     void findPointClosestCell(const std::array<double, 3> &point, bool interiorCellsOnly, long *closestId, double *closestDistance) const;
     void updatePointClosestCell(const std::array<double, 3> &point, bool interiorCellsOnly, long *closestId, double *closestDistance) const;
-
-protected:
-    struct Allocator : std::allocator<SkdNode>
-    {
-        template<typename U, typename... Args>
-        void construct(U* p, Args&&... args)
-        {
-            ::new((void *)p) U(std::forward<Args>(args)...);
-        }
-
-        template<typename U> struct rebind { typedef Allocator other; };
-
-    };
-
-    SkdNode();
-    SkdNode(const SkdPatchInfo *patchInfo, std::size_t cellRangeBegin, std::size_t cellRangeEnd);
 
 private:
     const SkdPatchInfo *m_patchInfo;
@@ -218,7 +205,7 @@ protected:
     std::size_t m_nMinLeafCells;
     std::size_t m_nMaxLeafCells;
 
-    std::vector<SkdNode, SkdNode::Allocator> m_nodes;
+    std::vector<SkdNode> m_nodes;
 
     bool m_interiorCellsOnly;
 


### PR DESCRIPTION
Having public constructors allows to get rid of the custom allocator.