### PR TITLE
containers: allow to pass a constant kernel when setting dynamic synchronization of a PiercedStorage

### DIFF
--- a/examples/voloctree_mapper_example_00003.cpp
+++ b/examples/voloctree_mapper_example_00003.cpp
@@ -168,6 +168,7 @@ void run()
 
     /** Create a new patch */
     VolOctree *patch_2D = new VolOctree(std::move(treePointer2), &treePointer2);
+    patch_2D->update(false);
 #if BITPIT_ENABLE_MPI==1
     patch_2D->setVTKWriteTarget(PatchKernel::WriteTarget::WRITE_TARGET_CELLS_INTERNAL);
 #endif

--- a/examples/voloctree_mapper_example_00003.cpp
+++ b/examples/voloctree_mapper_example_00003.cpp
@@ -146,7 +146,7 @@ void run()
 #endif
     }
 
-    patch_2D_original->update(true);
+    patch_2D_original->update(false);
 
     patch_2D_original->getVTK().setName("mesh_original.0");
 #if BITPIT_ENABLE_MPI==1
@@ -221,7 +221,7 @@ void run()
         patch_2D->initializeAdjacencies();
         patch_2D->initializeInterfaces();
 
-        patch_2D->update(true);
+        patch_2D->update(false);
 
         nCells = patch_2D->getCellCount();
         log::cout() << ">> Final number of cells... " << nCells << std::endl;

--- a/examples/voloctree_mapper_example_00004.cpp
+++ b/examples/voloctree_mapper_example_00004.cpp
@@ -147,7 +147,7 @@ void runReferenceAdaptation()
 #endif
     }
 
-    patch_2D_original->update(true);
+    patch_2D_original->update(false);
 
     /**
      * Create the new tree
@@ -216,7 +216,7 @@ void runReferenceAdaptation()
         patch_2D->initializeAdjacencies();
         patch_2D->initializeInterfaces();
 
-        patch_2D->update(true);
+        patch_2D->update(false);
 
         nCells = patch_2D->getCellCount();
         log::cout() << ">> Final number of cells... " << nCells << std::endl;
@@ -800,7 +800,7 @@ void runMappedAdaptation()
 #endif
     }
 
-    patch_2D_original->update(true);
+    patch_2D_original->update(false);
 
     /**
      * Create the new tree
@@ -869,7 +869,7 @@ void runMappedAdaptation()
         patch_2D->initializeAdjacencies();
         patch_2D->initializeInterfaces();
 
-        patch_2D->update(true);
+        patch_2D->update(false);
 
         nCells = patch_2D->getCellCount();
         log::cout() << ">> Final number of cells... " << nCells << std::endl;

--- a/examples/voloctree_mapper_example_00004.cpp
+++ b/examples/voloctree_mapper_example_00004.cpp
@@ -163,6 +163,7 @@ void runReferenceAdaptation()
 
     /** Create a new patch */
     VolOctree *patch_2D = new VolOctree(std::move(treePointer2), &treePointer2);
+    patch_2D->update(false);
 #if BITPIT_ENABLE_MPI==1
     patch_2D->setVTKWriteTarget(PatchKernel::WriteTarget::WRITE_TARGET_CELLS_INTERNAL);
 #endif
@@ -816,6 +817,7 @@ void runMappedAdaptation()
 
     /** Create a new patch */
     VolOctree *patch_2D = new VolOctree(std::move(treePointer2), &treePointer2);
+    patch_2D->update(false);
 #if BITPIT_ENABLE_MPI==1
     patch_2D->setVTKWriteTarget(PatchKernel::WriteTarget::WRITE_TARGET_CELLS_INTERNAL);
 #endif

