### PR TITLE
IO: change the defualt encoding of the XML config to "UTF-8"

### DIFF
--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -38,7 +38,7 @@ namespace XML {
 /*!
     Default encoding.
 */
-const std::string DEFAULT_ENCODING = "ISO-8859-1";
+const std::string DEFAULT_ENCODING = "UTF-8";
 
 /*!
     Read an XML node.


### PR DESCRIPTION
Nowadays UTF-8 is the default encoding for almost every application.