### PR TITLE
levelset: fix object update after partitioning

### DIFF
--- a/src/levelset/levelSet.cpp
+++ b/src/levelset/levelSet.cpp
@@ -807,8 +807,8 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
 
     assert(m_kernel && "LevelSet::setMesh() must be called prior to LevelSet::partition()");
 
-    VolumeKernel *mesh = m_kernel->getMesh();
 #if BITPIT_ENABLE_MPI
+    const VolumeKernel *mesh = m_kernel->getMesh();
     bool isMeshPartitioned = mesh->isPartitioned();
 #endif
 
@@ -821,57 +821,27 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
     }
 #endif
 
-    // Inspect adaption data to detect what needs to be updated
-    std::unordered_map<int,std::vector<long>> partitioningSendList ;
-    std::unordered_map<int,std::vector<long>> partitioningRecvList ;
-
-    bool updateNarrowBand   = false;
-    bool updatePartitioning = false;
+    // Check if the levelset needs to be updated
+    bool isDirty = false;
     for( const adaption::Info &adaptionInfo : adaptionData){
         if( adaptionInfo.entity != adaption::Entity::ENTITY_CELL){
             continue;
         }
 
-        if( adaptionInfo.type == adaption::Type::TYPE_PARTITION_SEND){
-            partitioningSendList.insert({{adaptionInfo.rank,adaptionInfo.previous}}) ;
-            updatePartitioning = true;
-        } else if( adaptionInfo.type == adaption::Type::TYPE_PARTITION_RECV){
-            partitioningRecvList.insert({{adaptionInfo.rank,adaptionInfo.current}}) ;
-            updatePartitioning = true;
-        } else if (adaptionInfo.type == adaption::Type::TYPE_DELETION) {
-            updateNarrowBand = true;
-        } else {
-            if (!updateNarrowBand) {
-                for (long cellId : adaptionInfo.current) {
-                    const Cell &cell = mesh->getCell(cellId);
-                    if (cell.isInterior()) {
-                        updateNarrowBand = true;
-                        break;
-                    }
-                }
-            }
-        }
+        isDirty = true;
+        break;
     }
 
 #if BITPIT_ENABLE_MPI
     if (isMeshPartitioned) {
-        MPI_Allreduce(MPI_IN_PLACE, &updateNarrowBand, 1, MPI_C_BOOL, MPI_LOR, m_kernel->getCommunicator());
-        MPI_Allreduce(MPI_IN_PLACE, &updatePartitioning, 1, MPI_C_BOOL, MPI_LOR, m_kernel->getCommunicator());
+        MPI_Allreduce(MPI_IN_PLACE, &isDirty, 1, MPI_C_BOOL, MPI_LOR, m_kernel->getCommunicator());
     }
 #endif
 
     // Early return if no update is needed
-    if (!updateNarrowBand && !updatePartitioning) {
+    if (!isDirty) {
         return;
     }
-
-#if BITPIT_ENABLE_MPI
-    // Get data communicator for updating partitioning
-    std::unique_ptr<DataCommunicator> dataCommunicator;
-    if (updatePartitioning) {
-        dataCommunicator = m_kernel->createDataCommunicator();
-    }
-#endif
 
     // Update kernel
     m_kernel->update( adaptionData ) ;
@@ -896,13 +866,6 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
             signPropagationObject = nullptr;
         }
 
-#if BITPIT_ENABLE_MPI
-        // Start partitioning update
-        if (updatePartitioning) {
-            object->startExchange( partitioningSendList, dataCommunicator.get() );
-        }
-#endif
-
         // Propagated sign is now dirty
         //
         // The propagated sign will be set as non-dirty by the sign propagator.
@@ -910,25 +873,8 @@ void LevelSet::update( const std::vector<adaption::Info> &adaptionData, const st
             signPropagationObject->setSignStorageDirty(true);
         }
 
-        // Clear data structures after mesh update
-        object->clearAfterMeshAdaption( adaptionData ) ;
-
-#if BITPIT_ENABLE_MPI
-        // Complete partitioning update
-        if (updatePartitioning) {
-            object->completeExchange( partitioningRecvList, dataCommunicator.get() );
-        }
-#endif
-
-        // Update levelset inside narrow band
-        if (updateNarrowBand) {
-            object->updateNarrowBand( adaptionData, m_signedDistance ) ;
-        }
-
-#if BITPIT_ENABLE_MPI
-        // Update data on ghost cells
-        object->exchangeGhosts();
-#endif
+        // Update object
+        object->update( adaptionData, m_signedDistance );
 
         // Propagate sign
         //

