### PR TITLE
IO: add a generic function to flush VTK values 

### DIFF
--- a/examples/voloctree_adaptation_example_00001.cpp
+++ b/examples/voloctree_adaptation_example_00001.cpp
@@ -58,18 +58,15 @@ public:
 
     void flushData(std::fstream &stream, const std::string &name, VTKFormat format) override
     {
-        assert(format == VTKFormat::APPENDED);
-        BITPIT_UNUSED(format);
-
         if (name == "scalarField") {
             for (const Cell &cell : m_patch.getVTKCellWriteRange()) {
                 long id = cell.getId();
-                genericIO::flushBINARY(stream, m_scalarField.at(id));
+                flushValue(stream, format, m_scalarField.at(id));
             }
         } else if (name == "vectorField") {
             for (const Cell &cell : m_patch.getVTKCellWriteRange()) {
                 long id = cell.getId();
-                genericIO::flushBINARY(stream, m_vectorField.at(id));
+                flushValue(stream, format, m_vectorField.at(id));
             }
         }
     };

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -214,6 +214,12 @@ class VTKBaseStreamer{
 
         virtual void            flushData( std::fstream &, const std::string &, VTKFormat)  ;
         virtual void            absorbData( std::fstream &, const std::string &, VTKFormat, uint64_t, uint8_t, VTKDataType)  ;
+
+        template<typename T>
+        void                    flushValue(std::fstream &, VTKFormat, const T &value);
+        template<typename T>
+        void                    flushValue(std::fstream &, VTKFormat, const T *values, int nValues);
+
 };
 
 class VTKNativeStreamer : public VTKBaseStreamer {

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -397,6 +397,9 @@ class VTK{
 
         int                     _findFieldIndex( const std::string &name, const std::vector<VTKField> &fields ) const;
 
+        bool                    isAppendedActive() const;
+        bool                    isASCIIActive() const;
+
         void                    calcAppendedOffsets() ;
         virtual uint64_t        calcFieldSize( const VTKField &) =0;
         virtual uint64_t        calcFieldEntries( const VTKField &) =0;

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -264,9 +264,10 @@ void VTKRectilinearGrid::writeMetaInformation( ){
     str << "  </RectilinearGrid>" << std::endl;
 
     //Write Appended Section
-    str << "  <AppendedData encoding=\"raw\">" << std::endl;
-    str << "_" ;
-    str << std::endl ;
+    if (isAppendedActive()) {
+        str << "  <AppendedData encoding=\"raw\">" << std::endl;
+        str << "_" << std::endl;
+    }
 
     //Closing XML
     str << "</VTKFile>" << std::endl;

--- a/src/IO/VTKStreamer.tpp
+++ b/src/IO/VTKStreamer.tpp
@@ -50,6 +50,50 @@ VTKVectorContainer<T>::VTKVectorContainer( std::vector<T> &data){
 }
 
 /*!
+ * Writes value to file stream
+ * @tparam T type of std::vector<>
+ * @param[in] str file stream
+ * @param[in] format VTKFormat::ASCII or VTKFormat::APPENDED
+ * @param[in] value is the value that will be written
+ */
+template<class T>
+void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T &value){
+
+    if( format==VTKFormat::ASCII){
+        genericIO::flushASCII( str, value) ;
+
+    } else if( format==VTKFormat::APPENDED) {
+        genericIO::flushBINARY( str, value) ;
+
+    }
+
+}
+
+/*!
+ * Writes value to file stream
+ * @tparam T type of std::vector<>
+ * @param[in] str file stream
+ * @param[in] format VTKFormat::ASCII or VTKFormat::APPENDED
+ * @param[in] values is a pointer to the values that will be written
+ * @param[in] size is the number of values that will be writtend
+ */
+template<class T>
+void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T *values, int nValues){
+
+    if( format==VTKFormat::ASCII){
+        genericIO::flushASCII( str, values, nValues) ;
+
+    } else if( format==VTKFormat::APPENDED) {
+        genericIO::flushBINARY( str, values, nValues) ;
+
+    } else {
+        throw std::runtime_error("VTK format not supported.") ;
+
+    }
+
+}
+
+/*!
  * Writes data to file stream
  * @tparam T type of std::vector<>
  * @param[in] str file stream
@@ -63,6 +107,9 @@ void VTKVectorContainer<T>::flushData( std::fstream &str, VTKFormat format){
 
     } else if( format==VTKFormat::APPENDED) {
         genericIO::flushBINARY( str, *m_ptr) ;
+
+    } else {
+        throw std::runtime_error("VTK format not supported.") ;
 
     }
 

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -76,78 +76,38 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::flushData( std::fstream &str,
 
     VTKDataType connectivityDataType = m_connectivity->getDataType();
 
-    if( format == VTKFormat::APPENDED){
-
-        if(name == "types" ){
-            uint8_t type = (uint8_t) m_type ;
-            for( unsigned int i=0; i<m_nCells; ++i){
-                genericIO::flushBINARY(str, type );
-            }
-        
-        } else if(name == "offsets" ){
-            uint8_t     n = vtk::getElementNodeCount(m_type) ;
-            if (connectivityDataType == VTKDataType::Int64 || connectivityDataType == VTKDataType::UInt64) {
-                uint64_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushBINARY(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int32 || connectivityDataType == VTKDataType::UInt32) {
-                uint32_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushBINARY(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int16 || connectivityDataType == VTKDataType::UInt16) {
-                uint16_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushBINARY(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int8 || connectivityDataType == VTKDataType::UInt8) {
-                uint8_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushBINARY(str, offset );
-                }
-            }
-        
+    if(name == "types" ){
+        uint8_t type = (uint8_t) m_type ;
+        for( unsigned int i=0; i<m_nCells; ++i){
+            flushValue(str, format, type );
         }
 
-    } else {
-        if(name == "types" ){
-            uint8_t type = (uint8_t) m_type ;
-            for( unsigned int i=0; i<m_nCells; ++i)
-                genericIO::flushASCII(str, type );
-        
-        } else if(name == "offsets" ){
-            uint8_t     n = vtk::getElementNodeCount(m_type) ;
-            if (connectivityDataType == VTKDataType::Int64 || connectivityDataType == VTKDataType::UInt64) {
-                uint64_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushASCII(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int32 || connectivityDataType == VTKDataType::UInt32) {
-                uint32_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushASCII(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int16 || connectivityDataType == VTKDataType::UInt16) {
-                uint16_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushASCII(str, offset );
-                }
-            } else if (connectivityDataType == VTKDataType::Int8 || connectivityDataType == VTKDataType::UInt8) {
-                uint8_t    offset(0) ;
-                for( unsigned int i=0; i<m_nCells; ++i){
-                    offset += n ;
-                    genericIO::flushASCII(str, offset );
-                }
+    } else if(name == "offsets" ){
+        uint8_t     n = vtk::getElementNodeCount(m_type) ;
+        if (connectivityDataType == VTKDataType::Int64 || connectivityDataType == VTKDataType::UInt64) {
+            uint64_t    offset(0) ;
+            for( unsigned int i=0; i<m_nCells; ++i){
+                offset += n ;
+                flushValue(str, format, offset );
             }
-        
+        } else if (connectivityDataType == VTKDataType::Int32 || connectivityDataType == VTKDataType::UInt32) {
+            uint32_t    offset(0) ;
+            for( unsigned int i=0; i<m_nCells; ++i){
+                offset += n ;
+                flushValue(str, format, offset );
+            }
+        } else if (connectivityDataType == VTKDataType::Int16 || connectivityDataType == VTKDataType::UInt16) {
+            uint16_t    offset(0) ;
+            for( unsigned int i=0; i<m_nCells; ++i){
+                offset += n ;
+                flushValue(str, format, offset );
+            }
+        } else if (connectivityDataType == VTKDataType::Int8 || connectivityDataType == VTKDataType::UInt8) {
+            uint8_t    offset(0) ;
+            for( unsigned int i=0; i<m_nCells; ++i){
+                offset += n ;
+                flushValue(str, format, offset );
+            }
         }
 
     }

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -520,10 +520,12 @@ void VTKUnstructuredGrid::writeMetaInformation( ){
     str << "  </UnstructuredGrid>"  << std::endl;
 
     //Appended Section
+    if (isAppendedActive()) {
+        str << "  <AppendedData encoding=\"raw\">" << std::endl;
+        str << "_" << std::endl;
+    }
 
-    str << "  <AppendedData encoding=\"raw\">" << std::endl;
-    str << "_" ;
-    str << std::endl ;
+    // Closing XML
     str << "</VTKFile>" << std::endl;
 
     str.close() ;

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -633,74 +633,34 @@ void LevelSetObject::flushData( std::fstream &stream, const std::string &name, V
 
     if(utils::string::keywordInString(name,"levelsetValue")){
 
-        void (*writeFunctionPtr)(std::fstream &, const double &) = nullptr;
-
-        if(format==VTKFormat::APPENDED){
-            writeFunctionPtr = genericIO::flushBINARY<double>;
-        } else if(format==VTKFormat::ASCII){
-            writeFunctionPtr = genericIO::flushASCII<double>;
-        } else {
-            BITPIT_UNREACHABLE("Non-existent VTK format.");
-        }
-
         for( const Cell &cell : m_kernel->getMesh()->getVTKCellWriteRange() ){
             long cellId = cell.getId();
             double value = getValue(cellId);
-            (*writeFunctionPtr)(stream,value);
+            flushValue(stream, format, value);
         }
 
     } else if( utils::string::keywordInString(name,"levelsetGradient")){
 
-        void (*writeFunctionPtr)(std::fstream &, const std::array<double,3> &) = nullptr;
-
-        if(format==VTKFormat::APPENDED){
-            writeFunctionPtr = genericIO::flushBINARY<std::array<double,3>>;
-        } else if(format==VTKFormat::ASCII){
-            writeFunctionPtr = genericIO::flushASCII<std::array<double,3>>;
-        } else {
-            BITPIT_UNREACHABLE("Non-existent VTK format.");
-        }
-
         for( const Cell &cell : m_kernel->getMesh()->getVTKCellWriteRange() ){
             long cellId = cell.getId();
             const std::array<double,3> &value = getGradient(cellId);
-            (*writeFunctionPtr)(stream,value);
+            flushValue(stream, format, value);
         }
 
     } else if( utils::string::keywordInString(name,"levelsetNormal")){
 
-        void (*writeFunctionPtr)(std::fstream &, const std::array<double,3> &) = nullptr;
-
-        if(format==VTKFormat::APPENDED){
-            writeFunctionPtr = genericIO::flushBINARY<std::array<double,3>>;
-        } else if(format==VTKFormat::ASCII){
-            writeFunctionPtr = genericIO::flushASCII<std::array<double,3>>;
-        } else {
-            BITPIT_UNREACHABLE("Non-existent VTK format.");
-        }
-
         for( const Cell &cell : m_kernel->getMesh()->getVTKCellWriteRange() ){
             long cellId = cell.getId();
             const std::array<double,3> &value = getNormal(cellId);
-            (*writeFunctionPtr)(stream,value);
+            flushValue(stream, format, value);
         }
 
     } else if( utils::string::keywordInString(name,"levelsetPart")){
 
-        void (*writeFunctionPtr)(std::fstream &, const int &) = nullptr;
-
-        if(format==VTKFormat::APPENDED){
-            writeFunctionPtr = genericIO::flushBINARY<int>;
-        } else if(format==VTKFormat::ASCII){
-            writeFunctionPtr = genericIO::flushASCII<int>;
-        } else {
-            BITPIT_UNREACHABLE("Non-existent VTK format.");
-        }
-
         for( const Cell &cell : m_kernel->getMesh()->getVTKCellWriteRange() ){
             long cellId = cell.getId();
             int value = getPart(cellId);
-            (*writeFunctionPtr)(stream,value);
+            flushValue(stream, format, value);
         }
     }
 }


### PR DESCRIPTION
The new function allows to easily flush values on both ASCII and appended files.