### PR TITLE
levelset: fix evalution of segment information for points that lie on the segmentation

### DIFF
--- a/src/CG/CG_elem.cpp
+++ b/src/CG/CG_elem.cpp
@@ -48,8 +48,8 @@ namespace CGElem{
 /*!
  * \private
  * Projects points on a triangle.
- * Transcribed from Christer Ericson's Real-Time Collision Detection book,
- * it's effectively Cramer's rule for solving a linear system.
+ * See "Computing the Barycentric Coordinates of a Projected Point", W. Heidrich,
+ * Journal of Graphics, GPU, and Game Tools,Volume 10, Issue 3, 2005.
  * Projection points are the closest points to the original points within the triangle.
  *
  * \param[in] nPoints number of points
@@ -68,21 +68,15 @@ void _projectPointsTriangle( int nPoints, array3D const *points, array3D const &
     array3D v0 = Q1 - Q0;
     array3D v1 = Q2 - Q0;
 
-    double d00 = dotProduct(v0, v0);
-    double d01 = dotProduct(v0, v1);
-    double d11 = dotProduct(v1, v1);
-
-    double denom = d00 * d11 - d01 * d01;
+    array3D n = crossProduct(v0, v1);
+    double n2 = dotProduct(n, n);
 
     for( int i=0; i<nPoints; ++i){
         array3D v2 = points[i] - Q0;
 
-        double d20 = dotProduct(v2, v0);
-        double d21 = dotProduct(v2, v1);
-
         double *pointLambda = lambda + 3 * i;
-        pointLambda[1] = (d11 * d20 - d01 * d21) / denom;
-        pointLambda[2] = (d00 * d21 - d01 * d20) / denom;
+        pointLambda[2] = dotProduct(crossProduct(v0, v2), n) / n2;
+        pointLambda[1] = dotProduct(crossProduct(v2, v1), n) / n2;
         pointLambda[0] = 1. - pointLambda[1] - pointLambda[2];
 
         array3D *pointProjections = proj + i;

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -230,8 +230,21 @@ int SegmentationKernel::getSegmentInfo( const std::array<double,3> &pointCoords,
     // on the segmentation or on the normal plane. In the latter case the sign
     // must be evaluated taking into account the the curvature of the surface.
     // However, this is not yet implemented.
+    //
+    // The sign should be evaluated with the same tolerance used when checking
+    // if the point lies on the segmentation.
     std::array<double, 3> pseudoNormal = computePseudoNormal(segmentIterator, lambda);
-    int s = sign( dotProduct(pointProjectionVector, pseudoNormal) );
+    double pointProjectionNormalComponent = dotProduct(pointProjectionVector, pseudoNormal);
+
+    int s;
+    if (utils::DoubleFloatingEqual()(pointProjectionNormalComponent, 0., distanceTolerance, distanceTolerance)) {
+        s = 0;
+    } else if (pointProjectionNormalComponent > 0) {
+        s = 1;
+    } else {
+        s = -1;
+    }
+
     if (!pointOnSegmentation && s == 0) {
         distance = levelSetDefaults::VALUE;
         gradient = levelSetDefaults::GRADIENT;

--- a/src/levelset/levelSetSegmentationObject.tpp
+++ b/src/levelset/levelSetSegmentationObject.tpp
@@ -496,7 +496,7 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::computeNarrowBand( LevelSe
         std::array<double, 3> normal;
         int error = m_segmentation->getSegmentInfo(cellCentroid, segmentId, signd, distance, gradient, normal);
         if (error) {
-            throw std::runtime_error ("Unable to extract the levelset information from segment.");
+            throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
         }
 
 
@@ -582,7 +582,7 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::computeNarrowBand( LevelSe
         std::array<double,3> normal;
         int error = m_segmentation->getSegmentInfo(cellCentroid, segmentId, signd, distance, gradient, normal);
         if (error) {
-            throw std::runtime_error ("Unable to extract the levelset information from segment.");
+            throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
         }
 
         typename narrow_band_cache_t::KernelIterator narrowBandCacheItr = narrowBandCache->insert(cellId, true) ;
@@ -642,7 +642,7 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::computeNarrowBand( LevelSe
             std::array<double,3> normal;
             int error = m_segmentation->getSegmentInfo(neighCentroid, segmentId, signd, distance, gradient, normal);
             if (error) {
-                throw std::runtime_error ("Unable to extract the levelset information from segment.");
+                throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
             }
 
             typename narrow_band_cache_t::KernelIterator narrowBandCacheItr = narrowBandCache->insert(neighId, true) ;
@@ -718,7 +718,7 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::updateNarrowBand( LevelSet
             std::array<double,3> normal;
             int error = m_segmentation->getSegmentInfo(centroid, segmentId, signd, distance, gradient, normal);
             if (error) {
-                throw std::runtime_error ("Unable to extract the levelset information from segment.");
+                throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
             }
 
             typename narrow_band_cache_t::KernelIterator narrowBandCacheItr = narrowBandCache->insert(cellId, true) ;
@@ -777,7 +777,7 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::updateNarrowBand( LevelSet
         std::array<double,3> normal;
         int error = m_segmentation->getSegmentInfo(cellCentroid, segmentId, signd, distance, gradient, normal);
         if (error) {
-            throw std::runtime_error ("Unable to extract the levelset information from segment.");
+            throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
         }
 
         typename narrow_band_cache_t::KernelIterator narrowBandCacheItr = narrowBandCache->insert(cellId, true) ;
@@ -802,7 +802,7 @@ LevelSetInfo LevelSetSegmentationObject<narrow_band_cache_t>::computeLevelSetInf
 
     int error = m_segmentation->getSegmentInfo(coords, segmentId, false, distance, gradient, normal);
     if (error) {
-        throw std::runtime_error ("Unable to extract the levelset information from segment.");
+        throw std::runtime_error ("Unable to extract the levelset information from segment " + std::to_string(segmentId) + ".");
     }
 
     return LevelSetInfo(distance,gradient);


### PR DESCRIPTION
Levelset sign should be evaluated with the same tolerance used when checking if the point lies on the segmentation. Also, I've replace the algorithm for projection points onto triangles. The new algorithm is more precise when the point lies on the triangle.