--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -49,7 +49,8 @@ template class LevelSetCachedObject<LevelSetNarrowBandCache<LevelSetDirectStorag
  * \param kernel is the container associated with the storage manager
  */
 LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>::LevelSetNarrowBandCache(Kernel *kernel)
-    : LevelSetExternalPiercedStorageManager(kernel), LevelSetNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
+    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC),
+      LevelSetNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
 {
     m_values    = addStorage<double>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
     m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);

--- a/src/levelset/levelSetCachedObject.cpp
+++ b/src/levelset/levelSetCachedObject.cpp
@@ -49,13 +49,13 @@ template class LevelSetCachedObject<LevelSetNarrowBandCache<LevelSetDirectStorag
  * \param kernel is the container associated with the storage manager
  */
 LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>::LevelSetNarrowBandCache(Kernel *kernel)
-    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC),
+    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC, StorageSyncMode::SYNC_MODE_JOURNALED),
       LevelSetNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
 {
-    m_values    = addStorage<double>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
-    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    m_values    = addStorage<double>(getStorageCount(), 1);
+    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1);
 
-    m_narrowBandFlag = addStorage<char>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    m_narrowBandFlag = addStorage<char>(getStorageCount(), 1);
     m_narrowBandFlag->fill(0);
 }
 
@@ -247,14 +247,16 @@ void LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>::swap(LevelS
 
 /*!
  * Constructor
+ *
+ * It is faster to use a concurrent synchronization for the storage manager, because items will
+ * be added/removed to the kernel one at the time.
  */
 LevelSetNarrowBandCache<LevelSetInternalPiercedStorageManager>::LevelSetNarrowBandCache()
-    : LevelSetInternalPiercedStorageManager(), LevelSetNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
+    : LevelSetInternalPiercedStorageManager(StorageSyncMode::SYNC_MODE_CONCURRENT),
+      LevelSetNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
 {
-    // It is faster to use a concurrent synchronization because items will be added/removed
-    // to the kernel one at the time.
-    m_values    = addStorage<double>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
-    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
+    m_values    = addStorage<double>(getStorageCount(), 1);
+    m_gradients = addStorage<std::array<double, 3>>(getStorageCount(), 1);
 }
 
 /*!

--- a/src/levelset/levelSetCachedObject.hpp
+++ b/src/levelset/levelSetCachedObject.hpp
@@ -223,6 +223,9 @@ template<typename narrow_band_cache_t>
 class LevelSetCachedObject : public LevelSetObject, public LevelSetCachedObjectInterface<narrow_band_cache_t>, public LevelSetSignedObjectInterface {
 
     protected:
+# if BITPIT_ENABLE_MPI
+    UpdateStrategy                              getPartitioningUpdateStrategy() const override;
+# endif
 
     void                                        pruneNarrowBand(const std::vector<long> &cellIds) override ;
 

--- a/src/levelset/levelSetCachedObject.hpp
+++ b/src/levelset/levelSetCachedObject.hpp
@@ -223,9 +223,10 @@ template<typename narrow_band_cache_t>
 class LevelSetCachedObject : public LevelSetObject, public LevelSetCachedObjectInterface<narrow_band_cache_t>, public LevelSetSignedObjectInterface {
 
     protected:
-    void                                        _clear( ) override ;
 
-    void                                        _clearAfterMeshAdaption(const std::vector<adaption::Info> & ) override ;
+    void                                        pruneNarrowBand(const std::vector<long> &cellIds) override ;
+
+    void                                        _clear( ) override ;
 
     void                                        _dump( std::ostream &) override ;
     void                                        _restore( std::istream &) override ;

--- a/src/levelset/levelSetCachedObject.tpp
+++ b/src/levelset/levelSetCachedObject.tpp
@@ -354,6 +354,26 @@ std::array<double,3> LevelSetCachedObject<narrow_band_cache_t>::getGradient(long
 
 }
 
+#if BITPIT_ENABLE_MPI
+/*!
+ * Get the strategy that should be used to update the object after a partitioning.
+ * @result The strategy that should be used to update the object after a partitioning.
+ */
+template<typename narrow_band_cache_t>
+LevelSetObject::UpdateStrategy LevelSetCachedObject<narrow_band_cache_t>::getPartitioningUpdateStrategy() const {
+    // If the kernel of the cache uses an automatic synchronization, it's not possible to
+    // update the object after a partitioning exchanging data. That's because, at the time
+    // the update takes place, the automatic synchronization has already deleted the data
+    // of the cells that have been sent.
+    const narrow_band_cache_t *narrowBandCache = this->getNarrowBandCache();
+    if (narrowBandCache->getKernelSyncMode() == narrow_band_cache_t::KERNEL_SYNC_MODE_MANUAL) {
+        return UPDATE_STRATEGY_EXCHANGE;
+    } else {
+        return UPDATE_STRATEGY_EVALUATE;
+    }
+}
+#endif
+
 /*!
  * Clear narrow band information associated with the specified cells.
  * @param[in] cellIds are the ids of the cells for which narrow band information will be deleted

--- a/src/levelset/levelSetCachedObject.tpp
+++ b/src/levelset/levelSetCachedObject.tpp
@@ -354,24 +354,17 @@ std::array<double,3> LevelSetCachedObject<narrow_band_cache_t>::getGradient(long
 
 }
 
-/*! 
- * Deletes non-existing items after grid adaption.
- * @param[in] adaptionData are the information about the adaption
+/*!
+ * Clear narrow band information associated with the specified cells.
+ * @param[in] cellIds are the ids of the cells for which narrow band information will be deleted
  */
 template<typename narrow_band_cache_t>
-void LevelSetCachedObject<narrow_band_cache_t>::_clearAfterMeshAdaption( const std::vector<adaption::Info> &adaptionData ){
+void LevelSetCachedObject<narrow_band_cache_t>::pruneNarrowBand(const std::vector<long> &cellIds){
 
-    // Clear stale narrow band entries
     narrow_band_cache_t *narrowBandCache = this->getNarrowBandCache();
-    for (const adaption::Info &adaptionInfo : adaptionData) {
-        if (adaptionInfo.entity != adaption::Entity::ENTITY_CELL) {
-            continue;
-        }
-
-        for (long cellId : adaptionInfo.previous) {
-            if (narrowBandCache->contains(cellId)) {
-                narrowBandCache->erase(cellId, false);
-            }
+    for (long cellId : cellIds) {
+        if (narrowBandCache->contains(cellId)) {
+            narrowBandCache->erase(cellId, false);
         }
     }
 

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -85,6 +85,11 @@ class LevelSetObject : public VTKBaseStreamer, public virtual LevelSetObjectInte
     std::size_t                                 decrementReferenceCount();
 
     protected:
+    enum UpdateStrategy {
+        UPDATE_STRATEGY_EXCHANGE,
+        UPDATE_STRATEGY_EVALUATE,
+    };
+
     LevelSetObject(int);
     LevelSetObject(const LevelSetObject &other);
     LevelSetObject(LevelSetObject &&other);
@@ -96,6 +101,10 @@ class LevelSetObject : public VTKBaseStreamer, public virtual LevelSetObjectInte
     void                                        update( const std::vector<adaption::Info> &adaptionData, bool signedDistance );
 
     void                                        setSizeNarrowBand(double) ;
+
+# if BITPIT_ENABLE_MPI
+    virtual UpdateStrategy                      getPartitioningUpdateStrategy() const;
+# endif
 
     virtual void                                computeNarrowBand(bool);
     virtual void                                updateNarrowBand(const std::vector<long> &cellIds, bool signd);

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -93,12 +93,13 @@ class LevelSetObject : public VTKBaseStreamer, public virtual LevelSetObjectInte
     LevelSetKernel *                            getKernel() override;
 
     void                                        clear();
+    void                                        update( const std::vector<adaption::Info> &adaptionData, bool signedDistance );
 
     void                                        setSizeNarrowBand(double) ;
 
     virtual void                                computeNarrowBand(bool);
-    virtual void                                updateNarrowBand(const std::vector<adaption::Info> &, bool);
-    void                                        clearAfterMeshAdaption(const std::vector<adaption::Info>&);
+    virtual void                                updateNarrowBand(const std::vector<long> &cellIds, bool signd);
+    virtual void                                pruneNarrowBand(const std::vector<long> &cellIds);
 
     short                                       evalValueSign(double) const ;
 
@@ -116,7 +117,6 @@ class LevelSetObject : public VTKBaseStreamer, public virtual LevelSetObjectInte
     double                                      m_narrowBandSize;   /**< Size of narrow band */
 
     virtual void                                _clear();
-    virtual void                                _clearAfterMeshAdaption(const std::vector<adaption::Info>&) ;
     virtual void                                _dump(std::ostream &);
     virtual void                                _restore( std::istream &);
 

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -43,7 +43,9 @@ template class LevelSetSegmentationObject<LevelSetSegmentationNarrowBandCache<Le
  * \param kernel is the container associated with the storage manager
  */
 LevelSetSegmentationNarrowBandCache<LevelSetExternalPiercedStorageManager>::LevelSetSegmentationNarrowBandCache(Kernel *kernel)
-    : LevelSetExternalPiercedStorageManager(kernel), LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>(kernel), LevelSetSegmentationNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
+    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC),
+      LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>(kernel),
+      LevelSetSegmentationNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
 {
     m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
     m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -43,12 +43,12 @@ template class LevelSetSegmentationObject<LevelSetSegmentationNarrowBandCache<Le
  * \param kernel is the container associated with the storage manager
  */
 LevelSetSegmentationNarrowBandCache<LevelSetExternalPiercedStorageManager>::LevelSetSegmentationNarrowBandCache(Kernel *kernel)
-    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC),
+    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC, StorageSyncMode::SYNC_MODE_JOURNALED),
       LevelSetNarrowBandCache<LevelSetExternalPiercedStorageManager>(kernel),
       LevelSetSegmentationNarrowBandCacheBase<LevelSetExternalPiercedStorageManager>()
 {
-    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
-    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1);
+    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1);
 }
 
 /*!
@@ -105,14 +105,17 @@ const std::array<double, 3> & LevelSetSegmentationNarrowBandCache<LevelSetExtern
 
 /*!
  * Constructor
+ *
+ * It is faster to use a concurrent synchronization for the storage manager, because items will
+ * be added/removed to the kernel one at the time.
  */
 LevelSetSegmentationNarrowBandCache<LevelSetInternalPiercedStorageManager>::LevelSetSegmentationNarrowBandCache()
-    : LevelSetInternalPiercedStorageManager(), LevelSetNarrowBandCache<LevelSetInternalPiercedStorageManager>(), LevelSetSegmentationNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
+    : LevelSetInternalPiercedStorageManager(StorageSyncMode::SYNC_MODE_CONCURRENT),
+      LevelSetNarrowBandCache<LevelSetInternalPiercedStorageManager>(),
+      LevelSetSegmentationNarrowBandCacheBase<LevelSetInternalPiercedStorageManager>()
 {
-    // It is faster to use a concurrent synchronization because items will be added/removed
-    // to the kernel one at the time.
-    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
-    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_CONCURRENT);
+    m_supportIds     = this->template addStorage<long>(this->getStorageCount(), 1);
+    m_surfaceNormals = this->template addStorage<std::array<double, 3>>(this->getStorageCount(), 1);
 }
 
 /*!

--- a/src/levelset/levelSetSegmentationObject.hpp
+++ b/src/levelset/levelSetSegmentationObject.hpp
@@ -215,8 +215,8 @@ class LevelSetSegmentationObject : public LevelSetSegmentationKernel, public Lev
     void                                        computeNarrowBand(bool) override;
     void                                        computeNarrowBand( LevelSetCartesianKernel *, bool);
     void                                        computeNarrowBand( LevelSetKernel *, bool);
-    void                                        updateNarrowBand(const std::vector<adaption::Info> &, bool) override;
-    void                                        updateNarrowBand(LevelSetKernel *, const std::vector<adaption::Info> &, bool);
+    void                                        updateNarrowBand(const std::vector<long> &cellIds, bool signd) override;
+    void                                        updateNarrowBand(LevelSetKernel *, const std::vector<long> &cellIds, bool signd);
 
     public:
 

--- a/src/levelset/levelSetSignPropagator.cpp
+++ b/src/levelset/levelSetSignPropagator.cpp
@@ -504,11 +504,11 @@ void LevelSetSignPropagator::executeSeedPropagation(const std::vector<std::size_
 
     std::vector<std::size_t> rawProcessList;
 
-    std::size_t rawSeedCursor = rawSeeds.size();
-    while (rawSeedCursor != 0) {
+    std::size_t nRawSeeds = rawSeeds.size();
+    while (nRawSeeds != 0) {
         // Get a seed
-        --rawSeedCursor;
-        std::size_t seedRawId = rawSeeds[rawSeedCursor];
+        --nRawSeeds;
+        std::size_t seedRawId = rawSeeds[nRawSeeds];
 
         // Get the sign of the seed
         LevelSetSignStorage::KernelIterator seedSignStorageItr = storage->rawFind(seedRawId);

--- a/src/levelset/levelSetSignedObject.cpp
+++ b/src/levelset/levelSetSignedObject.cpp
@@ -54,9 +54,11 @@ const LevelSetSignStorage::Sign LevelSetSignStorage::SIGN_POSITIVE  =  1;
  *
  * \param kernel is the kernel
  */
