### PR TITLE
levelset: fix evaluation of levelset on segmentation with pixel elements

### DIFF
--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -306,6 +306,17 @@ std::array<double,3> SegmentationKernel::computePseudoNormal( const SurfUnstruct
     } else {
         int nSegmentVertices = segment.getVertexCount();
         positionFlag = CGElem::convertBarycentricToFlagPolygon(nSegmentVertices, lambda, m_surface->getTol());
+        if (positionFlag > 0) {
+            int polygonVertex = positionFlag - 1;
+            int elementVertex = m_surface->getFacetOrderedLocalVertex(segment, polygonVertex);
+
+            positionFlag = elementVertex + 1;
+        } else if (positionFlag < 0) {
+            int polygonEdge = (- positionFlag) - 1;
+            int elementEdge = m_surface->getFacetOrderedLocalEdge(segment, polygonEdge);
+
+            positionFlag = - (elementEdge + 1);
+        }
     }
 
     std::array<double,3> pseudoNormal;

--- a/src/levelset/levelSetSegmentationObject.tpp
+++ b/src/levelset/levelSetSegmentationObject.tpp
@@ -437,7 +437,10 @@ void LevelSetSegmentationObject<narrow_band_cache_t>::computeNarrowBand( LevelSe
     std::vector<std::array<double,3>> segmentVertexCoords;
     for (const Cell &segment : surface.getCells()) {
         // Get segment info
-        ConstProxyVector<long> segmentVertexIds = segment.getVertexIds();
+        //
+        // Since vertex information will be passed to the CG module, we need to
+        // get the vertices in counter-clockwise order.
+        ConstProxyVector<long> segmentVertexIds = surface.getFacetOrderedVertexIds(segment);
         std::size_t nSegmentVertices = segmentVertexIds.size();
 
         // Get segment coordinates

--- a/src/patchkernel/element.tpp
+++ b/src/patchkernel/element.tpp
@@ -183,7 +183,7 @@ std::size_t ElementHalfItem<DerivedElement>::Hasher::operator()(const ElementHal
 	} else {
 		// Reversing the winding of pixel elements needs special handling. In
 		// pixel elements, vertices are ordered using the Z-order, whereas in
-		// all other elements vertices are ordered anti-clockwise.
+		// all other elements vertices are ordered counter-clockwise.
 		if (item.m_element.getType() != ElementType::PIXEL) {
 			for (std::size_t i = nVertices; i > 0; --i) {
 				std::size_t k = (item.m_firstVertexId + i) % nVertices;

--- a/src/patchkernel/element_reference.cpp
+++ b/src/patchkernel/element_reference.cpp
@@ -1176,6 +1176,30 @@ double Reference2DElementInfo::evalPointDistance(const std::array<double, 3> &po
 }
 
 /*!
+    Check if the vertices are ordered counter-clockwise.
+
+    \result Return true if the vertices are ordered counter-clockwise,
+    false otherwise.
+*/
+bool Reference2DElementInfo::areVerticesCCWOrdered() const
+{
+    return true;
+}
+
+/*!
+    Get the index of the vertex occupying the n-th position in the
+    counter-clockwise ordered list of vertices.
+
+    \param n is the requested position
+    \result The index of the vertex occupying the n-th position in the
+    counter-clockwise ordered list of vertices.
+*/
+int Reference2DElementInfo::getCCWOrderedVertex(int n) const
+{
+    return n;
+}
+
+/*!
     Gets the vertex coordinates ordered counter-clockwise.
 
     If the input vertex coordintaes are already ordered, the function will
@@ -1193,9 +1217,17 @@ void Reference2DElementInfo::getCCWVertexCoords(const std::array<double, 3> *ver
                                                 const std::array<double, 3> **ccwVertexCoords,
                                                 std::array<double, 3> *ccwVertexCoordsStorage) const
 {
-    BITPIT_UNUSED(ccwVertexCoordsStorage);
+    // Early return if vertex are already ordered
+    if (areVerticesCCWOrdered()) {
+        *ccwVertexCoords = vertexCoords;
+        return;
+    }
 
-    *ccwVertexCoords = vertexCoords;
+    // Order vertices
+    for (int i = 0; i < nVertices; ++i) {
+        ccwVertexCoordsStorage[i] = vertexCoords[getCCWOrderedVertex(i)];
+    }
+    *ccwVertexCoords = ccwVertexCoordsStorage;
 }
 
 /*!
@@ -1446,29 +1478,29 @@ std::array<double, 3> ReferencePixelInfo::evalNormal(const std::array<double, 3>
 }
 
 /*!
-    Gets the vertex coordinates ordered counter-clockwise.
+    Check if the vertices are ordered counter-clockwise.
 
-    If the input vertex coordintaes are already ordered, the function will
-    only make the output vertex coordinates point the input ones, otherwise
-    a full reoredr will be perfromed (the re-ordered coordinates will be
-    stored in the storage provided by the user).
-
-    \param vertexCoords are the coordinates of the vertices
-    \param[out] ccwVertexCoords on output will contain the coordinates of the
-    vertices ordered counter-clockwise
-    \param[out] ccwVertexCoordsStorage if a re-ordered is needed, this is the
-    storage that will contain the ordered coordinates
+    \result Return true if the vertices are ordered counter-clockwise,
+    false otherwise.
 */
-void ReferencePixelInfo::getCCWVertexCoords(const std::array<double, 3> *vertexCoords,
-                                            const std::array<double, 3> **ccwVertexCoords,
-                                            std::array<double, 3> *ccwVertexCoordsStorage) const
+bool ReferencePixelInfo::areVerticesCCWOrdered() const
 {
-    ccwVertexCoordsStorage[0] = vertexCoords[0];
-    ccwVertexCoordsStorage[1] = vertexCoords[1];
-    ccwVertexCoordsStorage[2] = vertexCoords[3];
-    ccwVertexCoordsStorage[3] = vertexCoords[2];
+    return false;
+}
 
-    *ccwVertexCoords = ccwVertexCoordsStorage;
+/*!
+    Get the index of the vertex occupying the n-th position in the
+    counter-clockwise ordered list of vertices.
+
+    \param n is the requested position
+    \result The index of the vertex occupying the n-th position in the
+    counter-clockwise ordered list of vertices.
+*/
+int ReferencePixelInfo::getCCWOrderedVertex(int n) const
+{
+    static const std::array<int, 4> CCW_ORDERED_VERTICES = {{0, 1, 3, 2}};
+
+    return CCW_ORDERED_VERTICES[n];
 }
 
 /*!

--- a/src/patchkernel/element_reference.cpp
+++ b/src/patchkernel/element_reference.cpp
@@ -1200,6 +1200,30 @@ int Reference2DElementInfo::getCCWOrderedVertex(int n) const
 }
 
 /*!
+    Check if the faces are ordered counter-clockwise.
+
+    \result Return true if the faces are ordered counter-clockwise,
+    false otherwise.
+*/
+bool Reference2DElementInfo::areFacesCCWOrdered() const
+{
+    return true;
+}
+
+/*!
+    Get the index of the face occupying the n-th position in the
+    counter-clockwise ordered list of faces.
+
+    \param n is the requested position
+    \result The local index of the face occupying the n-th position in the
+    counter-clockwise ordered list of faces.
+*/
+int Reference2DElementInfo::getCCWOrderedFace(int n) const
+{
+    return n;
+}
+
+/*!
     Gets the vertex coordinates ordered counter-clockwise.
 
     If the input vertex coordintaes are already ordered, the function will
@@ -1501,6 +1525,32 @@ int ReferencePixelInfo::getCCWOrderedVertex(int n) const
     static const std::array<int, 4> CCW_ORDERED_VERTICES = {{0, 1, 3, 2}};
 
     return CCW_ORDERED_VERTICES[n];
+}
+
+/*!
+    Check if the faces are ordered counter-clockwise.
+
+    \result Return true if the faces are ordered counter-clockwise,
+    false otherwise.
+*/
+bool ReferencePixelInfo::areFacesCCWOrdered() const
+{
+    return false;
+}
+
+/*!
+    Get the index of the face occupying the n-th position in the
+    counter-clockwise ordered list of faces.
+
+    \param[in] n is the requested position
+    \result The local index of the face occupying the n-th position in the
+    counter-clockwise ordered list of faces.
+*/
+int ReferencePixelInfo::getCCWOrderedFace(int n) const
+{
+    static const std::array<int, 4> CCW_ORDERED_FACES = {{2, 1, 3, 0}};
+
+    return CCW_ORDERED_FACES[n];
 }
 
 /*!

--- a/src/patchkernel/element_reference.hpp
+++ b/src/patchkernel/element_reference.hpp
@@ -202,6 +202,9 @@ public:
     virtual bool areVerticesCCWOrdered() const;
     virtual int getCCWOrderedVertex(int n) const;
 
+    virtual bool areFacesCCWOrdered() const;
+    virtual int getCCWOrderedFace(int n) const;
+
 protected:
     Reference2DElementInfo(ElementType type, int nVertices);
 
@@ -250,6 +253,9 @@ public:
 
     bool areVerticesCCWOrdered() const override;
     int getCCWOrderedVertex(int n) const override;
+
+    bool areFacesCCWOrdered() const override;
+    int getCCWOrderedFace(int n) const override;
 
     const static ReferencePixelInfo info;
 

--- a/src/patchkernel/element_reference.hpp
+++ b/src/patchkernel/element_reference.hpp
@@ -199,10 +199,13 @@ public:
     void evalPointProjection(const std::array<double, 3> &point, const std::array<double, 3> *vertexCoords, std::array<double, 3> *projection, double *distance) const override;
     double evalPointDistance(const std::array<double, 3> &point, const std::array<double, 3> *vertexCoords) const override;
 
+    virtual bool areVerticesCCWOrdered() const;
+    virtual int getCCWOrderedVertex(int n) const;
+
 protected:
     Reference2DElementInfo(ElementType type, int nVertices);
 
-    virtual void getCCWVertexCoords(const std::array<double, 3> *vertexCoords, const std::array<double, 3> **ccwVertexCoords, std::array<double, 3> *ccwVertexCoordsStorage) const;
+    void getCCWVertexCoords(const std::array<double, 3> *vertexCoords, const std::array<double, 3> **ccwVertexCoords, std::array<double, 3> *ccwVertexCoordsStorage) const;
 
 };
 
@@ -245,6 +248,9 @@ public:
 
     std::array<double, 3> evalNormal(const std::array<double, 3> *vertexCoords, const std::array<double, 3> &point = {{0.5, 0.5, 0.5}}) const override;
 
+    bool areVerticesCCWOrdered() const override;
+    int getCCWOrderedVertex(int n) const override;
+
     const static ReferencePixelInfo info;
 
 protected:
@@ -252,8 +258,6 @@ protected:
 
     ReferencePixelInfo(ReferencePixelInfo const &) = delete;
     ReferencePixelInfo & operator=(ReferencePixelInfo const &) = delete;
-
-    void getCCWVertexCoords(const std::array<double, 3> *vertexCoords, const std::array<double, 3> **ccwVertexCoords, std::array<double, 3> *ccwVertexCoordsStorage) const override;
 
 };
 

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -1762,4 +1762,90 @@ int SurfaceKernel::getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) 
     }
 }
 
+/*!
+	Get the counter-clockwise ordered list of edge for the specified facet.
+
+	\param facet is the facet
+	\result The counter-clockwise ordered list of edge for the specified facet.
+*/
+ConstProxyVector<long> SurfaceKernel::getFacetOrderedEdgeIds(const Cell &facet) const
+{
+    std::size_t nEdges = facet.getFaceCount();
+    ConstProxyVector<long> orderedEdgeIds(ConstProxyVector<long>::INTERNAL_STORAGE, nEdges);
+    ConstProxyVector<long>::storage_pointer orderedEdgeIdsStorage = orderedEdgeIds.storedData();
+    for (std::size_t k = 0; k < nEdges; ++k) {
+        orderedEdgeIdsStorage[k] = getFacetOrderedLocalEdge(facet, k);
+    }
+
+    return orderedEdgeIds;
+}
+
+/*!
+ * Check if the edges of the specified facet are counter-clockwise ordered.
+ *
+ * \param[in] facet is the facet
+ * \result Return true if the edges of the specified facet are counter-clockwise
+ * ordered, false otherwise.
+*/
+bool SurfaceKernel::areFacetEdgesOrdered(const Cell &facet) const
+{
+    // Early return for low-dimension elements
+    if (getDimension() <= 1) {
+        return true;
+    }
+
+    // Check if edges are ordered
+    ElementType facetType = facet.getType();
+    switch (facetType) {
+
+    case (ElementType::POLYGON):
+    {
+        return true;
+    }
+
+    default:
+    {
+        assert(facetType != ElementType::UNDEFINED);
+        const Reference2DElementInfo &facetInfo = static_cast<const Reference2DElementInfo &>(facet.getInfo());
+        return facetInfo.areFacesCCWOrdered();
+    }
+
+    }
+}
+
+/*!
+ * Get the local index of the edge occupying the n-th position in the
+ * counter-clockwise ordered list of edge ids.
+ *
+ * \param[in] facet is the facet
+ * \param[in] n is the requested position
+ * \result The local index of the edge occupying the n-th position in the
+ * counter-clockwise ordered list of edge ids.
+*/
+int SurfaceKernel::getFacetOrderedLocalEdge(const Cell &facet, std::size_t n) const
+{
+    // Early return for low-dimension elements
+    if (getDimension() <= 1) {
+        return n;
+    }
+
+    // Get the request index
+    ElementType facetType = facet.getType();
+    switch (facetType) {
+
+    case (ElementType::POLYGON):
+    {
+        return n;
+    }
+
+    default:
+    {
+        assert(facetType != ElementType::UNDEFINED);
+        const Reference2DElementInfo &facetInfo = static_cast<const Reference2DElementInfo &>(facet.getInfo());
+        return facetInfo.getCCWOrderedFace(n);
+    }
+
+    }
+}
+
 }

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -1694,13 +1694,26 @@ ConstProxyVector<long> SurfaceKernel::getFacetOrderedVertexIds(const Cell &facet
 */
 bool SurfaceKernel::areFacetVerticesOrdered(const Cell &facet) const
 {
-    switch (facet.getType()) {
+    // Early return for low-dimension elements
+    if (getDimension() <= 1) {
+        return true;
+    }
 
-    case ElementType::PIXEL:
-        return false;
+    // Check if vertices are ordered
+    ElementType facetType = facet.getType();
+    switch (facetType) {
+
+    case (ElementType::POLYGON):
+    {
+        return true;
+    }
 
     default:
-        return true;
+    {
+        assert(facetType != ElementType::UNDEFINED);
+        const Reference2DElementInfo &facetInfo = static_cast<const Reference2DElementInfo &>(facet.getInfo());
+        return facetInfo.areVerticesCCWOrdered();
+    }
 
     }
 }
@@ -1716,20 +1729,26 @@ bool SurfaceKernel::areFacetVerticesOrdered(const Cell &facet) const
 */
 int SurfaceKernel::getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const
 {
-    switch (facet.getType()) {
+    // Early return for low-dimension elements
+    if (getDimension() <= 1) {
+        return n;
+    }
 
-    case ElementType::PIXEL:
-        if (n == 2) {
-            return 3;
-        } else if (n == 3) {
-            return 2;
-        } else {
-            return n;
-        }
+    // Get the request index
+    ElementType facetType = facet.getType();
+    switch (facetType) {
+
+    case (ElementType::POLYGON):
+    {
+        return n;
+    }
 
     default:
-        assert(areFacetVerticesOrdered(facet));
-        return n;
+    {
+        assert(facetType != ElementType::UNDEFINED);
+        const Reference2DElementInfo &facetInfo = static_cast<const Reference2DElementInfo &>(facet.getInfo());
+        return facetInfo.getCCWOrderedVertex(n);
+    }
 
     }
 }

--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -1671,10 +1671,10 @@ bool SurfaceKernel::compareSelectedTypes(unsigned short mask_, ElementType type_
 }
 
 /*!
-	Get the anti-clockwise ordered list of vertex for the specified facet.
+	Get the counter-clockwise ordered list of vertex for the specified facet.
 
 	\param facet is the facet
-	\result The anti-clockwise ordered list of vertex for the specified facet.
+	\result The counter-clockwise ordered list of vertex for the specified facet.
 */
 ConstProxyVector<long> SurfaceKernel::getFacetOrderedVertexIds(const Cell &facet) const
 {
@@ -1695,11 +1695,11 @@ ConstProxyVector<long> SurfaceKernel::getFacetOrderedVertexIds(const Cell &facet
 }
 
 /*!
- * Check if the vertices of the specified facet are anti-clockwise ordered.
+ * Check if the vertices of the specified facet are counter-clockwise ordered.
  *
  * \param[in] facet is the facet
- * \result Return true if the vertices of the specified facet are anti-clockwise ordered,
- * false otherwise.
+ * \result Return true if the vertices of the specified facet are counter-clockwise
+ * ordered, false otherwise.
 */
 bool SurfaceKernel::areFacetVerticesOrdered(const Cell &facet) const
 {
@@ -1728,13 +1728,13 @@ bool SurfaceKernel::areFacetVerticesOrdered(const Cell &facet) const
 }
 
 /*!
- * Get the local index of the vertex occupying the n-th position in the anti-clockwise ordered
- * list of vertex ids.
+ * Get the local index of the vertex occupying the n-th position in the
+ * counter-clockwise ordered list of vertex ids.
  *
  * \param[in] facet is the facet
  * \param[in] n is the requested position
- * \result The local index of the vertex occupying the n-th position in the anti-clockwise
- * ordered list of vertex ids.
+ * \result The local index of the vertex occupying the n-th position in the
+ * counter-clockwise ordered list of vertex ids.
 */
 int SurfaceKernel::getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const
 {

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -77,6 +77,10 @@ public:
     bool areFacetVerticesOrdered(const Cell &facet) const;
     int getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const;
 
+    ConstProxyVector<long> getFacetOrderedEdgeIds(const Cell &facet) const;
+    bool areFacetEdgesOrdered(const Cell &facet) const;
+    int getFacetOrderedLocalEdge(const Cell &facet, std::size_t n) const;
+
     void displayQualityStats(std::ostream&, unsigned int padding = 0) const;
     std::vector<double> computeHistogram(eval_f_ funct_, std::vector<double> &bins, long &count, int n_intervals = 8, unsigned short mask = SELECT_ALL) const;
 

--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -74,6 +74,8 @@ public:
     void flipCellOrientation(long id);
 
     ConstProxyVector<long> getFacetOrderedVertexIds(const Cell &facet) const;
+    bool areFacetVerticesOrdered(const Cell &facet) const;
+    int getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const;
 
     void displayQualityStats(std::ostream&, unsigned int padding = 0) const;
     std::vector<double> computeHistogram(eval_f_ funct_, std::vector<double> &bins, long &count, int n_intervals = 8, unsigned short mask = SELECT_ALL) const;
@@ -98,9 +100,6 @@ protected:
     SurfaceKernel(int dimension, bool expert);
     SurfaceKernel(int id, int dimension, bool expert);
 #endif
-
-    bool areFacetVerticesOrdered(const Cell &facet) const;
-    int getFacetOrderedLocalVertex(const Cell &facet, std::size_t n) const;
 
 };
 

--- a/src/patchkernel/volume_kernel.hpp
+++ b/src/patchkernel/volume_kernel.hpp
@@ -50,6 +50,10 @@ public:
 	virtual double evalInterfaceArea(long id)const = 0;
         virtual std::array<double,3> evalInterfaceNormal(long id)const = 0;
 
+	ConstProxyVector<long> getFaceOrderedVertexIds(const Cell &cell, int face) const;
+	bool areFaceVerticesOrdered(const Cell &cell, int face) const;
+	int getFaceOrderedLocalVertex(const Cell &cell, int face, std::size_t n) const;
+
 protected:
 #if BITPIT_ENABLE_MPI==1
 	VolumeKernel(MPI_Comm communicator, std::size_t haloSize, bool expert);


### PR DESCRIPTION
There were still some cases where the pixel's vertices were not properly ordered before passing them to the CG utilities.

Depends on #394.