### PR TITLE
LA: fixes for serial builds

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -907,6 +907,8 @@ void SystemSolver::assembly(MPI_Comm communicator, bool isPartitioned, const Sys
  * system matrix will be set equal to the block size specified by the assembler.
  *
  * \param assembler is the matrix assembler
+ * \param reordering is the reordering that will be applied when assemblying the
+ * system
  */
 void SystemSolver::assembly(const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering)
 {

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -848,32 +848,6 @@ void SystemSolver::assembly(const SparseMatrix &matrix, const SystemMatrixOrderi
  * will be created with a unitary block size. Otherwise, the block size of the
  * system matrix will be set equal to the block size specified by the assembler.
  *
- * \param assembler is the matrix assembler
- */
-void SystemSolver::assembly(const SystemMatrixAssembler &assembler)
-{
-    assembly(MPI_COMM_SELF, false, assembler, NaturalSystemMatrixOrdering());
-}
-
-/*!
- * Assembly the system.
- *
- * \param assembler is the matrix assembler
- * \param reordering is the reordering that will be applied when assemblying the
- * system
- */
-void SystemSolver::assembly(const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering)
-{
-    assembly(MPI_COMM_SELF, false, assembler, reordering);
-}
-
-/*!
- * Assembly the system.
- *
- * If the system was created with the flatten flag set to true, the system matrix
- * will be created with a unitary block size. Otherwise, the block size of the
- * system matrix will be set equal to the block size specified by the assembler.
- *
  * \param communicator is the MPI communicator
  * \param isPartitioned controls if the system is partitioned
  * \param assembler is the matrix assembler
@@ -899,6 +873,20 @@ void SystemSolver::assembly(MPI_Comm communicator, bool isPartitioned, const Sys
 void SystemSolver::assembly(MPI_Comm communicator, bool isPartitioned, const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering)
 {
 #else
+/*!
+ * Assembly the system.
+ *
+ * If the system was created with the flatten flag set to true, the system matrix
+ * will be created with a unitary block size. Otherwise, the block size of the
+ * system matrix will be set equal to the block size specified by the assembler.
+ *
+ * \param assembler is the matrix assembler
+ */
+void SystemSolver::assembly(const SystemMatrixAssembler &assembler)
+{
+    assembly(assembler, NaturalSystemMatrixOrdering());
+}
+
 /*!
  * Assembly the system.
  *

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -267,11 +267,12 @@ public:
 
     void assembly(const SparseMatrix &matrix);
     void assembly(const SparseMatrix &matrix, const SystemMatrixOrdering &reordering);
-    void assembly(const SystemMatrixAssembler &assembler);
-    void assembly(const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering);
 #if BITPIT_ENABLE_MPI==1
     void assembly(MPI_Comm communicator, bool isPartitioned, const SystemMatrixAssembler &assembler);
     void assembly(MPI_Comm communicator, bool isPartitioned, const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering);
+#else
+    void assembly(const SystemMatrixAssembler &assembler);
+    void assembly(const SystemMatrixAssembler &assembler, const SystemMatrixOrdering &reordering);
 #endif
     bool isAssembled() const;
 


### PR DESCRIPTION
System Solver 's assembly methods have been fixed to build without MPI