-LevelSetSignStorage::LevelSetSignStorage(PiercedKernel<long> *kernel) : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC) {
+LevelSetSignStorage::LevelSetSignStorage(PiercedKernel<long> *kernel)
+    : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC, StorageSyncMode::SYNC_MODE_JOURNALED)
+{
 
-    m_signs = addStorage<Sign>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
+    m_signs = addStorage<Sign>(getStorageCount(), 1);
 
 }
 

--- a/src/levelset/levelSetSignedObject.cpp
+++ b/src/levelset/levelSetSignedObject.cpp
@@ -54,7 +54,7 @@ const LevelSetSignStorage::Sign LevelSetSignStorage::SIGN_POSITIVE  =  1;
  *
  * \param kernel is the kernel
  */
-LevelSetSignStorage::LevelSetSignStorage(PiercedKernel<long> *kernel) : LevelSetExternalPiercedStorageManager(kernel) {
+LevelSetSignStorage::LevelSetSignStorage(PiercedKernel<long> *kernel) : LevelSetExternalPiercedStorageManager(kernel, KERNEL_SYNC_MODE_AUTOMATIC) {
 
     m_signs = addStorage<Sign>(getStorageCount(), 1, PiercedSyncMaster::SYNC_MODE_JOURNALED);
 

--- a/src/levelset/levelSetStorage.cpp
+++ b/src/levelset/levelSetStorage.cpp
@@ -86,17 +86,18 @@ void LevelSetContainerWrapper::swap(LevelSetContainerWrapper &other) noexcept
  * Constructor.
  */
 LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager()
-    : LevelSetExternalPiercedStorageManager(nullptr)
+    : LevelSetExternalPiercedStorageManager(nullptr, KERNEL_SYNC_MODE_MANUAL)
 {
 }
 
 /*!
  * Constructor.
  *
- * \param kernel is the container associated with the storage manager
+ * \param kernel is the kernel associated with the storage manager
+ * \param kernelSyncMode is the synchronization mode of the kernel
  */
-LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager(Kernel *kernel)
-    : LevelSetStorageManager<PiercedKernel<long>>(kernel)
+LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode)
+    : LevelSetStorageManager<PiercedKernel<long>>(kernel, kernelSyncMode)
 {
 }
 
@@ -253,7 +254,7 @@ void LevelSetExternalPiercedStorageManager::swap(LevelSetExternalPiercedStorageM
  * Constructor.
  */
 LevelSetInternalPiercedStorageManager::LevelSetInternalPiercedStorageManager()
-    : LevelSetExternalPiercedStorageManager(&m_internalKernel)
+    : LevelSetExternalPiercedStorageManager(&m_internalKernel, KERNEL_SYNC_MODE_MANUAL)
 {
 }
 
@@ -365,7 +366,7 @@ LevelSetDirectStorageManager::LevelSetDirectStorageManager()
  * \param nItems is the number of items each storage will contain
  */
 LevelSetDirectStorageManager::LevelSetDirectStorageManager(std::size_t nItems)
-    : LevelSetStorageManager<std::size_t, std::size_t>(nullptr), m_nItems(nItems)
+    : LevelSetStorageManager<std::size_t, std::size_t>(nullptr, KERNEL_SYNC_MODE_MANUAL), m_nItems(nItems)
 {
 }
 

--- a/src/levelset/levelSetStorage.cpp
+++ b/src/levelset/levelSetStorage.cpp
@@ -86,7 +86,7 @@ void LevelSetContainerWrapper::swap(LevelSetContainerWrapper &other) noexcept
  * Constructor.
  */
 LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager()
-    : LevelSetExternalPiercedStorageManager(nullptr, KERNEL_SYNC_MODE_MANUAL)
+    : LevelSetExternalPiercedStorageManager(nullptr, KERNEL_SYNC_MODE_MANUAL, StorageSyncMode::SYNC_MODE_DISABLED)
 {
 }
 
@@ -95,9 +95,11 @@ LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager()
  *
  * \param kernel is the kernel associated with the storage manager
  * \param kernelSyncMode is the synchronization mode of the kernel
+ * \param storageSyncMode is the synchronization mode that will be used for the storages
  */
-LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode)
-    : LevelSetStorageManager<PiercedKernel<long>>(kernel, kernelSyncMode)
+LevelSetExternalPiercedStorageManager::LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode, StorageSyncMode storageSyncMode)
+    : LevelSetStorageManager<PiercedKernel<long>>(kernel, kernelSyncMode),
+      m_storageSyncMode(storageSyncMode)
 {
 }
 
