### PR TITLE
discretization: allow to evaluate partial reconstruction weights

### DIFF
--- a/src/common/commonUtils.cpp
+++ b/src/common/commonUtils.cpp
@@ -91,6 +91,30 @@ void extractWithoutReplacement(int n, int m, std::vector<int> &list)
     }
 }
 
+
+/*!
+ * \ingroup common_misc
+ *
+ * Count the number of digits of the given number.
+ *
+ * \param[in] n is number whose digits should be counted
+ * \result The number of digits of the specified number.
+ */
+std::size_t countDigits(int n)
+{
+    if (n== 0) {
+        return 1;
+    }
+
+    std::size_t nDigits = 0;
+    while (n != 0) {
+        n /= 10;
+        ++nDigits;
+    }
+
+    return nDigits;
+}
+
 /*!
  * \ingroup common_misc
  *

--- a/src/common/commonUtils.hpp
+++ b/src/common/commonUtils.hpp
@@ -126,6 +126,8 @@ void extractWithoutReplacement(                                               //
     std::vector<int>           &                                              // (input/output) list of extracted value
 );
 
+std::size_t countDigits(int n);
+
 unsigned long factorial(unsigned long n);
 
 /*!

--- a/src/discretization/reconstruction.hpp
+++ b/src/discretization/reconstruction.hpp
@@ -203,18 +203,24 @@ public:
 
     void computeValueWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, double *valueWeights) const;
     void computeValueWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, double *valueWeights) const;
+    void computeValueWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, double *valueWeights) const;
     void computeValueLimitedWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, double *valueWeights) const;
     void computeValueLimitedWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, double *valueWeights) const;
+    void computeValueLimitedWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, double *valueWeights) const;
 
     void computeDerivativeWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, double *derivativeWeights) const;
     void computeDerivativeWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, double *derivativeWeights) const;
+    void computeDerivativeWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, double *derivativeWeights) const;
     void computeDerivativeLimitedWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, const double *limiters, double *derivativeWeights) const;
     void computeDerivativeLimitedWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, const double *limiters, double *derivativeWeights) const;
+    void computeDerivativeLimitedWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const std::array<double, 3> &direction, const double *limiters, double *derivativeWeights) const;
 
     void computeGradientWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, std::array<double, 3> *gradientWeights) const;
     void computeGradientWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, std::array<double, 3> *gradientWeights) const;
+    void computeGradientWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, std::array<double, 3> *gradientWeights) const;
     void computeGradientLimitedWeights(const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, std::array<double, 3> *gradientWeights) const;
     void computeGradientLimitedWeights(uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, std::array<double, 3> *gradientWeights) const;
+    void computeGradientLimitedWeights(int nEquations, uint8_t degree, const std::array<double, 3> &origin, const std::array<double, 3> &point, const double *limiters, std::array<double, 3> *gradientWeights) const;
 
     void display(std::ostream &out, double tolerance = 1.e-10) const;
 


### PR DESCRIPTION
There are cases in which weights should be evaluated using the coefficients associated with only some of the equations.