### PR TITLE
cicd: add github configuration to run continuous integration

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,119 @@
+name: Continuous integration
+
+on:
+  workflow_dispatch:
+    inputs:
+  pull_request:
+    branches: [ "master" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu
+    name: Setup
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build environment
+        shell: bash
+        run: |
+          DOCKER_BUILDKIT=1 docker buildx build \
+          --builder=container \
+          --cache-from type=local,src=/home/bob/products/bitpit/ubuntu-cache \
+          --cache-to type=local,dest=/home/bob/products/bitpit/ubuntu-cache \
+          --rm \
+          --target bitpit-environment \
+          -f environments/ubuntu/Dockerfile .
+      - name: Remove temporary docker images and containers
+        shell: bash
+        run: |
+          for CONTAINER in $(docker ps -a -q)
+          do
+            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${CONTAINER})
+            if [[ ${LABEL} == "bitpit-"* && ${LABEL} != "bitpit-environment" ]]; then
+              [ -z "$(docker ps --format '{{.ID}}' | grep "${CONTAINER}" -w)" ] || docker stop ${CONTAINER}
+              docker rm ${CONTAINER}
+            fi
+          done
+          for IMAGE in $(docker images -q --filter dangling=true)
+          do
+            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${IMAGE})
+            if [[ ${LABEL} == "bitpit-"* && ${LABEL} != "bitpit-environment" ]]; then
+              docker rmi ${IMAGE}
+            fi
+          done
+  tests:
+    runs-on: ubuntu
+    needs: setup
+    name: (${{ matrix.compiler }}) MPI ${{ matrix.mpi }} - Debug ${{ matrix.debug }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            mpi: ON
+            debug: ON
+          - compiler: gcc
+            mpi: ON
+            debug: OFF
+          - compiler: gcc
+            mpi: OFF
+            debug: ON
+          - compiler: gcc
+            mpi: OFF
+            debug: OFF
+          - compiler: clang
+            mpi: ON
+            debug: OFF
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build bitpit
+        shell: bash
+        run: |
+          DOCKER_BUILDKIT=1 docker buildx build \
+          --builder=container \
+          --cache-from type=local,src=/home/bob/products/bitpit/ubuntu-cache \
+          --rm \
+          --build-arg COMPILER=${{ matrix.compiler }} \
+          --build-arg MPI=${{ matrix.mpi }} \
+          --build-arg DEBUG=${{ matrix.debug }} \
+          --target bitpit-build \
+          -f environments/ubuntu/Dockerfile .
+      - name: Run bitpit tests
+        shell: bash
+        run: |
+          DOCKER_BUILDKIT=1 docker buildx build \
+          --builder=container \
+          --cache-from type=local,src=/home/bob/products/bitpit/ubuntu-cache \
+          --rm \
+          --build-arg COMPILER=${{ matrix.compiler }} \
+          --build-arg MPI=${{ matrix.mpi }} \
+          --build-arg DEBUG=${{ matrix.debug }} \
+          --target bitpit-test \
+          -f environments/ubuntu/Dockerfile .
+  cleanup:
+    runs-on: ubuntu
+    needs: tests
+    name: Cleanup
+    if: always()
+    steps:
+      - name: Remove docker images and containers
+        shell: bash
+        run: |
+          for CONTAINER in $(docker ps -a -q)
+          do
+            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${CONTAINER})
+            if [[ ${LABEL} == "bitpit-"* ]]; then
+              [ -z "$(docker ps --format '{{.ID}}' | grep "${CONTAINER}" -w)" ] || docker stop ${CONTAINER}
+              docker rm ${CONTAINER}
+            fi
+          done
+          for IMAGE in $(docker images -q --filter dangling=true)
+          do
+            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${IMAGE})
+            if [[ ${LABEL} == "bitpit-"* ]]; then
+              docker rmi ${IMAGE}
+            fi
+          done

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,12 @@ jobs:
     runs-on: ubuntu
     name: Setup
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout build environment information
+        uses: actions/checkout@v3
+        with:
+          path: bitpit
+          sparse-checkout: |
+            environments
       - name: Build environment
         shell: bash
         run: |
@@ -25,25 +30,10 @@ jobs:
           --cache-to type=local,dest=/home/bob/products/bitpit/ubuntu-cache \
           --rm \
           --target bitpit-environment \
-          -f environments/ubuntu/Dockerfile .
-      - name: Remove temporary docker images and containers
-        shell: bash
+          -f bitpit/environments/ubuntu/Dockerfile .
+      - name: Cleanup build environment information
         run: |
-          for CONTAINER in $(docker ps -a -q)
-          do
-            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${CONTAINER})
-            if [[ ${LABEL} == "bitpit-"* && ${LABEL} != "bitpit-environment" ]]; then
-              [ -z "$(docker ps --format '{{.ID}}' | grep "${CONTAINER}" -w)" ] || docker stop ${CONTAINER}
-              docker rm ${CONTAINER}
-            fi
-          done
-          for IMAGE in $(docker images -q --filter dangling=true)
-          do
-            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${IMAGE})
-            if [[ ${LABEL} == "bitpit-"* && ${LABEL} != "bitpit-environment" ]]; then
-              docker rmi ${IMAGE}
-            fi
-          done
+          rm -rf bitpit
   tests:
     runs-on: ubuntu
     needs: setup