--- a/src/POD/pod.cpp
+++ b/src/POD/pod.cpp
@@ -669,6 +669,7 @@ void POD::setExpert(bool mode)
  */
 void POD::setSensorMask(const PiercedStorage<bool> & mask, VolumeKernel * mesh)
 {
+    m_sensorMask.unsetKernel();
     m_sensorMask.setStaticKernel(&(m_podkernel->getMesh()->getCells()));
 
     if (m_staticMesh || mesh == m_podkernel->getMesh()){
@@ -1002,6 +1003,7 @@ void POD::_evalMeanMesh()
     //Compute cells volume
     m_podkernel->evalCellsVolume();
 
+    m_filter.unsetKernel();
     m_filter.setStaticKernel(&(m_podkernel->getMesh()->getCells()));
     m_filter.fill(true);
 
@@ -2322,7 +2324,9 @@ void POD::restore()
 
     // Restore the modes, mean and mesh
     {
+        m_filter.unsetKernel();
         m_filter.setStaticKernel(&m_podkernel->getMesh()->getCells());
+        m_sensorMask.unsetKernel();
         m_sensorMask.setStaticKernel(&m_podkernel->getMesh()->getCells());
 
         if (m_memoryMode == MemoryMode::MEMORY_NORMAL) {

--- a/src/POD/pod_common.hpp
+++ b/src/POD/pod_common.hpp
@@ -157,8 +157,11 @@ struct PODField
      */
     void setStaticKernel(const PiercedKernel<long> *lkernel)
     {
+        mask->unsetKernel();
         mask->setStaticKernel(lkernel);
+        scalar->unsetKernel();
         scalar->setStaticKernel(lkernel);
+        vector->unsetKernel();
         vector->setStaticKernel(lkernel);
     }
 

--- a/src/POD/pod_kernel.cpp
+++ b/src/POD/pod_kernel.cpp
@@ -159,6 +159,7 @@ void PODKernel::restoreMesh(const pod::SnapshotFile &snap)
  */
 void PODKernel::evalCellsVolume()
 {
+    m_cellsVolume.unsetKernel();
     m_cellsVolume.setStaticKernel(&m_meshPOD->getCells());
     for (Cell & cell : m_meshPOD->getCells()){
         long id = cell.getId();

--- a/src/POD/pod_voloctree.cpp
+++ b/src/POD/pod_voloctree.cpp
@@ -1050,6 +1050,7 @@ void PODVolOctree::mapBoolFieldToPOD(const PiercedStorage<bool> & field, const V
     // Map bool field (number of fields = 1) on pod mesh
     const PiercedStorage<mapping::Info> &mappingInfo = getMapper()->getMapping();
 
+    mappedField.unsetKernel();
     mappedField.setStaticKernel(&getMesh()->getCells());
     mappedField.fill(false);
 

--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -98,7 +98,7 @@ public:
 
     // Methods for synchronizing the storage
     void setStaticKernel(const PiercedKernel<id_t> *kernel);
-    void setDynamicKernel(PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
+    void setDynamicKernel(const PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     void unsetKernel(bool release = true);
     const PiercedKernel<id_t> * getKernel() const;
     KernelType getKernelType() const;
@@ -108,19 +108,19 @@ public:
     void swap(PiercedStorageSyncSlave<id_t> &other) noexcept;
 
 protected:
-    const PiercedKernel<id_t> *m_const_kernel;
-    PiercedKernel<id_t> *m_kernel;
+    const PiercedKernel<id_t> *m_kernel;
+    KernelType m_kernelType;
 
     // Constructors and initialization
     PiercedStorageSyncSlave();
     PiercedStorageSyncSlave(const PiercedKernel<id_t> *kernel);
-    PiercedStorageSyncSlave(PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
+    PiercedStorageSyncSlave(const PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other);
     PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, const PiercedKernel<id_t> *kernel);
-    PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
+    PiercedStorageSyncSlave(const PiercedStorageSyncSlave<id_t> &other, const PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other);
     PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other, const PiercedKernel<id_t> *kernel);
-    PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other, PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
+    PiercedStorageSyncSlave(PiercedStorageSyncSlave<id_t> &&other, const PiercedKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
 
     // Methods for synchronizing the storage
     virtual void _postSetStaticKernel();

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -228,6 +228,10 @@ PiercedStorageSyncSlave<id_t>::~PiercedStorageSyncSlave()
 * The storage will NOT be synchronized with the kernel. Every change to the
 * kernel can potentially invalidate the link between kernel and storage.
 *
+* If a kernel has already been set for the storage, it is mandatory to unset it
+* before setting a new one. Calling this function when the kernel is already
+* associated with a kernel will lead to an exception being thrown.
+*
 * \param kernel is the kernel that will be set
 */
 template<typename id_t>
@@ -250,9 +254,6 @@ void PiercedStorageSyncSlave<id_t>::setStaticKernel(const PiercedKernel<id_t> *k
 /**
 * Internal function that will be called after setting a static kernel.
 *
-* The storage will NOT be synchronized with the kernel. Every change to the
-* kernel can potentially invalidate the link between kernel and storage.
-*
 * \param kernel is the kernel that will be set
 */
 template<typename id_t>
@@ -265,6 +266,10 @@ void PiercedStorageSyncSlave<id_t>::_postSetStaticKernel()
 * Sets the kernel that will be used by the storage.
 *
 * The storage will dynamically synchronized with the kernel.
+*
+* If a kernel has already been set for the storage, it is mandatory to unset it
+* before setting a new one. Calling this function when the kernel is already
+* associated with a kernel will lead to an exception being thrown.
 *
 * \param kernel is the kernel that will be set
 * \param syncMode is the synchronization mode that will be used for the storage
@@ -285,8 +290,6 @@ void PiercedStorageSyncSlave<id_t>::setDynamicKernel(PiercedKernel<id_t> *kernel
 
 /**
 * Internal function that will be called after setting a dynamic kernel.
-*
-* The storage will dynamically synchronized with the kernel.
 */
 template<typename id_t>
 void PiercedStorageSyncSlave<id_t>::_postSetDynamicKernel()

--- a/src/containers/piercedStorage.tpp
+++ b/src/containers/piercedStorage.tpp
@@ -681,6 +681,7 @@ void PiercedStorage<value_t, id_t>::_postSetStaticKernel()
 {
     // Resize the storage
     rawResize(this->m_kernel->rawSize());
+    rawShrinkToFit();
 }
 
 /**

--- a/src/containers/piercedSync.cpp
+++ b/src/containers/piercedSync.cpp
@@ -222,7 +222,7 @@ void PiercedSyncMaster::swap(PiercedSyncMaster &other) noexcept
 * \param slave is the slave that will be registered
 * \param syncMode is the synchronization mode that will be used for the slave
 */
-void PiercedSyncMaster::registerSlave(PiercedSyncSlave *slave, SyncMode syncMode)
+void PiercedSyncMaster::registerSlave(PiercedSyncSlave *slave, SyncMode syncMode) const
 {
     if (m_slaves.count(slave) > 0) {
         throw std::out_of_range("Slave is already registered");
@@ -270,7 +270,7 @@ void PiercedSyncMaster::processSyncAction(const PiercedSyncAction &action)
 * \param slave is the slave thr action will be commited to
 * \param action is the synchronization action that will be commited
 */
-void PiercedSyncMaster::commitSyncAction(PiercedSyncSlave *slave, const PiercedSyncAction &action)
+void PiercedSyncMaster::commitSyncAction(PiercedSyncSlave *slave, const PiercedSyncAction &action) const
 {
     slave->commitSyncAction(action);
 }
@@ -372,7 +372,7 @@ void PiercedSyncMaster::journalSyncAction(const PiercedSyncAction &action)
 *
 * \param slave is the slave that will be unregistered
 */
-void PiercedSyncMaster::unregisterSlave(const PiercedSyncSlave *slave)
+void PiercedSyncMaster::unregisterSlave(const PiercedSyncSlave *slave) const
 {
     // Check if the slave was actually registered
     if (!isSlaveRegistered(slave)) {
@@ -475,7 +475,7 @@ bool PiercedSyncMaster::isSynced() const
 * \param enabled is set to true the synchronization will be enabled, otherwise
 *  it will be disabled
 */
-void PiercedSyncMaster::setSyncEnabled(bool enabled)
+void PiercedSyncMaster::setSyncEnabled(bool enabled) const
 {
     m_syncEnabled = enabled;
 }

--- a/src/containers/piercedSync.hpp
+++ b/src/containers/piercedSync.hpp
@@ -159,17 +159,17 @@ protected:
     /**
     * Slaves
     */
-    std::unordered_map<PiercedSyncSlave *, SyncMode> m_slaves;
+    mutable std::unordered_map<PiercedSyncSlave *, SyncMode> m_slaves;
 
     PiercedSyncMaster();
 
-    void registerSlave(PiercedSyncSlave *slave, PiercedSyncMaster::SyncMode syncMode);
-    void unregisterSlave(const PiercedSyncSlave *slave);
+    void registerSlave(PiercedSyncSlave *slave, PiercedSyncMaster::SyncMode syncMode) const;
+    void unregisterSlave(const PiercedSyncSlave *slave) const;
     bool isSlaveRegistered(const PiercedSyncSlave *slave) const;
     PiercedSyncMaster::SyncMode getSlaveSyncMode(const PiercedSyncSlave *slave) const;
     bool isSlaveSynced(const PiercedSyncSlave *slave) const;
 
-    void setSyncEnabled(bool enabled);
+    void setSyncEnabled(bool enabled) const;
     bool isSyncEnabled() const;
 
     void sync();
@@ -187,7 +187,7 @@ private:
     /**
     * Slave synchronization groups
     */
-    std::unordered_map<SyncMode, SyncGroup, SyncModeHasher> m_syncGroups;
+    mutable std::unordered_map<SyncMode, SyncGroup, SyncModeHasher> m_syncGroups;
 
     /**
     * Slave synchronization groups
@@ -197,9 +197,9 @@ private:
     /**
     * Controls if the synchronization is enabled
     */
-    bool m_syncEnabled;
+    mutable bool m_syncEnabled;
 
-    void commitSyncAction(PiercedSyncSlave *slave, const PiercedSyncAction &action);
+    void commitSyncAction(PiercedSyncSlave *slave, const PiercedSyncAction &action) const;
     void journalSyncAction(const PiercedSyncAction &action);
 
 };

--- a/src/containers/piercedSync.hpp
+++ b/src/containers/piercedSync.hpp
@@ -161,16 +161,6 @@ protected:
     */
     std::unordered_map<PiercedSyncSlave *, SyncMode> m_slaves;
 
-    /**
-    * Slave synchronization groups
-    */
-    std::unordered_map<SyncMode, SyncGroup, SyncModeHasher> m_syncGroups;
-
-    /**
-    * Slave synchronization groups
-    */
-    std::vector<PiercedSyncAction> m_syncJournal;
-
     PiercedSyncMaster();
 
     void registerSlave(PiercedSyncSlave *slave, PiercedSyncMaster::SyncMode syncMode);
@@ -194,6 +184,19 @@ protected:
     void dump(std::ostream &stream) const;
 
 private:
+    /**
+    * Slave synchronization groups
+    */
+    std::unordered_map<SyncMode, SyncGroup, SyncModeHasher> m_syncGroups;
+
+    /**
+    * Slave synchronization groups
+    */
+    std::vector<PiercedSyncAction> m_syncJournal;
+
+    /**
+    * Controls if the synchronization is enabled
+    */
     bool m_syncEnabled;
 
     void commitSyncAction(PiercedSyncSlave *slave, const PiercedSyncAction &action);

--- a/src/containers/piercedVector.tpp
+++ b/src/containers/piercedVector.tpp
@@ -822,7 +822,7 @@ void PiercedVector<value_t, id_t>::swap(PiercedVector &other) noexcept
     try {
         PiercedVectorStorage<value_t, id_t>::setDynamicKernel(this, PiercedVectorKernel<id_t>::SYNC_MODE_DISABLED);
         other.PiercedVectorStorage<value_t, id_t>::setDynamicKernel(&other, PiercedVectorKernel<id_t>::SYNC_MODE_DISABLED);
-    } catch (const std::runtime_error &exception) {
+    } catch (const std::exception &exception) {
         assert(false && "Error while swapping the PiercedVector!");
         std::cout << "Error while swapping the PiercedVector!" << std::endl;
         exit(0);

--- a/src/containers/piercedVectorStorage.hpp
+++ b/src/containers/piercedVectorStorage.hpp
@@ -97,7 +97,7 @@ public:
     using PiercedStorage<value_t, id_t>::unsetKernel;
 
     void setStaticKernel(const PiercedVectorKernel<id_t> *kernel);
-    void setDynamicKernel(PiercedVectorKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
+    void setDynamicKernel(const PiercedVectorKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode);
     const PiercedVectorKernel<id_t> * getKernel() const;
 
     // Dump and restore

--- a/src/containers/piercedVectorStorage.tpp
+++ b/src/containers/piercedVectorStorage.tpp
@@ -182,7 +182,7 @@ void PiercedVectorStorage<value_t, id_t>::setStaticKernel(const PiercedVectorKer
 * \param syncMode is the synchronization mode that will be used for the storage
 */
 template<typename value_t, typename id_t>
-void PiercedVectorStorage<value_t, id_t>::setDynamicKernel(PiercedVectorKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode)
+void PiercedVectorStorage<value_t, id_t>::setDynamicKernel(const PiercedVectorKernel<id_t> *kernel, PiercedSyncMaster::SyncMode syncMode)
 {
     PiercedStorage<value_t, id_t>::setDynamicKernel(kernel, syncMode);
 }

--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -182,15 +182,12 @@ int LevelSet::addObject( SurfUnstructured *segmentation, double angle, int id ) 
  */
 int LevelSet::addObject( std::unique_ptr<SurfaceKernel> &&segmentation, double angle, int id ) {
 
-    SurfUnstructured *surfUnstructured = dynamic_cast<SurfUnstructured *>(segmentation.get());
+    auto surfUnstructured = std::unique_ptr<SurfUnstructured>(dynamic_cast<SurfUnstructured *>(segmentation.release())) ;
     if (!surfUnstructured) {
         throw std::runtime_error ("Segmentation type not supported");
     }
 
-    segmentation.release();
-    std::unique_ptr<SurfUnstructured> surfUnstructuredUPtr = std::unique_ptr<SurfUnstructured>(surfUnstructured) ;
-
-    std::unique_ptr<LevelSetObject> object = LevelSetObjectFactory::createSegmentationObject<LevelSetSegmentationNarrowBandCache, int &, std::unique_ptr<SurfUnstructured> &&, double &>( m_kernel.get(), m_storageType, id, std::move(surfUnstructuredUPtr), angle ) ;
+    std::unique_ptr<LevelSetObject> object = LevelSetObjectFactory::createSegmentationObject<LevelSetSegmentationNarrowBandCache, int &, std::unique_ptr<SurfUnstructured> &&, double &>( m_kernel.get(), m_storageType, id, std::move(surfUnstructured), angle ) ;
 
     return registerObject(std::move(object));
 }

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -83,7 +83,11 @@ LevelSetObject::LevelSetObject(LevelSetObject &&other)
 LevelSetObject::~LevelSetObject() {
     // Disable all output for the object
     if (m_kernel) {
-        enableVTKOutput(LevelSetWriteField::ALL, false);
+        try {
+            enableVTKOutput(LevelSetWriteField::ALL, false);
+        } catch (const std::exception &exception) {
+            // Nothing to do
+        }
     }
 }
 

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -374,6 +374,7 @@ void LevelSetSegmentationKernel::setSurface( const SurfUnstructured *surface, do
     m_featureAngle = featureAngle;
 
     // Segment vertices information
+    m_segmentVertexOffset.unsetKernel();
     m_segmentVertexOffset.setStaticKernel(&m_surface->getCells());
 
     std::size_t nTotalSegmentVertices = 0;
@@ -383,12 +384,16 @@ void LevelSetSegmentationKernel::setSurface( const SurfUnstructured *surface, do
     }
 
     // Normals
+    m_segmentNormalsValid.unsetKernel();
     m_segmentNormalsValid.setStaticKernel(&m_surface->getCells());
     m_segmentNormalsValid.fill(false);
+    m_segmentNormalsStorage.unsetKernel();
     m_segmentNormalsStorage.setStaticKernel(&m_surface->getCells());
 
+    m_unlimitedVertexNormalsValid.unsetKernel();
     m_unlimitedVertexNormalsValid.setStaticKernel(&m_surface->getVertices());
     m_unlimitedVertexNormalsValid.fill(false);
+    m_unlimitedVertexNormalsStorage.unsetKernel();
     m_unlimitedVertexNormalsStorage.setStaticKernel(&m_surface->getVertices());
 
     m_limitedSegmentVertexNormalValid.resize(nTotalSegmentVertices);

--- a/src/levelset/levelSetSignPropagator.cpp
+++ b/src/levelset/levelSetSignPropagator.cpp
@@ -394,6 +394,7 @@ void LevelSetSignPropagator::initializePropagation(const LevelSetObjectInterface
     // Initialize propagation state
     m_nWaiting = m_mesh->getCellCount();
 
+    m_propagationStates.unsetKernel();
     m_propagationStates.setStaticKernel(&(m_mesh->getCells()));
     m_propagationStates.fill(STATE_WAITING);
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -523,7 +523,7 @@ void PatchKernel::initialize()
 	initializeHaloSize(haloSize);
 
 	// Mark patch as partioned
-	if (isPartitioned()) {
+	if (getCommunicator() != MPI_COMM_NULL) {
 		setPartitioningStatus(PARTITIONING_CLEAN);
 	} else {
 		setPartitioningStatus(PARTITIONING_UNSUPPORTED);

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1233,7 +1233,7 @@ void PatchKernel::write(VTKWriteMode mode)
 	}
 
 	int vtkVertexCount = 0;
-	m_vtkVertexMap.unsetKernel(true);
+	m_vtkVertexMap.unsetKernel();
 	m_vtkVertexMap.setStaticKernel(&m_vertices);
 	VertexConstIterator endItr = vertexConstEnd();
 	for (VertexConstIterator itr = vertexConstBegin(); itr != endItr; ++itr) {

--- a/src/patchkernel/volume_mapper.cpp
+++ b/src/patchkernel/volume_mapper.cpp
@@ -70,9 +70,9 @@ namespace bitpit {
 /**
  * \param[in] communicator is the MPI communicator
  */
-VolumeMapper::VolumeMapper(VolumeKernel *referencePatch, VolumeKernel *mappedPatch, MPI_Comm communicator)
+VolumeMapper::VolumeMapper(const VolumeKernel *referencePatch, const VolumeKernel *mappedPatch, MPI_Comm communicator)
 #else
-VolumeMapper::VolumeMapper(VolumeKernel *referencePatch, VolumeKernel *mappedPatch)
+VolumeMapper::VolumeMapper(const VolumeKernel *referencePatch, const VolumeKernel *mappedPatch)
 #endif
     : m_referencePatch(referencePatch), m_mappedPatch(mappedPatch), m_mapping(1)
 #if BITPIT_ENABLE_MPI

--- a/src/patchkernel/volume_mapper.hpp
+++ b/src/patchkernel/volume_mapper.hpp
@@ -126,8 +126,8 @@ public:
 #endif
 
 protected:
-    VolumeKernel *m_referencePatch;    /**< Pointer to reference mesh.*/
-    VolumeKernel *m_mappedPatch;       /**< Pointer to mapped mesh.*/
+    const VolumeKernel *m_referencePatch;    /**< Pointer to reference mesh.*/
+    const VolumeKernel *m_mappedPatch;       /**< Pointer to mapped mesh.*/
 
     PiercedStorage<mapping::Info> m_mapping;                     /**< Mapping info for each cell of reference mesh.
                                                                      The mapping info is treated as a set of adaption info related to
@@ -144,9 +144,9 @@ protected:
 #endif
 
 #if BITPIT_ENABLE_MPI
-    VolumeMapper(VolumeKernel *referencePatch, VolumeKernel *mappedPatch, MPI_Comm communicator);
+    VolumeMapper(const VolumeKernel *referencePatch, const VolumeKernel *mappedPatch, MPI_Comm communicator);
 #else
-    VolumeMapper(VolumeKernel *referencePatch, VolumeKernel *mappedPatch);
+    VolumeMapper(const VolumeKernel *referencePatch, const VolumeKernel *mappedPatch);
 #endif
 
     virtual void _mapMeshes(bool fillInverse) = 0;

--- a/src/voloctree/voloctree_mapper.cpp
+++ b/src/voloctree/voloctree_mapper.cpp
@@ -308,7 +308,7 @@ void VolOctreeMapper::_mappingAdaptionReferenceUpdate(const std::vector<adaption
                             if (checkPart || mappedRanks[imapped] == m_rank) {
 #endif
                                 oinfoprev = mappedPatch->getCellOctant(mappedId);
-                                Octant *octm = mappedPatch->getOctantPointer(oinfoprev);
+                                const Octant *octm = mappedPatch->getOctantPointer(oinfoprev);
                                 mortonmapped = mappedPatch->getTree().getMorton(octm);
                                 mortonlastdescmapped = mappedPatch->getTree().getLastDescMorton(octm);
                                 levelmapped = mappedPatch->getCellLevel(mappedId);
@@ -329,7 +329,7 @@ void VolOctreeMapper::_mappingAdaptionReferenceUpdate(const std::vector<adaption
                                 uint64_t morton, mortonlastdesc;
                                 level = adaptedPatch->getCellLevel(id);
                                 VolOctree::OctantInfo octantIfo = adaptedPatch->getCellOctant(id);
-                                Octant *octant = adaptedPatch->getOctantPointer(octantIfo);
+                                const Octant *octant = adaptedPatch->getOctantPointer(octantIfo);
                                 morton = adaptedPatch->getTree().getMorton(octant);
                                 mortonlastdesc = adaptedPatch->getTree().getLastDescMorton(octant);
 
@@ -779,7 +779,7 @@ std::unordered_map<int, std::vector<long>> VolOctreeMapper::getSentReferenceIds(
     // Recover id to be recv/send
     std::unordered_map<int, std::set<long>> rankIdSend;
 
-    for (Cell &cell : m_referencePatch->getCells()) {
+    for (const Cell &cell : m_referencePatch->getCells()) {
         long id = cell.getId();
         auto info = m_mapping[id];
         for (int rank : info.ranks) {
@@ -815,7 +815,7 @@ std::unordered_map<int, std::vector<long>> VolOctreeMapper::getReceivedReference
 
     std::unordered_map<int, std::set<long>> rankIdRecv;
 
-    for (Cell & cell : m_mappedPatch->getCells()) {
+    for (const Cell & cell : m_mappedPatch->getCells()) {
         long id = cell.getId();
         auto info = m_inverseMapping.at(id);
         std::size_t idsSize = info.ids.size();

--- a/src/voloctree/voloctree_mapper.cpp
+++ b/src/voloctree/voloctree_mapper.cpp
@@ -65,10 +65,10 @@ namespace bitpit {
 /**
  * \param[in] communicator is the MPI communicator
  */
-VolOctreeMapper::VolOctreeMapper(bitpit::VolOctree *referencePatch, bitpit::VolOctree *mappedPatch, MPI_Comm communicator)
+VolOctreeMapper::VolOctreeMapper(const bitpit::VolOctree *referencePatch, const bitpit::VolOctree *mappedPatch, MPI_Comm communicator)
     : VolumeMapper(referencePatch, mappedPatch, communicator)
 #else
-VolOctreeMapper::VolOctreeMapper(bitpit::VolOctree *referencePatch, bitpit::VolOctree *mappedPatch)
+VolOctreeMapper::VolOctreeMapper(const bitpit::VolOctree *referencePatch, const bitpit::VolOctree *mappedPatch)
     : VolumeMapper(referencePatch, mappedPatch)
 #endif
 {
@@ -177,8 +177,8 @@ void VolOctreeMapper::adaptionCleanup()
  */
 void VolOctreeMapper::_mappingAdaptionReferenceUpdate(const std::vector<adaption::Info> &adaptionInfo, bool inverseFilled)
 {
-    VolOctree *adaptedPatch = static_cast<VolOctree*>(m_referencePatch);
-    VolOctree *mappedPatch  = static_cast<VolOctree*>(m_mappedPatch);
+    const VolOctree *adaptedPatch = static_cast<const VolOctree*>(m_referencePatch);
+    const VolOctree *mappedPatch  = static_cast<const VolOctree*>(m_mappedPatch);
 
     PiercedStorage<mapping::Info> *mappingAdapted = &m_mapping;
     PiercedStorage<mapping::Info> *mappingMapped  = &m_inverseMapping;
@@ -461,8 +461,8 @@ void VolOctreeMapper::_mappingAdaptionReferenceUpdate(const std::vector<adaption
  */
 void VolOctreeMapper::_mappingAdaptionMappedUpdate(const std::vector<adaption::Info> &adaptionInfo)
 {
-    VolOctree *adaptedPatch   = static_cast<VolOctree*>(m_mappedPatch);
-    VolOctree *referencePatch = static_cast<VolOctree*>(m_referencePatch);
+    const VolOctree *adaptedPatch   = static_cast<const VolOctree*>(m_mappedPatch);
+    const VolOctree *referencePatch = static_cast<const VolOctree*>(m_referencePatch);
 
     PiercedStorage<mapping::Info> *mappingAdapted   = &m_inverseMapping;
     PiercedStorage<mapping::Info> *mappingReference = &m_mapping;
@@ -865,10 +865,10 @@ std::unordered_map<int, std::vector<long>> VolOctreeMapper::getSentMappedIds() c
  */
 void VolOctreeMapper::_mapMeshes(bool fillInverse)
 {
-    std::array<double,3> originR = static_cast<VolOctree*>(m_referencePatch)->getOrigin();
-    std::array<double,3> originM = static_cast<VolOctree*>(m_mappedPatch)->getOrigin();
+    std::array<double,3> originR = static_cast<const VolOctree*>(m_referencePatch)->getOrigin();
+    std::array<double,3> originM = static_cast<const VolOctree*>(m_mappedPatch)->getOrigin();
 
-    if (!(utils::DoubleFloatingEqual()(static_cast<VolOctree*>(m_referencePatch)->getLength(),static_cast<VolOctree*>(m_mappedPatch)->getLength()))
+    if (!(utils::DoubleFloatingEqual()(static_cast<const VolOctree*>(m_referencePatch)->getLength(),static_cast<const VolOctree*>(m_mappedPatch)->getLength()))
             || !(utils::DoubleFloatingEqual()(originR[0],originM[0]))
             || !(utils::DoubleFloatingEqual()(originR[1],originM[1]))
             || !(utils::DoubleFloatingEqual()(originR[2],originM[2]))) {
@@ -925,8 +925,8 @@ void VolOctreeMapper::_mapMeshes(bool fillInverse)
 void VolOctreeMapper::_mapMeshesSamePartition(const std::vector<OctantIR> *octantsIRReference, const std::vector<OctantIR> *octantsIRMapped,
                                               bool fillInverse, long *indRef)
 {
-    bitpit::VolOctree *referencePatch = static_cast<VolOctree*>(m_referencePatch);
-    bitpit::VolOctree *mappedPatch    = static_cast<VolOctree*>(m_mappedPatch);
+    const bitpit::VolOctree *referencePatch = static_cast<const VolOctree*>(m_referencePatch);
+    const bitpit::VolOctree *mappedPatch    = static_cast<const VolOctree*>(m_mappedPatch);
 
     // Fill IR with meshes if list pointer is null
 #if BITPIT_ENABLE_MPI
@@ -939,7 +939,7 @@ void VolOctreeMapper::_mapMeshesSamePartition(const std::vector<OctantIR> *octan
         tempOctantsIRReference.reserve(n);
         for (long i = 0; i < n; i++) {
             VolOctree::OctantInfo octantIfoRef(i, true);
-            const Octant *octRef = static_cast<VolOctree*>(m_referencePatch)->getOctantPointer(octantIfoRef);
+            const Octant *octRef = referencePatch->getOctantPointer(octantIfoRef);
             long idRef = referencePatch->getOctantId(octantIfoRef);
 #if BITPIT_ENABLE_MPI
             tempOctantsIRReference.emplace_back(*octRef, idRef, idRef, m_rank);
@@ -1126,8 +1126,8 @@ void VolOctreeMapper::_mapMeshesSamePartition(const std::vector<OctantIR> *octan
  */
 bool VolOctreeMapper::checkPartition()
 {
-    std::vector<uint64_t> partitionMapped    = static_cast<VolOctree*>(m_mappedPatch)->getTree().getPartitionLastDesc();
-    std::vector<uint64_t> partitionReference = static_cast<VolOctree*>(m_referencePatch)->getTree().getPartitionLastDesc();
+    std::vector<uint64_t> partitionMapped    = static_cast<const VolOctree*>(m_mappedPatch)->getTree().getPartitionLastDesc();
+    std::vector<uint64_t> partitionReference = static_cast<const VolOctree*>(m_referencePatch)->getTree().getPartitionLastDesc();
     for (int rank = 0; rank < m_nProcs; ++rank) {
         if (partitionReference[rank] != partitionMapped[rank]) {
             return false;
@@ -1150,13 +1150,13 @@ void VolOctreeMapper::_mapMeshPartitioned(bool fillInverse)
     // Fill IR with reference mesh
     //
     // TODO: make a method to do that
-    long n = static_cast<VolOctree*>(m_referencePatch)->getInternalCellCount();
+    long n = static_cast<const VolOctree*>(m_referencePatch)->getInternalCellCount();
     std::vector<OctantIR> octantsIRReference;
     octantsIRReference.reserve(n);
     for (long i = 0; i < n; i++) {
         VolOctree::OctantInfo octantIfoRef(i, true);
-        const Octant *octRef = static_cast<VolOctree*>(m_referencePatch)->getOctantPointer(octantIfoRef);
-        long idRef = static_cast<VolOctree*>(m_referencePatch)->getOctantId(octantIfoRef);
+        const Octant *octRef = static_cast<const VolOctree*>(m_referencePatch)->getOctantPointer(octantIfoRef);
+        long idRef = static_cast<const VolOctree*>(m_referencePatch)->getOctantId(octantIfoRef);
         octantsIRReference.emplace_back(*octRef, idRef, idRef, m_rank);
     }
 
@@ -1178,8 +1178,8 @@ bool VolOctreeMapper::_recoverPartition()
     // to match the partitioning between the two meshes
 
     // Find owner of reference partition over mapped mesh partition
-    VolOctree* referencePatch = static_cast<VolOctree*>(m_referencePatch);
-    VolOctree* mappedPatch = static_cast<VolOctree*>(m_mappedPatch);
+    const VolOctree* referencePatch = static_cast<const VolOctree*>(m_referencePatch);
+    const VolOctree* mappedPatch = static_cast<const VolOctree*>(m_mappedPatch);
     std::vector<uint64_t> partitionLDReference = referencePatch->getTree().getPartitionLastDesc();
     std::vector<uint64_t> partitionLDMapped = mappedPatch->getTree().getPartitionLastDesc();
     std::vector<uint64_t> partitionFDReference = referencePatch->getTree().getPartitionFirstDesc();
@@ -1430,7 +1430,7 @@ void VolOctreeMapper::_communicateInverseMapper(const std::vector<OctantIR> *oct
             long globalId;
             recvBuffer >> globalId;
 
-            uint32_t idx = static_cast<VolOctree*>(m_mappedPatch)->getTree().getLocalIdx(globalId);
+            uint32_t idx = static_cast<const VolOctree*>(m_mappedPatch)->getTree().getLocalIdx(globalId);
             VolOctree::OctantInfo octantIfo(idx, true);
 
             int type;
@@ -1439,7 +1439,7 @@ void VolOctreeMapper::_communicateInverseMapper(const std::vector<OctantIR> *oct
             int entity;
             recvBuffer >> entity;
 
-            long id = static_cast<VolOctree*>(m_mappedPatch)->getOctantId(octantIfo);
+            long id = static_cast<const VolOctree*>(m_mappedPatch)->getOctantId(octantIfo);
             mapping::Info &info = (*inverseLocalMapping)[id];
             info.type = mapping::Type(type);
             info.entity = mapping::Entity(entity);

--- a/src/voloctree/voloctree_mapper.hpp
+++ b/src/voloctree/voloctree_mapper.hpp
@@ -42,9 +42,9 @@ class VolOctreeMapper: public VolumeMapper {
 
 public:
 #if BITPIT_ENABLE_MPI
-    VolOctreeMapper(VolOctree *referencePatch, VolOctree *mappedPatch, MPI_Comm communicator);
+    VolOctreeMapper(const VolOctree *referencePatch, const VolOctree *mappedPatch, MPI_Comm communicator);
 #else
-    VolOctreeMapper(VolOctree *referencePatch, VolOctree *mappedPatch);
+    VolOctreeMapper(const VolOctree *referencePatch, const VolOctree *mappedPatch);
 #endif
 
     void adaptionPrepare(const std::vector<adaption::Info> &adaptionInfo, bool reference = true) override;

--- a/test/integration_tests/containers/test_containers_00003.cpp
+++ b/test/integration_tests/containers/test_containers_00003.cpp
@@ -57,10 +57,11 @@ int subtest_001()
     std::cout << "Moving container..." << std::endl;
 
     PiercedVector<double> container(containerExpected);
-    PiercedVector<double> movedContainer(std::move(container));
-
     std::cout << "  Size of original container ....... " << container.size() << std::endl;
+
+    PiercedVector<double> movedContainer(std::move(container));
     std::cout << "  Size of moved container .......... " << movedContainer.size() << std::endl;
+
     if (containerExpected.size() != movedContainer.size()) {
         throw std::runtime_error("Contents of moved container doesn't match expected values");
     }

--- a/test/integration_tests/voloctree/test_voloctree_00004.cpp
+++ b/test/integration_tests/voloctree/test_voloctree_00004.cpp
@@ -189,9 +189,10 @@ int subtest_001(VolOctree *patch_2D, VolOctree *patch_2D_restored)
     binaryWriter2D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");
@@ -433,9 +434,10 @@ int subtest_002(VolOctree *patch_3D, VolOctree *patch_3D_restored)
     binaryWriter3D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");

--- a/test/integration_tests/volunstructured/test_volunstructured_00002.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_00002.cpp
@@ -161,9 +161,10 @@ int subtest_001(VolUnstructured *patch_2D, VolUnstructured *patch_2D_restored)
     binaryWriter2D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");
@@ -479,9 +480,10 @@ int subtest_002(VolUnstructured *patch_3D, VolUnstructured *patch_3D_restored)
     binaryWriter3D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
@@ -208,9 +208,10 @@ int subtest_001(int rank, VolUnstructured *patch_2D, VolUnstructured *patch_2D_r
     binaryWriter2D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");
@@ -583,9 +584,10 @@ int subtest_002(int rank, VolUnstructured *patch_3D, VolUnstructured *patch_3D_r
     binaryWriter3D.close();
 
     // Reset the data
-    booleanStorage.fill(false);
-    doubleStorage.fill(0);
-    arrayDoubleStorage.fill({{0., 0., 0.}});
+    booleanStorage.unsetKernel(true);
+    doubleStorage.unsetKernel(true);
+    arrayDoubleStorage.unsetKernel(true);
+
     stringValue = "";
     stringVector.clear();
     stringArray.fill("");


### PR DESCRIPTION
The rationale for this change is that when a storage is registered for synchronization, it won't alter the kernel in a way that affects the usage of the kernel. What happens is that a new PiercedSyncSlave will be added to the list of objects that should be keep in sync with the kernel.