### PR TITLE
patchkernel: optimize evaluation of vertex/pixel/voxel bounding box

### DIFF
--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -5643,17 +5643,66 @@ std::array<double, 3> PatchKernel::evalElementCentroid(const Element &element) c
 */
 void PatchKernel::evalElementBoundingBox(const Element &element, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const
 {
-	ConstProxyVector<long> elementVertexIds = element.getVertexIds();
-	const int nElementVertices = elementVertexIds.size();
+	ElementType elementType = element.getType();
+	switch (elementType)
+	{
 
-	*minPoint = getVertexCoords(elementVertexIds[0]);
-	*maxPoint = *minPoint;
-	for (int i = 1; i < nElementVertices; ++i) {
-		const std::array<double, 3> &vertexCoord = getVertexCoords(elementVertexIds[i]);
+	case ElementType::VERTEX:
+	{
+		const long *elementConnect = element.getConnect();
+		*minPoint = getVertexCoords(elementConnect[0]);
+		*maxPoint = *minPoint;
+		break;
+	}
+
+	case ElementType::PIXEL:
+	{
+		const long *elementConnect = element.getConnect();
+
+		const std::array<double, 3> &vertexCoord_0 = getVertexCoords(elementConnect[0]);
+		const std::array<double, 3> &vertexCoord_3 = getVertexCoords(elementConnect[3]);
+
 		for (int d = 0; d < 3; ++d) {
-			(*minPoint)[d] = std::min(vertexCoord[d], (*minPoint)[d]);
-			(*maxPoint)[d] = std::max(vertexCoord[d], (*maxPoint)[d]);
+			(*minPoint)[d] = std::min(vertexCoord_0[d], vertexCoord_3[d]);
+			(*maxPoint)[d] = std::max(vertexCoord_0[d], vertexCoord_3[d]);
 		}
+
+		break;
+	}
+
+	case ElementType::VOXEL:
+	{
+		const long *elementConnect = element.getConnect();
+
+		const std::array<double, 3> &vertexCoord_0 = getVertexCoords(elementConnect[0]);
+		const std::array<double, 3> &vertexCoord_7 = getVertexCoords(elementConnect[7]);
+
+		for (int d = 0; d < 3; ++d) {
+			(*minPoint)[d] = std::min(vertexCoord_0[d], vertexCoord_7[d]);
+			(*maxPoint)[d] = std::max(vertexCoord_0[d], vertexCoord_7[d]);
+		}
+
+		break;
+	}
+
+	default:
+	{
+		ConstProxyVector<long> elementVertexIds = element.getVertexIds();
+		const int nElementVertices = elementVertexIds.size();
+
+		*minPoint = getVertexCoords(elementVertexIds[0]);
+		*maxPoint = *minPoint;
+		for (int i = 1; i < nElementVertices; ++i) {
+			const std::array<double, 3> &vertexCoord = getVertexCoords(elementVertexIds[i]);
+			for (int d = 0; d < 3; ++d) {
+				(*minPoint)[d] = std::min(vertexCoord[d], (*minPoint)[d]);
+				(*maxPoint)[d] = std::max(vertexCoord[d], (*maxPoint)[d]);
+			}
+		}
+
+		break;
+	}
+
 	}
 }
 

--- a/src/voloctree/voloctree.cpp
+++ b/src/voloctree/voloctree.cpp
@@ -721,22 +721,6 @@ std::array<double, 3> VolOctree::evalCellCentroid(long id) const
 }
 
 /*!
-	Evaluates the bounding box of the specified cell.
-
-	\param id is the id of the cell
-	\param[out] minPoint is the minimum point of the bounding box
-	\param[out] maxPoint is the maximum point of the bounding box
-*/
-void VolOctree::evalCellBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const
-{
-	OctantInfo octantInfo = getCellOctant(id);
-	const Octant *octant = getOctantPointer(octantInfo);
-
-	*minPoint = m_tree->getNode(octant, 0);
-	*maxPoint = m_tree->getNode(octant, m_cellTypeInfo->nVertices - 1);
-}
-
-/*!
 	Evaluates the characteristic size of the specified cell.
 
 	\param id is the id of the cell

--- a/src/voloctree/voloctree.hpp
+++ b/src/voloctree/voloctree.hpp
@@ -98,8 +98,6 @@ public:
 
 	void simulateCellUpdate(long id, adaption::Marker marker, std::vector<Cell> *virtualCells, PiercedVector<Vertex, long> *virtualVertices) const override;
 
-	void evalCellBoundingBox(long id, std::array<double,3> *minPoint, std::array<double,3> *maxPoint) const override;
-
 	double evalInterfaceArea(long id) const override;
 	std::array<double, 3> evalInterfaceNormal(long id) const override;
 


### PR DESCRIPTION
It is faster to evaluate the bounding box in PatchKernel rather than delegate the evaluation to PABLO.