@@ -68,7 +58,8 @@ jobs:
             mpi: ON
             debug: OFF
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout bitpit
+        uses: actions/checkout@v3
       - name: Build bitpit
         shell: bash
         run: |
@@ -93,27 +84,3 @@ jobs:
           --build-arg DEBUG=${{ matrix.debug }} \
           --target bitpit-test \
           -f environments/ubuntu/Dockerfile .
-  cleanup:
-    runs-on: ubuntu
-    needs: tests
-    name: Cleanup
-    if: always()
-    steps:
-      - name: Remove docker images and containers
-        shell: bash
-        run: |
-          for CONTAINER in $(docker ps -a -q)
-          do
-            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${CONTAINER})
-            if [[ ${LABEL} == "bitpit-"* ]]; then
-              [ -z "$(docker ps --format '{{.ID}}' | grep "${CONTAINER}" -w)" ] || docker stop ${CONTAINER}
-              docker rm ${CONTAINER}
-            fi
-          done
-          for IMAGE in $(docker images -q --filter dangling=true)
-          do
-            LABEL=$(docker inspect --format '{{ index .Config.Labels "stage"}}' ${IMAGE})
-            if [[ ${LABEL} == "bitpit-"* ]]; then
-              docker rmi ${IMAGE}
-            fi
-          done

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,52 +30,6 @@ env:
 
 jobs:
   include:
-    - if: branch != coverity
-      os: linux
-      env:
-        - BUILD_TYPE="Release" BITPIT_ENABLE_MPI="True"
-
-    - if: branch != coverity
-      os: linux
-      env:
-        - BUILD_TYPE="Release" BITPIT_ENABLE_MPI="False"
-
-    - if: branch != coverity
-      os: linux
-      env:
-        - BUILD_TYPE="Debug" BITPIT_ENABLE_MPI="True"
-
-    - if: branch != coverity
-      os: linux
-      env:
-        - BUILD_TYPE="Debug" BITPIT_ENABLE_MPI="False"
-
-    - if: branch != coverity
-      os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang
-            - g++-7
-            - gfortran-7
-            - cmake
-            - libblas-dev
-            - liblapack-dev
-            - liblapacke-dev
-            - openmpi-bin
-            - libboost-all-dev
-            - libopenmpi-dev
-            - libpetsc3.6
-            - libpetsc3.6.2-dev
-
-      env:
-        - C_COMPILER="clang"
-        - CXX_COMPILER="clang++"
-        - Fortran_COMPILER="gfortran-7"
-        - BUILD_TYPE="Release" BITPIT_ENABLE_MPI="True"
-
     - if: branch = coverity
       os: linux
       addons:

