### PR TITLE
containers: fixes and improvements to the restore of PiercedVector containers

### DIFF
--- a/src/containers/piercedStorage.hpp
+++ b/src/containers/piercedStorage.hpp
@@ -355,8 +355,6 @@ public:
     PiercedStorage & operator=(const PiercedStorage &other);
     PiercedStorage & operator=(PiercedStorage &&other);
 
-
-
     // Methods for accessing container properties
     std::size_t getFieldCount() const;
 

--- a/src/containers/piercedSync.cpp
+++ b/src/containers/piercedSync.cpp
@@ -97,6 +97,16 @@ void PiercedSyncAction::swap(PiercedSyncAction &other) noexcept
 *
 * \param values are the values that will be imported
 */
+void PiercedSyncAction::importData(std::vector<std::size_t> &&values)
+{
+    data = std::unique_ptr<std::vector<std::size_t>>(new std::vector<std::size_t>(std::move(values)));
+}
+
+/*!
+* Import the given data.
+*
+* \param values are the values that will be imported
+*/
 void PiercedSyncAction::importData(const std::vector<std::size_t> &values)
 {
     data = std::unique_ptr<std::vector<std::size_t>>(new std::vector<std::size_t>(values));

--- a/src/containers/piercedSync.cpp
+++ b/src/containers/piercedSync.cpp
@@ -117,11 +117,18 @@ void PiercedSyncAction::restore(std::istream &stream)
         utils::binary::read(stream, info[k]);
     }
 
-    std::size_t dataSize;
-    utils::binary::read(stream, dataSize);
-    data = std::unique_ptr<std::vector<std::size_t>>(new std::vector<std::size_t>(dataSize));
-    for (std::size_t k = 0; k < dataSize; ++k) {
-        utils::binary::read(stream, (*data)[k]);
+    bool hasData;
+    utils::binary::read(stream, hasData);
+
+    if (hasData) {
+        std::size_t dataSize;
+        utils::binary::read(stream, dataSize);
+        data = std::unique_ptr<std::vector<std::size_t>>(new std::vector<std::size_t>(dataSize));
+        for (std::size_t k = 0; k < dataSize; ++k) {
+            utils::binary::read(stream, (*data)[k]);
+        }
+    } else {
+        data.reset();
     }
 }
 
@@ -138,10 +145,15 @@ void PiercedSyncAction::dump(std::ostream &stream) const
         utils::binary::write(stream, info[k]);
     }
 
-    std::size_t dataSize = data->size();
-    utils::binary::write(stream, dataSize);
-    for (std::size_t k = 0; k < dataSize; ++k) {
-        utils::binary::write(stream, (*data)[k]);
+    bool hasData = (data != nullptr);
+    utils::binary::write(stream, hasData);
+
+    if (hasData) {
+        std::size_t dataSize = data->size();
+        utils::binary::write(stream, dataSize);
+        for (std::size_t k = 0; k < dataSize; ++k) {
+            utils::binary::write(stream, (*data)[k]);
+        }
     }
 }
 

--- a/src/containers/piercedSync.hpp
+++ b/src/containers/piercedSync.hpp
@@ -82,6 +82,7 @@ public:
 
     void swap(PiercedSyncAction &other) noexcept;
 
+    void importData(std::vector<std::size_t> &&values);
     void importData(const std::vector<std::size_t> &values);
 
     // Dump and restore

--- a/src/containers/piercedVector.hpp
+++ b/src/containers/piercedVector.hpp
@@ -227,10 +227,10 @@ public:
     using PiercedVectorStorage<value_t, id_t>::rawFind;
 
     // Dump and restore
-    template<typename T = value_t, typename std::enable_if<PiercedVectorStorage<T, id_t>::has_restore()>::type * = nullptr>
+    template<typename T = value_t, typename std::enable_if<std::is_pod<T>::value || PiercedVectorStorage<T, id_t>::has_restore()>::type * = nullptr>
     void restore(std::istream &stream);
 
-    template<typename T = value_t, typename std::enable_if<PiercedVectorStorage<T, id_t>::has_dump()>::type * = nullptr>
+    template<typename T = value_t, typename std::enable_if<std::is_pod<T>::value || PiercedVectorStorage<T, id_t>::has_dump()>::type * = nullptr>
     void dump(std::ostream &stream) const;
 
     void restoreKernel(std::istream &stream);

--- a/src/containers/piercedVector.tpp
+++ b/src/containers/piercedVector.tpp
@@ -866,7 +866,7 @@ void PiercedVector<value_t, id_t>::dump() const
 * \param stream is the stream data should be read from
 */
 template<typename value_t, typename id_t>
-template<typename T, typename std::enable_if<PiercedVectorStorage<T, id_t>::has_restore()>::type *>
+template<typename T, typename std::enable_if<std::is_pod<T>::value || PiercedVectorStorage<T, id_t>::has_restore()>::type *>
 void PiercedVector<value_t, id_t>::restore(std::istream &stream)
 {
     restoreKernel(stream);
@@ -880,7 +880,7 @@ void PiercedVector<value_t, id_t>::restore(std::istream &stream)
 * \param stream is the stream data should be written to
 */
 template<typename value_t, typename id_t>
-template<typename T, typename std::enable_if<PiercedVectorStorage<T, id_t>::has_dump()>::type *>
+template<typename T, typename std::enable_if<std::is_pod<T>::value || PiercedVectorStorage<T, id_t>::has_dump()>::type *>
 void PiercedVector<value_t, id_t>::dump(std::ostream &stream) const
 {
     dumpKernel(stream);


### PR DESCRIPTION
Dump/restore are now enabled also for PiercedVectors that store POD data (previously they were enabled only if the data was implementing dump/restore functions).

PiercedSyncActions with no data are now properly dumped/restored (this change breaks the compatibility with older dumps).