@@ -254,7 +256,17 @@ void LevelSetExternalPiercedStorageManager::swap(LevelSetExternalPiercedStorageM
  * Constructor.
  */
 LevelSetInternalPiercedStorageManager::LevelSetInternalPiercedStorageManager()
-    : LevelSetExternalPiercedStorageManager(&m_internalKernel, KERNEL_SYNC_MODE_MANUAL)
+    : LevelSetInternalPiercedStorageManager(StorageSyncMode::SYNC_MODE_DISABLED)
+{
+}
+
+/*!
+ * Constructor.
+ *
+ * \param storageSyncMode is the synchronization mode that will be used for the storages
+ */
+LevelSetInternalPiercedStorageManager::LevelSetInternalPiercedStorageManager(StorageSyncMode storageSyncMode)
+    : LevelSetExternalPiercedStorageManager(&m_internalKernel, KERNEL_SYNC_MODE_MANUAL, storageSyncMode)
 {
 }
 

--- a/src/levelset/levelSetStorage.hpp
+++ b/src/levelset/levelSetStorage.hpp
@@ -204,6 +204,19 @@ class LevelSetStorageManager
 {
 
 public:
+    /*!
+    * Defines the kernel synchronization mode.
+    *
+    * Possible synchronization modes are:
+    *  - manual, in this mode the storage manager is in charge of updating the kernel;
+    *  - automatic, in this mode the storage manager doesn't need to updated the kernel,
+    *    because its update will be performed automatically.
+    */
+    enum KernelSyncMode {
+        KERNEL_SYNC_MODE_MANUAL,
+        KERNEL_SYNC_MODE_AUTOMATIC,
+    };
+
     typedef kernel_t Kernel;
     typedef kernel_iterator_t KernelIterator;
 
@@ -213,6 +226,7 @@ public:
     void setDirty(bool dirty);
 
     const Kernel * getKernel() const;
+    KernelSyncMode getKernelSyncMode() const;
 
     virtual KernelIterator insert(long id, bool sync = true) = 0;
     virtual void erase(long id, bool sync = true) = 0;
@@ -265,10 +279,11 @@ public:
 protected:
     bool m_dirty; //! Controls if the manager is dirty
     Kernel *m_kernel; //! Kernel associated with the manager
+    KernelSyncMode m_kernelSyncMode; //! Kernel synchronization mode
     std::unordered_map<int, std::unique_ptr<LevelSetBaseStorage<kernel_iterator_t>>> m_storages; //! Storages handled by the manager
     std::vector<std::unique_ptr<LevelSetContainerWrapper>> m_containers; //! Containers that are handled by the manager
 
-    LevelSetStorageManager(Kernel *kernel);
+    LevelSetStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode);
 
     virtual void clearKernel() = 0;
 
@@ -304,7 +319,7 @@ public:
 
 protected:
     LevelSetExternalPiercedStorageManager();
-    LevelSetExternalPiercedStorageManager(Kernel *kernel);
+    LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode);
 
     void clearKernel() override;
 

