### PR TITLE
IO/VTK: declare some functions as constants

### DIFF
--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -216,9 +216,9 @@ class VTKBaseStreamer{
         virtual void            absorbData( std::fstream &, const std::string &, VTKFormat, uint64_t, uint8_t, VTKDataType)  ;
 
         template<typename T>
-        void                    flushValue(std::fstream &, VTKFormat, const T &value);
+        void                    flushValue(std::fstream &, VTKFormat, const T &value) const;
         template<typename T>
-        void                    flushValue(std::fstream &, VTKFormat, const T *values, int nValues);
+        void                    flushValue(std::fstream &, VTKFormat, const T *values, int nValues) const;
 
 };
 

--- a/src/IO/VTKStreamer.tpp
+++ b/src/IO/VTKStreamer.tpp
@@ -57,7 +57,7 @@ VTKVectorContainer<T>::VTKVectorContainer( std::vector<T> &data){
  * @param[in] value is the value that will be written
  */
 template<class T>
-void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T &value){
+void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T &value) const {
 
     if( format==VTKFormat::ASCII){
         genericIO::flushASCII( str, value) ;
@@ -78,7 +78,7 @@ void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T &
  * @param[in] size is the number of values that will be writtend
  */
 template<class T>
-void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T *values, int nValues){
+void VTKBaseStreamer::flushValue( std::fstream &str, VTKFormat format, const T *values, int nValues) const {
 
     if( format==VTKFormat::ASCII){
         genericIO::flushASCII( str, values, nValues) ;


### PR DESCRIPTION
Functions that flush values to a stream can be declared as constant.