--- a/environments/ubuntu/Dockerfile
+++ b/environments/ubuntu/Dockerfile
@@ -1,0 +1,127 @@
+ARG MPI=ON
+ARG DEBUG=OFF
+
+FROM ubuntu:20.04 AS bitpit-ubuntu-base
+LABEL stage=bitpit-ubuntu-base
+ENV DEBIAN_FRONTEND noninteractive
+RUN sed -i "s/htt[p|ps]:\/\/archive.ubuntu.com\/ubuntu\//mirror:\/\/mirrors.ubuntu.com\/mirrors.txt/g" /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y \
+        build-essential \
+        cmake \
+        clang \
+        libblas-dev  \
+        liblapack-dev  \
+        liblapacke-dev \
+        mpich \
+        libxml2-dev \
+        libmetis-dev \
+        git \
+        wget \
+        python3 \
+        rapidjson-dev
+
+FROM bitpit-ubuntu-base AS bitpit-ubuntu-mpi
+LABEL stage=bitpit-ubuntu-mpi
+RUN cd /opt && \
+    wget https://www.mpich.org/static/downloads/4.0.3/mpich-4.0.3.tar.gz && \
+    tar xzf mpich-4.0.3.tar.gz && \
+    cd mpich-4.0.3 && \
+    ./configure --prefix=/usr/local && \
+    make -j10 && \
+    make install && \
+    cd .. && \
+    rm -rf mpich-4.0.3*
+
+FROM bitpit-ubuntu-base AS bitpit-ubuntu-boost
+LABEL stage=bitpit-ubuntu-boost
+RUN cd /opt && \
+    wget --no-verbose https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz && \
+    tar xzf boost_1_71_0.tar.gz && \
+    cd boost_1_71_0 && \
+    ./bootstrap.sh --prefix=/opt/boost-install && ./b2 -j 10 install && \
+    cd .. && \
+    rm -rf boost_1_71_0
+
+FROM bitpit-ubuntu-mpi AS bitpit-ubuntu-petsc
+LABEL stage=bitpit-ubuntu-petsc
+RUN cd /opt && \
+    git clone --depth 1 --single-branch -b release https://gitlab.com/petsc/petsc.git petsc-code && \
+    cd petsc-code && \
+    for MPI in "OFF" "ON"; do \
+        if [ "${MPI}" = "ON" ]; then \
+            PETSC_DIR="/opt/petsc-install"; \
+            PETSC_MPI_OPTIONS="--with-mpi=1 --with-mpi-dir=/usr/local/"; \
+        else \
+            PETSC_DIR="/opt/petsc-serial-install"; \
+            PETSC_MPI_OPTIONS="--with-mpi=0"; \
+        fi && \
+        ./configure \
+            ${PETSC_MPI_OPTIONS} \
+            --prefix=${PETSC_DIR} \
+            --with-debug=0 \
+            --with-shared-libraries=1 \
+            --with-scalar-type=real && \
+            COPTFLAGS='-O3 -march=native -mtune=native' \
+            CXXOPTFLAGS='-O3 -march=native -mtune=native' \
+            FOPTFLAGS='-O3 -march=native -mtune=native' \
+        make -j10 && \
+        make install; \
+    done && \
+    cd .. && \
+    rm -rf petsc-code
+
+FROM bitpit-ubuntu-mpi AS bitpit-environment
+LABEL stage=bitpit-environment
+COPY --from=bitpit-ubuntu-boost /opt/boost-install/ /usr/local/
+COPY --from=bitpit-ubuntu-petsc /opt/petsc-install /opt/petsc-install
+COPY --from=bitpit-ubuntu-petsc /opt/petsc-serial-install /opt/petsc-serial-install
+
+FROM bitpit-environment AS bitpit-build
+LABEL stage=bitpit-build
+COPY . /opt/bitpit
+ARG MPI
+ARG DEBUG
+ARG COMPILER
+RUN cd /opt/bitpit && \
+    mkdir build && \
+    cd build && \
+    if [ "$DEBUG" = "ON" ]; then \
+      BUILD_TYPE="Debug"; \
+    else \
+      BUILD_TYPE="Release"; \
+    fi && \
+    if [ "${MPI}" = "ON" ]; then \
+        PETSC_DIR="/opt/petsc-install"; \
+    else \
+        PETSC_DIR="/opt/petsc-serial-install"; \
+    fi && \
+    if [ "${COMPILER}" = "clang" ]; then \
+        C_COMPILER="clang"; \
+        CXX_COMPILER="clang++"; \
+        Fortran_COMPILER="gfortran"; \
+    else \
+        C_COMPILER="gcc"; \
+        CXX_COMPILER="g++"; \
+        Fortran_COMPILER="gfortran"; \
+    fi && \
+    cmake \
+        -DBITPIT_BUILD_EXAMPLES=ON \
+        -DBITPIT_BUILD_SHARED_LIBS=ON \
+        -DBITPIT_ENABLE_INTEGRATION_TESTS=ON \
+        -DBITPIT_ENABLE_MPI=${MPI} \
+        -DBITPIT_ENABLE_UNIT_TESTS=ON \
+        -DBITPIT_BUILD_EXAMPLES=ON \
+        -DBITPIT_VERBOSE_MAKE=ON \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_C_COMPILER=${C_COMPILER} \
+        -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
+        -DCMAKE_Fortran_COMPILER=${Fortran_COMPILER} \
+        -DPETSC_DIR=${PETSC_DIR} \
+        ../ && \
+    make -j10
+
+FROM bitpit-build AS bitpit-test
+LABEL stage=bitpit-test
+RUN cd /opt/bitpit/build && \
+    ctest --output-on-failure

--- a/environments/ubuntu/Dockerfile
+++ b/environments/ubuntu/Dockerfile
@@ -1,6 +1,3 @@
-ARG MPI=ON
-ARG DEBUG=OFF
-
 FROM ubuntu:20.04 AS bitpit-ubuntu-base
 LABEL stage=bitpit-ubuntu-base
 ENV DEBIAN_FRONTEND noninteractive
@@ -111,8 +108,7 @@ RUN cd /opt/bitpit && \
         -DBITPIT_ENABLE_INTEGRATION_TESTS=ON \
         -DBITPIT_ENABLE_MPI=${MPI} \
         -DBITPIT_ENABLE_UNIT_TESTS=ON \
-        -DBITPIT_BUILD_EXAMPLES=ON \
-        -DBITPIT_VERBOSE_MAKE=ON \
+        -DBUILD_TESTING=ON \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCMAKE_C_COMPILER=${C_COMPILER} \
         -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \


### PR DESCRIPTION
Continuous integration is now handled by github actions and runs on non-cloud machines (Ubuntu 20.4).

CI works in the same way as before, there are just some differences in the tests being run (we don't test anymore the compilation using older gcc versions).

The results of the tests are available at the follwing link: "https://github.com/optimad/bitpit/actions/workflows/continuous_integration.yml". Here an example of how the test results look like:
![bitpit_ci_1](https://github.com/optimad/bitpit/assets/7443174/96df48ec-a4d2-44e6-991d-bc2c91810da5)
![bitpit_ci_2](https://github.com/optimad/bitpit/assets/7443174/b297ce0d-3695-4bef-893f-a38f273f9c08)