--- a/src/levelset/levelSetStorage.hpp
+++ b/src/levelset/levelSetStorage.hpp
@@ -299,6 +299,8 @@ public:
     template<typename T>
     using Storage = PiercedStorage<T, long>;
 
+    using StorageSyncMode = PiercedSyncMaster::SyncMode;
+
     KernelIterator insert(long id, bool sync = true) override;
     void erase(long id, bool sync = true) override;
 
@@ -311,15 +313,17 @@ public:
     KernelIterator end() const override;
 
     template<typename value_t>
-    Storage<value_t> * addStorage(int id, int nFields, PiercedSyncMaster::SyncMode syncMode);
+    Storage<value_t> * addStorage(int id, int nFields);
 
     void syncStorages() override;
 
     void swap(LevelSetExternalPiercedStorageManager &other) noexcept;
 
 protected:
+    StorageSyncMode m_storageSyncMode; //! Storage synchronization mode
+
     LevelSetExternalPiercedStorageManager();
-    LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode);
+    LevelSetExternalPiercedStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode, StorageSyncMode storageSyncMode);
 
     void clearKernel() override;
 
@@ -343,6 +347,7 @@ protected:
     Kernel m_internalKernel; //! Internal pierced kernel
 
     LevelSetInternalPiercedStorageManager();
