### PR TITLE
levelset: fix initialization of segmentation limited-normal validity flag

### DIFF
--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -396,7 +396,7 @@ void LevelSetSegmentationKernel::setSurface( const SurfUnstructured *surface, do
     m_unlimitedVertexNormalsStorage.unsetKernel();
     m_unlimitedVertexNormalsStorage.setStaticKernel(&m_surface->getVertices());
 
-    m_limitedSegmentVertexNormalValid.resize(nTotalSegmentVertices);
+    m_limitedSegmentVertexNormalValid.assign(nTotalSegmentVertices, false);
 
     // Initialize search tree
     m_searchTree = std::unique_ptr<SurfaceSkdTree>(new SurfaceSkdTree(surface));


### PR DESCRIPTION
The validity flag should be explicitly set to false, otherwise, if the surface is set multiple times, the container may contain elements wrongly set to true (they were set to true during the evaluation of the levelset with the previous surface).