### PR TITLE
IO: do not require a space after the "solid" keyword of STL ASCII files

### DIFF
--- a/src/IO/STL.cpp
+++ b/src/IO/STL.cpp
@@ -56,7 +56,7 @@ const std::string STLBase::ASCII_SOLID_BEGIN  = "solid";
 const std::string STLBase::ASCII_SOLID_END    = "endsolid";
 const std::string STLBase::ASCII_FACET_BEGIN  = "facet";
 const std::string STLBase::ASCII_FACET_END    = "endfacet";
-const std::string STLBase::ASCII_FILE_BEGIN   = STLBase::ASCII_SOLID_BEGIN + " ";
+const std::string STLBase::ASCII_FILE_BEGIN   = STLBase::ASCII_SOLID_BEGIN;
 const std::string STLBase::ASCII_FILE_END     = STLBase::ASCII_SOLID_END;
 const std::size_t STLBase::ASCII_MINIMUM_SIZE = STLBase::ASCII_FILE_BEGIN.length() + STLBase::ASCII_FILE_END.length();
 

--- a/src/IO/STL.cpp
+++ b/src/IO/STL.cpp
@@ -149,9 +149,20 @@ STLReader::STLReader(const std::string &filename, Format format)
 }
 
 /*!
-    Detects if the specified STL file is in binary format.
+    Detects the format of the specified STL file.
+
+    An ASCII STL file begins with the line "solid name" and concludes with
+    the line "endsolid name", where name is an optional string.
+
+    A binary STL file has an 80-character header which is ignored, but should
+    never begin with the ASCII representation of the string solid. Following
+    the header is a 4-byte little-endian unsigned integer indicating the number
+    of triangular facets in the file. The size of the binary file should be
+    consistent with the number of factes. No extra data is allowed after the
+    definition of the factes.
 
     \param filename is the name of the STL file
+    \result The format of the specified STL file.
 */
 STLReader::Format STLReader::detectFormat(const std::string &filename)
 {


### PR DESCRIPTION
The space after the keyword "solid" is not a hard requirement of the [format](https://en.wikipedia.org/wiki/STL_(file_format)), it's only needed by some programs.