+    LevelSetInternalPiercedStorageManager(StorageSyncMode storageSyncMode);
 
     void clearKernel() override;
 

--- a/src/levelset/levelSetStorage.tpp
+++ b/src/levelset/levelSetStorage.tpp
@@ -889,9 +889,9 @@ void LevelSetStorageManager<kernel_t, kernel_iterator_t>::swap(LevelSetStorageMa
  * \result Returns a pointer to the container.
  */
 template<typename value_t>
-LevelSetExternalPiercedStorageManager::Storage<value_t> * LevelSetExternalPiercedStorageManager::addStorage(int id, int nFields, PiercedSyncMaster::SyncMode syncMode)
+LevelSetExternalPiercedStorageManager::Storage<value_t> * LevelSetExternalPiercedStorageManager::addStorage(int id, int nFields)
 {
-    std::unique_ptr<Storage<value_t>> container = std::unique_ptr<Storage<value_t>>(new Storage<value_t>(nFields, m_kernel, syncMode));
+    std::unique_ptr<Storage<value_t>> container = std::unique_ptr<Storage<value_t>>(new Storage<value_t>(nFields, m_kernel, m_storageSyncMode));
     m_containers.emplace_back(new LevelSetUniqueContainerWrapper<Storage<value_t>>(std::move(container)));
     LevelSetContainerWrapper *containerWrapper = m_containers.back().get();
 

--- a/src/levelset/levelSetStorage.tpp
+++ b/src/levelset/levelSetStorage.tpp
@@ -513,10 +513,11 @@ void LevelSetDirectStorage<value_t>::readItem(const KernelIterator &kernelIterat
  * Constructor.
  *
  * \param kernel is the container associated with the storage manager
+ * \param kernelSyncMode is the synchronization mode of the kernel
  */
 template<typename kernel_t, typename kernel_iterator_t>
-LevelSetStorageManager<kernel_t, kernel_iterator_t>::LevelSetStorageManager(Kernel *kernel)
-    : m_dirty(true), m_kernel(kernel)
+LevelSetStorageManager<kernel_t, kernel_iterator_t>::LevelSetStorageManager(Kernel *kernel, KernelSyncMode kernelSyncMode)
+    : m_dirty(true), m_kernel(kernel), m_kernelSyncMode(kernelSyncMode)
 {
 }
 
@@ -551,6 +552,17 @@ template<typename kernel_t, typename kernel_iterator_t>
 const typename LevelSetStorageManager<kernel_t, kernel_iterator_t>::Kernel * LevelSetStorageManager<kernel_t, kernel_iterator_t>::getKernel() const
 {
     return m_kernel;
+}
+
+/*!
+ * Get the synchronization mode of the kernel.
+ *
+ * \result The synchronization mode of the kernel.
+ */
+template<typename kernel_t, typename kernel_iterator_t>
+typename LevelSetStorageManager<kernel_t, kernel_iterator_t>::KernelSyncMode LevelSetStorageManager<kernel_t, kernel_iterator_t>::getKernelSyncMode() const
+{
+    return m_kernelSyncMode;
 }
 
 /*!


### PR DESCRIPTION
Objects that use a storage with automatic synchronization cannot exchange the levelset values after a partitioning, but need to evaluate the levelset on the received cells. That's because, at the time the update takes place, the automatic synchronization has already deleted the data of the cells that have been sent.
