### PR TITLE
PABLO: fix parallel 2:1 balance

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -2894,6 +2894,10 @@ namespace bitpit {
         std::sort(mortonList.begin(), mortonList.end());
 
         // Build node list and connectivity
+        m_nodes.clear();
+        m_connectivity.clear();
+        m_ghostsConnectivity.clear();
+
         m_nodes.reserve(mortonList.size());
         m_connectivity.resize(noctants);
         m_ghostsConnectivity.resize(nghosts);
@@ -2918,22 +2922,33 @@ namespace bitpit {
             }
             nodeId++;
         }
+
+        m_nodes.shrink_to_fit();
     };
 
     /*! Clear nodes vector and connectivity of octants of local tree
+     * \param[in] release if it's true the memory hold by the connectivity will be
+     * released, otherwise the connectivity will be cleared but its memory will
+     * not be released
      */
     void
-    LocalTree::clearConnectivity(){
-        u32arr3vector().swap(m_nodes);
-        u32vector2D().swap(m_connectivity);
-        u32vector2D().swap(m_ghostsConnectivity);
+    LocalTree::clearConnectivity(bool release){
+        if (release) {
+            u32arr3vector().swap(m_nodes);
+            u32vector2D().swap(m_connectivity);
+            u32vector2D().swap(m_ghostsConnectivity);
+        } else {
+            m_nodes.clear();
+            m_connectivity.clear();
+            m_ghostsConnectivity.clear();
+        }
     };
 
     /*! Updates nodes vector and connectivity of octants of local tree
      */
     void
     LocalTree::updateConnectivity(){
-        clearConnectivity();
+        clearConnectivity(false);
         computeConnectivity();
     };
 

--- a/src/PABLO/LocalTree.hpp
+++ b/src/PABLO/LocalTree.hpp
@@ -227,7 +227,7 @@ private:
 
 	void 		computeNeighSearchBegin(uint64_t sameSizeVirtualNeighMorton, const octvector &octants, uint32_t *searchBeginIdx, uint64_t *searchBeginMorton) const;
 
-	bool 		localBalance(bool doNew, bool doInterior, bool doGhost);
+	bool 		localBalance(bool doNew, bool checkInterior, bool checkGhost);
 
 	bool 		fixBrokenFamiliesMarkers(std::vector<Octant *> *updatedOctants = nullptr, std::vector<bool> *updatedGhostFlags = nullptr);
 

--- a/src/PABLO/LocalTree.hpp
+++ b/src/PABLO/LocalTree.hpp
@@ -240,7 +240,7 @@ private:
 	void 		findMortonUpperBound(uint64_t targetMorton, const octvector &octants, uint32_t *upperBoundIdx, uint64_t *upperBoundMorton) const;
 
 	void 		computeConnectivity();
-	void 		clearConnectivity();
+	void 		clearConnectivity(bool release = true);
 	void 		updateConnectivity();
 
 	// =================================================================================== //

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -3956,10 +3956,13 @@ namespace bitpit {
     }
 
     /** Clear the connectivity of octants.
+     * \param[in] release if it's true the memory hold by the connectivity will be
+     * released, otherwise the connectivity will be cleared but its memory will
+     * not be released
      */
     void
-    ParaTree::clearConnectivity() {
-        m_octree.clearConnectivity();
+    ParaTree::clearConnectivity(bool release) {
+        m_octree.clearConnectivity(release);
     }
 
     /** Update the connectivity of octants.

--- a/src/PABLO/ParaTree.cpp
+++ b/src/PABLO/ParaTree.cpp
@@ -5843,10 +5843,10 @@ namespace bitpit {
     void
     ParaTree::write(const std::string &filename) {
 
-        if (m_octree.m_connectivity.size() == 0) {
-            m_octree.computeConnectivity();
-        }
+        // Update connectivity
+        m_octree.updateConnectivity();
 
+        // Write output file
         stringstream name;
         name << "s" << std::setfill('0') << std::setw(4) << m_nproc << "-p" << std::setfill('0') << std::setw(4) << m_rank << "-" << filename << ".vtu";
 
@@ -5998,10 +5998,10 @@ namespace bitpit {
     void
     ParaTree::writeTest(const std::string &filename, vector<double> data) {
 
-        if (m_octree.m_connectivity.size() == 0) {
-            m_octree.computeConnectivity();
-        }
+        // Update connectivity
+        m_octree.updateConnectivity();
 
+        // Write output file
         stringstream name;
         name << "s" << std::setfill('0') << std::setw(4) << m_nproc << "-p" << std::setfill('0') << std::setw(4) << m_rank << "-" << filename << ".vtu";
 

--- a/src/PABLO/ParaTree.hpp
+++ b/src/PABLO/ParaTree.hpp
@@ -518,7 +518,7 @@ namespace bitpit {
         bool 		adaptGlobalRefine(bool mapper_flag = false);
         bool 		adaptGlobalCoarse(bool mapper_flag = false);
         void 		computeConnectivity();
-        void 		clearConnectivity();
+        void 		clearConnectivity(bool release = true);
         void 		updateConnectivity();
         const u32vector2D & getConnectivity() const;
         const u32vector & getConnectivity(uint32_t idx) const;


### PR DESCRIPTION
Before starting balancing a partitioned tree, it is necessary to exchange the adaption markers.