### PR TITLE
LA: properly setup the preconditioner when solving multiple linear systems

### DIFF
--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -119,7 +119,7 @@ SparseMatrix::SparseMatrix()
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -135,8 +135,8 @@ SparseMatrix::SparseMatrix(long nRows, long nCols, long nNZ)
 * \param blockSize is the block size of the matrix
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -156,7 +156,7 @@ SparseMatrix::SparseMatrix(int blockSize, long nRows, long nCols, long nNZ)
 * \param nCols is the number columns of the matrix, if the matrix is partitioned
 * this is the number of local columns
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -177,8 +177,8 @@ SparseMatrix::SparseMatrix(MPI_Comm communicator, bool partitioned, long nRows, 
 * this is the number of local rows
 * \param nCols is the number columns of the matrix, if the matrix is partitioned
 * this is the number of local columns
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -195,7 +195,7 @@ SparseMatrix::SparseMatrix(MPI_Comm communicator, bool partitioned, int blockSiz
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -211,8 +211,8 @@ SparseMatrix::SparseMatrix(long nRows, long nCols, long nNZ)
 * \param blockSize is the block size of the matrix
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -245,7 +245,7 @@ SparseMatrix::~SparseMatrix()
 * \param nCols is the number columns of the matrix, if the matrix is partitioned
 * this is the number of local columns
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -264,8 +264,8 @@ void SparseMatrix::initialize(bool partitioned, long nRows, long nCols, long nNZ
 * this is the number of local rows
 * \param nCols is the number columns of the matrix, if the matrix is partitioned
 * this is the number of local columns
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -282,7 +282,7 @@ void SparseMatrix::initialize(bool partitioned, int blockSize, long nRows, long 
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -298,8 +298,8 @@ void SparseMatrix::initialize(long nRows, long nCols, long nNZ)
 * \param blockSize is the block size of the matrix
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -323,8 +323,8 @@ void SparseMatrix::initialize(int blockSize, long nRows, long nCols, long nNZ)
 * this is the number of local rows
 * \param nCols is the number columns of the matrix, if the matrix is partitioned
 * this is the number of local columns
-* \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* \param nNZ is the number of non-zero blocks that the matrix will contain.
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -372,7 +372,7 @@ void SparseMatrix::_initialize(bool partitioned, int blockSize, long nRows, long
 * \param nRows is the number of rows of the matrix
 * \param nCols is the number of columns of the matrix
 * \param nNZ is the number of non-zero elements that the matrix will contain.
-* If this number is unknown, an estimante (or zero) could be passed. If the
+* If this number is unknown, an estimate (or zero) could be passed. If the
 * actual number of non-zero elements turns out to be greater than the provided
 * value, the initialization of the matrix will be slower because reallocation
 * of internal data may be needed
@@ -449,7 +449,7 @@ void SparseMatrix::initializePatternStorage()
 /**
 * Initialize the storage for the pattern.
 *
-* \param nNZ is the number of non-zero elements contained in the matrix
+* \param nNZ is the number of non-zero blocks/elements contained in the matrix
 */
 void SparseMatrix::initializePatternStorage(long nNZ)
 {
@@ -491,7 +491,7 @@ void SparseMatrix::initializeValueStorage()
 /**
 * Initialize the storage for the values.
 *
-* \param nNZ is the number of non-zero elements contained in the matrix
+* \param nNZ is the number of non-zero blocks/elements contained in the matrix
 */
 void SparseMatrix::initializeValueStorage(long nNZ)
 {
@@ -548,7 +548,7 @@ void SparseMatrix::assembly()
     }
 
 #if BITPIT_ENABLE_MPI==1
-    // Updathe global information of the non-zero elements
+    // Update global information of the non-zero elements
     if (m_partitioned) {
         MPI_Allreduce(&m_maxRowNZ, &m_global_maxRowNZ, 1, MPI_LONG, MPI_MAX, m_communicator);
         MPI_Allreduce(&m_nNZ, &m_global_nNZ, 1, MPI_LONG, MPI_SUM, m_communicator);
@@ -647,9 +647,9 @@ long SparseMatrix::getColElementCount() const
 }
 
 /**
-* Get the number of non-zero elements.
+* Get the number of non-zero blocks/elements.
 *
-* \result The number of non-zero elements.
+* \result The number of non-zero blocks/elements.
 */
 long SparseMatrix::getNZCount() const
 {
@@ -657,9 +657,9 @@ long SparseMatrix::getNZCount() const
 }
 
 /**
-* Get the number of non-zero elements in the specified row.
+* Get the number of non-zero blocks/elements in the specified row.
 *
-* \result The number of non-zero elements in the specified row.
+* \result The number of non-zero blocks/elements in the specified row.
 */
 long SparseMatrix::getRowNZCount(long row) const
 {
@@ -667,9 +667,9 @@ long SparseMatrix::getRowNZCount(long row) const
 }
 
 /**
-* Get the maximum number of non-zero elements per row.
+* Get the maximum number of non-zero blocks/elements per row.
 *
-* \result The maximum number of non-zero elements per row.
+* \result The maximum number of non-zero blocks/elements per row.
 */
 long SparseMatrix::getMaxRowNZCount() const
 {
@@ -678,6 +678,8 @@ long SparseMatrix::getMaxRowNZCount() const
 
 /**
 * Get the number of non-zero elements.
+*
+* This is the number of individual non-zero elements, NOT the number of non-zero blocks.
 *
 * \result The number of non-zero elements.
 */
@@ -690,6 +692,8 @@ long SparseMatrix::getNZElementCount() const
 
 /**
 * Get the number of non-zero elements.
+*
+* This is the number of individual non-zero elements, NOT the number of non-zero blocks.
 *
 * \param nNZ is the number of non-zero elements contained in the matrix
 * \result The number of non-zero elements.
@@ -705,6 +709,8 @@ long SparseMatrix::getNZElementCount(long nNZ) const
 /**
 * Get the number of non-zero elements in the specified row.
 *
+* This is the number of individual non-zero elements, NOT the number of non-zero blocks.
+*
 * \result The number of non-zero elements in the specified row.
 */
 long SparseMatrix::getRowNZElementCount(long row) const
@@ -716,6 +722,8 @@ long SparseMatrix::getRowNZElementCount(long row) const
 
 /**
 * Get the maximum number of non-zero elements per row.
+*
+* This is the number of individual non-zero elements, NOT the number of non-zero blocks.
 *
 * \result The maximum number of non-zero elements per row.
 */

--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -600,7 +600,21 @@ long SparseMatrix::getMaxRowNZCount() const
 */
 long SparseMatrix::getNZElementCount() const
 {
-    long nElements = getBlockSize() * getNZCount();
+    long nNZ = getNZCount();
+
+    return getNZElementCount(nNZ);
+}
+
+/**
+* Get the number of non-zero elements.
+*
+* \param nNZ is the number of non-zero elements contained in the matrix
+* \result The number of non-zero elements.
+*/
+long SparseMatrix::getNZElementCount(long nNZ) const
+{
+    int blockSize  = getBlockSize();
+    long nElements = blockSize * blockSize * nNZ;
 
     return nElements;
 }

--- a/src/LA/system_matrix.cpp
+++ b/src/LA/system_matrix.cpp
@@ -390,24 +390,19 @@ void SparseMatrix::_initialize(int blockSize, long nRows, long nCols, long nNZ)
     m_nRows     = nRows;
     m_nCols     = nCols;
 
-    m_pattern.reserve(m_nRows, nNZ);
-    m_values.reserve(m_blockSize * m_blockSize * nNZ);
+    initializePatternStorage(nNZ);
+    initializeValueStorage(nNZ);
 }
 
 /**
-* Clear the pattern.
+* Clear the matrix.
 *
-* \param release if set to true the memory hold by the pattern will be released
+* \param release if set to true the memory hold by the matrix will be released
 */
 void SparseMatrix::clear(bool release)
 {
-    if (release) {
-        m_pattern.clear();
-        m_values.clear();
-    } else {
-        FlatVector2D<long>().swap(m_pattern);
-        std::vector<double>().swap(m_values);
-    }
+    clearPatternStorage(release);
+    clearValueStorage(release);
 
     m_blockSize =  0;
     m_nRows     =  0;
@@ -433,12 +428,100 @@ void SparseMatrix::clear(bool release)
 /*!
 * Squeeze.
 *
-* Requests the matrix pattern to reduce its capacity to fit its size.
+* Requests the matrix to reduce its capacity to fit its size.
 */
 void SparseMatrix::squeeze()
 {
+    squeezePatternStorage();
+    squeezeValueStorage();
+}
+
+/**
+* Initialize the storage for the pattern.
+*/
+void SparseMatrix::initializePatternStorage()
+{
+    long nNZ = getNZCount();
+
+    m_pattern.reserve(nNZ);
+}
+
+/**
+* Initialize the storage for the pattern.
+*
+* \param nNZ is the number of non-zero elements contained in the matrix
+*/
+void SparseMatrix::initializePatternStorage(long nNZ)
+{
+    long nRows = getRowCount();
+
+    m_pattern.reserve(nRows, nNZ);
+}
+
+/**
+* Squeeze the storage for the pattern.
+*
+* Requests the pattern storage to reduce its capacity to fit its size.
+*/
+void SparseMatrix::squeezePatternStorage()
+{
     m_pattern.shrinkToFit();
+}
+
+/**
+* Clear the storage for the pattern.
+*
+* \param release if set to true the memory hold by the pattern storage will be released
+*/
+void SparseMatrix::clearPatternStorage(bool release)
+{
+    m_pattern.clear(release);
+}
+
+/**
+* Initialize the storage for the values.
+*/
+void SparseMatrix::initializeValueStorage()
+{
+    long nNZ = getNZCount();
+
+    initializeValueStorage(nNZ);
+}
+
+/**
+* Initialize the storage for the values.
+*
+* \param nNZ is the number of non-zero elements contained in the matrix
+*/
+void SparseMatrix::initializeValueStorage(long nNZ)
+{
+    long nNZElements = getNZElementCount(nNZ);
+
+    m_values.reserve(nNZElements);
+}
+
+/**
+* Squeeze the storage for the values.
+*
+* Requests the value storage to reduce its capacity to fit its size.
+*/
+void SparseMatrix::squeezeValueStorage()
+{
     m_values.shrink_to_fit();
+}
+
+/**
+* Clear the storage for the values.
+*
+* \param release if set to true the memory hold by the value storage will be released
+*/
+void SparseMatrix::clearValueStorage(bool release)
+{
+    m_values.clear();
+
+    if (release) {
+        squeezeValueStorage();
+    }
 }
 
 /*!

--- a/src/LA/system_matrix.hpp
+++ b/src/LA/system_matrix.hpp
@@ -154,6 +154,14 @@ protected:
     double * getRowValuesData(long row);
     const double * getRowValuesData(long row) const;
 
+    void initializePatternStorage();
+    void squeezePatternStorage();
+    void clearPatternStorage(bool release);
+
+    void initializeValueStorage();
+    void squeezeValueStorage();
+    void clearValueStorage(bool release);
+
 private:
     void _initialize(int blockSize, long nRows, long nCols, long nNZ);
 #if BITPIT_ENABLE_MPI==1
@@ -164,6 +172,9 @@ private:
     void setCommunicator(MPI_Comm communicator);
     void freeCommunicator();
 #endif
+
+    void initializePatternStorage(long capacity);
+    void initializeValueStorage(long capacity);
 
     long getNZElementCount(long nNZ) const;
 

--- a/src/LA/system_matrix.hpp
+++ b/src/LA/system_matrix.hpp
@@ -165,6 +165,8 @@ private:
     void freeCommunicator();
 #endif
 
+    long getNZElementCount(long nNZ) const;
+
 };
 
 }

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -775,9 +775,7 @@ SystemSolver::~SystemSolver()
  */
 void SystemSolver::clear()
 {
-    if (m_KSP) {
-        destroyKSP();
-    }
+    clearWorkspace();
 
     if (isAssembled()) {
         MatDestroy(&m_A);
@@ -792,6 +790,19 @@ void SystemSolver::clear()
     }
 
     clearReordering();
+}
+
+/*!
+ * Clear and release the memory of all data structures needed for the solution of the system
+ *
+ * These data structures will be re-created the next time the system will be solved.
+ */
+void SystemSolver::clearWorkspace()
+{
+    // Clear KSP
+    if (m_KSP) {
+        destroyKSP();
+    }
 }
 
 /*!

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -281,8 +281,8 @@ public:
     void update(const SystemMatrixAssembler &assembler);
     void update(long nRows, const long *rows, const SystemMatrixAssembler &assembler);
 
-    void setUp();
-    bool isSetUp() const;
+    BITPIT_DEPRECATED(void setUp());
+    BITPIT_DEPRECATED(bool isSetUp() const);
 
     int getBlockSize() const;
 
@@ -352,6 +352,11 @@ protected:
     void clearReordering();
     void setReordering(long nRows, long nCols, const SystemMatrixOrdering &reordering);
 
+    void prepareKSP();
+    void finalizeKSP();
+    void createKSP();
+    void destroyKSP();
+
     virtual void preKSPSetupActions();
     virtual void postKSPSetupActions();
 
@@ -370,7 +375,8 @@ private:
     std::string m_prefix;
 
     bool m_assembled;
-    bool m_setUp;
+
+    bool m_KSPDirty;
 
 #if BITPIT_ENABLE_MPI==1
     MPI_Comm m_communicator;

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -264,6 +264,7 @@ public:
     virtual ~SystemSolver();
 
     void clear();
+    void clearWorkspace();
 
     void assembly(const SparseMatrix &matrix);
     void assembly(const SparseMatrix &matrix, const SystemMatrixOrdering &reordering);


### PR DESCRIPTION
From the PETSc user manual: "To solve successive linear systems that have different preconditioner matrices (i.e., the matrix elements and/or the matrix data structure change), the user must call KSPSetOperators() and KSPSolve() for each solve."