### PR TITLE
 patchkernel: add a function to check if factes of surface patch have a consistent orientation

### DIFF
--- a/src/patchkernel/surface_kernel.hpp
+++ b/src/patchkernel/surface_kernel.hpp
@@ -69,6 +69,7 @@ public:
                                    std::array<double, 3> *unlimitedNormal, std::array<double, 3> *limitedNormal) const;
     double evalCellSize(long id) const override;
 
+    bool isCellOrientationConsistent() const;
     bool adjustCellOrientation();
     bool adjustCellOrientation(long id, bool invert = false);
     void flipCellOrientation(long id);

--- a/test/integration_tests/surfunstructured/test_surfunstructured_parallel_00003.cpp
+++ b/test/integration_tests/surfunstructured/test_surfunstructured_parallel_00003.cpp
@@ -212,6 +212,15 @@ if (myRank == 0) {
         log::cout() << "   Error during surface orientation" << endl;
     }
 
+    // Check if orientation is consistent ----------------------------------- //
+    log::cout() << "** Mesh adjust orientation" << endl;
+    bool oriented = mesh.isCellOrientationConsistent();
+    if (oriented) {
+        log::cout() << "   Mesh orientation is consistent" << endl;
+    } else {
+        log::cout() << "   Error while checking if mesh orientation is consisten" << endl;
+    }
+
     // Write mesh ----------------------------------------------------------- //
     log::cout() << "** Writing mesh" << endl;
     mesh.write();


### PR DESCRIPTION
The function can be used to check if all the factes of a surface patch are oriented in the same way. 

Draft because it need more testing.