### PR TITLE
IO/VTK: add support for second-order tensor fields

### DIFF
--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -926,6 +926,7 @@ void VTK::writeDataHeader( std::fstream &str, bool parallel ){
             if( field.isEnabled() && field.getLocation() == location){
                 if(      field.getFieldType() == VTKFieldType::SCALAR ) scalars <<  field.getName() << " " ;
                 else if( field.getFieldType() == VTKFieldType::VECTOR ) vectors <<  field.getName() << " " ;
+                else if( field.getFieldType() == VTKFieldType::TENSOR ) vectors <<  field.getName() << " " ;
             }
 
         }

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -54,11 +54,16 @@ enum class VTKWriteMode {
 /*!
  * @ingroup VTKEnums
  * Enum class defining types of fields whic may be written through class VTK
+ *
+ * Only second-order (3x3) tensors are supported. They should be passed to the VTK classes as
+ * 9-component vectors. It's up to the user of the VTK classes to specify how the tensors are
+ * linearized (e.g., row-major order).
  */
 enum class VTKFieldType {
     UNDEFINED = -1,
-    SCALAR = 1,
-    VECTOR = 3,
+    SCALAR    = 0,
+    VECTOR    = 1,
+    TENSOR    = 2,
 };
 
 /*!
@@ -237,7 +242,7 @@ class VTKField{
     //members
     protected:
         std::string             m_name;                     /**< name of the field */
-        VTKFieldType            m_fieldType;                /**< type of field [ VTKFieldType::SCALAR/VECTOR ] */
+        VTKFieldType            m_fieldType;                /**< type of field [ VTKFieldType::SCALAR/VECTOR/TENSOR ] */
         VTKDataType             m_dataType;                 /**< type of data [  VTKDataType::[[U]Int[8/16/32/64] / Float[32/64] ]] */
         VTKLocation             m_location;                 /**< cell or point data [ VTKLocation::CELL/VTKLocation::POINT] */
         VTKFormat               m_codification ;            /**< Type of codification [VTKFormat::ASCII, VTKFormat::APPENDED] */

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -249,6 +249,8 @@ class VTKField{
 
         //methods
     public:
+        static unsigned getComponentCount(VTKFieldType fieldType);
+
         virtual ~VTKField() = default;
 
         VTKField();
@@ -257,6 +259,7 @@ class VTKField{
         const std::string &     getName() const;
         VTKDataType             getDataType() const;
         VTKFieldType            getFieldType() const;
+        unsigned                getComponentCount() const;
         VTKLocation             getLocation() const;
         VTKFormat               getCodification() const;
         uint64_t                getOffset() const;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -59,7 +59,6 @@ enum class VTKFieldType {
     UNDEFINED = -1,
     SCALAR = 1,
     VECTOR = 3,
-    KNOWN_BY_CLASS = 4,
 };
 
 /*!
@@ -238,7 +237,7 @@ class VTKField{
     //members
     protected:
         std::string             m_name;                     /**< name of the field */
-        VTKFieldType            m_fieldType;                /**< type of field [ VTKFieldType::SCALAR/VECTOR/KNOWN_BY_CLASS ] */
+        VTKFieldType            m_fieldType;                /**< type of field [ VTKFieldType::SCALAR/VECTOR ] */
         VTKDataType             m_dataType;                 /**< type of data [  VTKDataType::[[U]Int[8/16/32/64] / Float[32/64] ]] */
         VTKLocation             m_location;                 /**< cell or point data [ VTKLocation::CELL/VTKLocation::POINT] */
         VTKFormat               m_codification ;            /**< Type of codification [VTKFormat::ASCII, VTKFormat::APPENDED] */

--- a/src/IO/VTK.tpp
+++ b/src/IO/VTK.tpp
@@ -47,7 +47,7 @@ VTKField& VTK::addData( const std::string &name, std::vector<T> &data ){
  * Codification will be set according to default value [appended] or to value set by VTK::setDataCodex( VTKFormat ) or VTK::setCodex( VTKFormat )
  * @tparam T type of std::vector<>
  * @param[in] name name of field
- * @param[in] comp type of data field [ VTKFieldType::SCALAR/ VTKFieldType::VECTOR ] 
+ * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR ]
  * @param[in] loc location of data [VTKLocation::CELL/VTKLocation::POINT]
  * @param[in] data data
  */
@@ -68,7 +68,7 @@ VTKField& VTK::addData(const std::string &name, VTKFieldType comp,  VTKLocation 
  * Codification will be set according to default value [appended] or to value set by VTK::setDataCodex( VTKFormat ) or VTK::setCodex( VTKFormat )
  * @tparam T type of data to be written or read
  * @param[in] name name of field
- * @param[in] comp type of data field [ VTKFieldType::SCALAR/ VTKFieldType::VECTOR ] 
+ * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR ]
  * @param[in] loc location of data [VTKLocation::CELL/VTKLocation::POINT]
  * @param[in] streamer data streamer
  */

--- a/src/IO/VTK.tpp
+++ b/src/IO/VTK.tpp
@@ -47,7 +47,7 @@ VTKField& VTK::addData( const std::string &name, std::vector<T> &data ){
  * Codification will be set according to default value [appended] or to value set by VTK::setDataCodex( VTKFormat ) or VTK::setCodex( VTKFormat )
  * @tparam T type of std::vector<>
  * @param[in] name name of field
- * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR ]
+ * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR/TENSOR ]
  * @param[in] loc location of data [VTKLocation::CELL/VTKLocation::POINT]
  * @param[in] data data
  */
@@ -68,7 +68,7 @@ VTKField& VTK::addData(const std::string &name, VTKFieldType comp,  VTKLocation 
  * Codification will be set according to default value [appended] or to value set by VTK::setDataCodex( VTKFormat ) or VTK::setCodex( VTKFormat )
  * @tparam T type of data to be written or read
  * @param[in] name name of field
- * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR ]
+ * @param[in] comp type of data field [ VTKFieldType::SCALAR/VECTOR/TENSOR ]
  * @param[in] loc location of data [VTKLocation::CELL/VTKLocation::POINT]
  * @param[in] streamer data streamer
  */

--- a/src/IO/VTKField.cpp
+++ b/src/IO/VTKField.cpp
@@ -34,6 +34,27 @@ namespace bitpit{
  */
 
 /*!
+ * get the number of field components
+ * @return number of field components
+ */
+unsigned VTKField::getComponentCount(VTKFieldType fieldType) {
+
+    switch (fieldType) {
+
+    case VTKFieldType::SCALAR:
+        return 1;
+
+    case VTKFieldType::VECTOR:
+        return 3;
+
+    default:
+        throw std::runtime_error("Unable to identify the number of components of field type " + std::to_string(static_cast<int>(fieldType)));
+
+    }
+}
+
+
+/*!
  * Default constructor
  */
 VTKField::VTKField(){
@@ -150,6 +171,15 @@ const std::string & VTKField::getName() const{
  */
 VTKFieldType VTKField::getFieldType() const{ 
     return m_fieldType; 
+}
+
+/*!
+ * get the number of field components
+ * @return number of field components
+ */
+unsigned VTKField::getComponentCount() const{
+
+    return getComponentCount(getFieldType());
 }
 
 /*!

--- a/src/IO/VTKField.cpp
+++ b/src/IO/VTKField.cpp
@@ -92,7 +92,7 @@ void VTKField::setCodification( VTKFormat cod ){
 
 /*!
  * set type of data field
- * @param[in] type type of data field [VTKFieldType::SCALAR/VECTOR/KNOWN_BY_CLASS]
+ * @param[in] type type of data field [ VTKFieldType::SCALAR/VECTOR ]
  */
 void VTKField::setFieldType( VTKFieldType type ){ 
     m_fieldType= type; 

--- a/src/IO/VTKField.cpp
+++ b/src/IO/VTKField.cpp
@@ -47,6 +47,9 @@ unsigned VTKField::getComponentCount(VTKFieldType fieldType) {
     case VTKFieldType::VECTOR:
         return 3;
 
+    case VTKFieldType::TENSOR:
+        return 9;
+
     default:
         throw std::runtime_error("Unable to identify the number of components of field type " + std::to_string(static_cast<int>(fieldType)));
 
@@ -113,7 +116,7 @@ void VTKField::setCodification( VTKFormat cod ){
 
 /*!
  * set type of data field
- * @param[in] type type of data field [ VTKFieldType::SCALAR/VECTOR ]
+ * @param[in] type type of data field [ VTKFieldType::SCALAR/VECTOR/TENSOR ]
  */
 void VTKField::setFieldType( VTKFieldType type ){ 
     m_fieldType= type; 

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -53,7 +53,7 @@ VTKRectilinearGrid::VTKRectilinearGrid( ) :VTK() {
 
     for( auto & field : m_geometry ){
         field.setLocation( VTKLocation::POINT ) ;
-        field.setFieldType( VTKFieldType::KNOWN_BY_CLASS ) ;
+        field.setFieldType( VTKFieldType::SCALAR ) ;
         field.setDataType( VTKDataType::Float64 ) ;
         field.setCodification(m_geomCodex);
     }

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -534,10 +534,7 @@ uint64_t VTKRectilinearGrid::calcFieldEntries( const VTKField &field ){
 
         }
 
-        VTKFieldType fieldType( field.getFieldType() ) ;
-        assert( fieldType != VTKFieldType::UNDEFINED) ;
-
-        entries *= static_cast<uint64_t>(fieldType) ;
+        entries *= field.getComponentCount() ;
 
     }
 
@@ -559,10 +556,7 @@ uint8_t VTKRectilinearGrid::calcFieldComponents( const VTKField &field ){
         comp = 1 ;
 
     } else{
-        VTKFieldType fieldType( field.getFieldType() ) ;
-        assert( fieldType != VTKFieldType::UNDEFINED) ;
-
-        comp = static_cast<uint8_t>(fieldType) ;
+        comp = field.getComponentCount();
 
     }
 

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -693,7 +693,7 @@ uint64_t VTKUnstructuredGrid::calcFieldEntries( const VTKField &field ){
     const std::string &name = field.getName() ;
 
     if( name == "Points" ){
-        entries = m_points *static_cast<int>(VTKFieldType::VECTOR) ; 
+        entries = m_points * VTKField::getComponentCount(VTKFieldType::VECTOR) ;
 
     } else if( name == "offsets" ){
         entries = m_cells ;
@@ -723,10 +723,7 @@ uint64_t VTKUnstructuredGrid::calcFieldEntries( const VTKField &field ){
 
         }
 
-        VTKFieldType fieldType( field.getFieldType() ) ;
-        assert( fieldType != VTKFieldType::UNDEFINED) ;
-
-        entries *= static_cast<uint64_t>(fieldType) ;
+        entries *= field.getComponentCount() ;
 
     }
 
@@ -745,7 +742,7 @@ uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ){
     const std::string &name = field.getName() ;
 
     if( name == "Points" ){
-        comp = static_cast<int>(VTKFieldType::VECTOR) ; 
+        comp = VTKField::getComponentCount(VTKFieldType::VECTOR) ;
 
     } else if( name == "offsets" ){
         comp = 1 ;
@@ -769,11 +766,7 @@ uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ){
         comp = 1 ;
 
     } else{
-
-        VTKFieldType fieldType( field.getFieldType() ) ;
-        assert( fieldType != VTKFieldType::UNDEFINED) ;
-
-        comp = static_cast<uint8_t>(fieldType) ;
+        comp = field.getComponentCount();
 
     }
 

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -187,7 +187,7 @@ VTKUnstructuredGrid::VTKUnstructuredGrid( VTKElementType elementType ) :VTK() {
 
     for( auto & field : m_geometry ){
         field.setLocation( VTKLocation::CELL ) ;
-        field.setFieldType( VTKFieldType::KNOWN_BY_CLASS ) ;
+        field.setFieldType( VTKFieldType::SCALAR ) ;
         field.setDataType( VTKDataType::Int32 ) ;
         field.setCodification(m_geomCodex);
     }

--- a/src/IO/VTKUtils.cpp
+++ b/src/IO/VTKUtils.cpp
@@ -142,10 +142,7 @@ bool vtk::convertStringToDataArray( const std::string &line, VTKField &field  ){
 std::string  vtk::convertDataArrayToString( const VTKField &field ){
 
     std::stringstream   os("") ;
-    unsigned            comp = static_cast<unsigned>(field.getFieldType())  ;
-
-    if( field.getFieldType() != VTKFieldType::SCALAR && field.getFieldType() != VTKFieldType::VECTOR )
-        comp = 1 ;
+    unsigned            comp = field.getComponentCount() ;
 
     os << "        <DataArray "
         << "type=\"" << vtk::convertEnumToString( field.getDataType() ) << "\" "
@@ -172,10 +169,7 @@ std::string  vtk::convertDataArrayToString( const VTKField &field ){
 std::string  vtk::convertPDataArrayToString( const VTKField &field ){
 
     std::stringstream  os("") ;
-    unsigned            comp = static_cast<unsigned>(field.getFieldType())  ;
-
-    if( field.getFieldType() != VTKFieldType::SCALAR && field.getFieldType() != VTKFieldType::VECTOR )
-        comp = 1 ;
+    unsigned            comp = field.getComponentCount() ;
 
     os << "        <PDataArray "
         << "type=\"" << vtk::convertEnumToString(field.getDataType()) << "\" "

--- a/src/IO/VTKUtils.cpp
+++ b/src/IO/VTKUtils.cpp
@@ -104,6 +104,8 @@ bool vtk::convertStringToDataArray( const std::string &line, VTKField &field  ){
 
         if(components==3)
             comp=VTKFieldType::VECTOR ;
+        else if(components==9)
+            comp=VTKFieldType::TENSOR ;
 
         vtk::convertStringToEnum( typ, type) ;
         vtk::convertStringToEnum( code, codex) ;

--- a/test/integration_tests/IO/test_IO_00001.cpp
+++ b/test/integration_tests/IO/test_IO_00001.cpp
@@ -41,8 +41,9 @@ int subtest_001()
     vector<array<double,3>>     points ;
     vector<vector<int>>          connectivity ;
 
-    vector<double>              pressure ;
-    vector<array<double,3>>     velocity ;
+    vector<double>           pressure ;
+    vector<array<double,3>>  velocity ;
+    vector<array<double,9>>  velocity_gradient ;
 
 
     points.resize(8) ;
@@ -51,6 +52,7 @@ int subtest_001()
 
     pressure.resize(8) ;
     velocity.resize(1) ;
+    velocity_gradient.resize(1) ;
 
     points[0][0]  =  0.  ;
     points[0][1]  =  0.  ;
@@ -88,9 +90,13 @@ int subtest_001()
     for( int i=0; i<8; i++)  connectivity[0][i] = i ;
 
     for( int i=0; i<8; i++)  pressure[i] = (double) i ;
-    velocity[0][0] = 1. ;
-    velocity[0][1] = 2. ;
-    velocity[0][2] = 3. ;
+
+    for (int d = 0; d < 3; ++d) {
+        velocity[0][d] = d + 1 ;
+        for (int k = 0; k < 3; ++k) {
+            velocity_gradient[0][d * 3 + k] = (d + 1) * 1000 + (k + 1) ;
+        }
+    }
 
     { //Write only grid to VTK in ascii format
         cout << "Write only grid to VTK in ascii format" << endl;
@@ -115,6 +121,7 @@ int subtest_001()
         vtk.setGeomData( bitpit::VTKUnstructuredField::CONNECTIVITY, connectivity) ;
         vtk.addData( "press", bitpit::VTKFieldType::SCALAR, bitpit::VTKLocation::POINT, pressure) ;
         vtk.addData( "vel", bitpit::VTKFieldType::VECTOR, bitpit::VTKLocation::CELL, velocity) ;
+        vtk.addData( "vel_grad", bitpit::VTKFieldType::TENSOR, bitpit::VTKLocation::CELL, velocity_gradient) ;
 
         vtk.write() ;
     }


### PR DESCRIPTION
Second-order tensors should be passed to the VTK classes as 9-component vectors. It's up to the user of the VTK classes
to specify how the tensors are linearized (e.g., row-major order).