### PR TITLE
IO/VTK: add support for writing time series 

### DIFF
--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -763,6 +763,21 @@ void VTK::writeCollection( const std::string &outputName ) const {
 }
 
 /*!
+ *  Creates a handler for the collection.
+ *
+ *  \param collectionName collection filename to be set for this output only
+ */
+FileHandler VTK::createCollectionHandler( const std::string &collectionName ) const {
+    FileHandler handler(m_fh) ;
+    handler.setSeries(false) ;
+    handler.setParallel(false) ;
+    handler.setName(collectionName) ;
+    handler.setAppendix(getCollectionExtension()) ;
+
+    return handler;
+}
+
+/*!
  * Writes data only in VTK file
  */
 void VTK::writeData( ){

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -33,14 +33,14 @@ namespace bitpit{
 /*!
  * @ingroup VisualizationToolKit
  * @interface VTK
- * @brief A base class for VTK input output. 
+ * @brief A base class for VTK input output.
  *
  * VTK provides all basic methods for reading and writing VTK files.
  * ASCII and APPENDED mode are supported.
  *
  */
 
-/*! 
+/*!
  * Default constructor referes to a serial VTK file with appended binary data.
  */
 VTK::VTK(){
@@ -49,7 +49,7 @@ VTK::VTK(){
     m_rank  = 0;
 
     m_headerType = "UInt32" ;
-    
+
     m_fh.setDirectory( "." ) ;
     m_fh.setSeries( false ) ;
     m_fh.setParallel( false ) ;
@@ -62,7 +62,7 @@ VTK::VTK(){
 
 }
 
-/*! 
+/*!
  * Constructor referes to a serial VTK file with appended binary data.
  * @param[in]  dir    directory of file with final "/"
  * @param[in]  name   file name without suffix
@@ -74,7 +74,7 @@ VTK::VTK(const std::string &dir, const std::string &name ):
 
 }
 
-/*! 
+/*!
  * set header type for appended binary output
  * @param[in] st header type ["UInt32"/"UInt64"]
  */
@@ -90,7 +90,7 @@ void  VTK::setHeaderType(const std::string &st){
 
 }
 
-/*! 
+/*!
  * Get header type for appended binary output
  * @return header type ["UInt32"/"UInt64"]
  */
@@ -98,7 +98,7 @@ const std::string &  VTK::getHeaderType( ) const{
     return m_headerType ;
 }
 
-/*! 
+/*!
  * set directory and name for VTK file
  * @param[in] dir directory of file with final "/"
  * @param[in] name file name without suffix
@@ -152,7 +152,7 @@ std::string  VTK::getDirectory() const {
  * Activates output for time series. sets series to true first output index to input
  * @param[in] counter first output index
  */
-void  VTK::setCounter( int counter){ 
+void  VTK::setCounter( int counter){
 
   m_fh.setSeries(true) ;
   m_fh.setCounter(counter) ;
@@ -174,22 +174,22 @@ void  VTK::incrementCounter( ){
 }
 
 /*!
- * De-activates output for time series. 
+ * De-activates output for time series.
  * @return last value of counter
  */
-int  VTK::unsetCounter( ){ 
+int  VTK::unsetCounter( ){
 
   int counter = getCounter() ;
   m_fh.setSeries(false) ;
 
-  return counter; 
+  return counter;
 }
 
 /*!
  * Returns the time index of the following file
- * @return counter 
+ * @return counter
  */
-int  VTK::getCounter( ) const{ 
+int  VTK::getCounter( ) const{
 
   return m_fh.getCounter( ) ;
 
@@ -200,13 +200,13 @@ int  VTK::getCounter( ) const{
  * @param[in] procs number of processes
  * @param[in] rank my rank
  */
-void  VTK::setParallel( uint16_t procs, uint16_t rank){ 
+void  VTK::setParallel( uint16_t procs, uint16_t rank){
 
   if( procs <  1 ) log::cout() << " Numer of processes must be greater than 0" << std::endl ;
   if( rank  >= procs) log::cout() << " m_rankess is not in valid range " << std::endl ;
 
-  m_procs = procs; 
-  m_rank  = rank; 
+  m_procs = procs;
+  m_rank  = rank;
 
   if(m_procs == 0) {
    m_fh.setParallel(false) ;
@@ -296,7 +296,7 @@ VTKField& VTK::addData( VTKField &&field ){
 }
 
 /*!
- * Add user data for input or output. 
+ * Add user data for input or output.
  * Codification will be set according to default value [appended] or to value
  * set by VTK::setDataCodex( VTKFormat ) or VTK::setCodex( VTKFormat )
  * @param[in] name name of field
@@ -337,7 +337,7 @@ void VTK::removeData( const std::string &name ){
         } else {
             ++fieldItr;
         }
-    } 
+    }
 
     log::cout() << "did not find field for removing in VTK: " << name << std::endl;
 
@@ -886,7 +886,7 @@ void VTK::writeData( ){
                     assert(false);
                 }
             }
-        } 
+        }
 
         for( auto &field : m_data ){
             if( field.isEnabled() && field.getCodification() == VTKFormat::APPENDED && field.getLocation() == VTKLocation::CELL ) {
@@ -909,7 +909,7 @@ void VTK::writeData( ){
                 }
 
             }
-        } 
+        }
 
         //Writing Geometry Data
         for( auto &field : m_geometry ){
@@ -996,7 +996,7 @@ void VTK::writeDataHeader( std::fstream &str, bool parallel ){
         //Writing DataArray
         for( auto &field : m_data ){
             if( field.isEnabled() && field.getLocation() == location && !parallel) writeDataArray( str, field ) ;
-            if( field.isEnabled() && field.getLocation() == location &&  parallel) writePDataArray( str, field ); 
+            if( field.isEnabled() && field.getLocation() == location &&  parallel) writePDataArray( str, field );
         }
 
         str << "      </" ;
@@ -1128,7 +1128,7 @@ void VTK::readData( ){
 
     }
 
-    
+
     //Read ascii data
     for( auto & field : m_data ){
         if( field.isEnabled() &&  field.getCodification() == VTKFormat::ASCII){
@@ -1212,7 +1212,7 @@ void VTK::readDataHeader( std::fstream &str ){
         ss << "</" << locationString << "Data>" ;
         loc = ss.str();
 
-        read= true ; 
+        read= true ;
         if( ! getline( str, line) ) read = false ;
         if( bitpit::utils::string::keywordInString( line, loc) ) read=false ;
 
@@ -1225,7 +1225,7 @@ void VTK::readDataHeader( std::fstream &str ){
                 }
 
                 else{
-                    pos_ =  0 ; 
+                    pos_ =  0 ;
                 }
 
                 temp.setPosition( pos_ ) ;
@@ -1288,7 +1288,7 @@ bool VTK::readDataArray( std::fstream &str, VTKField &field  ){
         }
     }
 
-    return false ; 
+    return false ;
 
 }
 

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -716,9 +716,7 @@ void VTK::write( VTKWriteMode writeMode ){
     writeData() ;
 
     // Write collection
-    if( m_procs > 1  && m_rank == 0){
-        writeCollection() ;
-    }
+    writeCollection() ;
 
     // Update counter
     if( writeMode == VTKWriteMode::DEFAULT || writeMode == VTKWriteMode::NO_INCREMENT ){

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -747,6 +747,24 @@ void VTK::write( const std::string &name, VTKWriteMode writeMode ){
 }
 
 /*!
+ *  Writes collection file for parallel output.
+ *  Is called by rank 0 in VTK::Write()
+ */
+void VTK::writeCollection( ) {
+    writeCollection(getName(), getName()) ;
+}
+
+/*!
+ *  Writes collection file for parallel output.
+ *  Is called by rank 0 in VTK::Write()
+ *
+ *  \param outputName filename to be set for this output only
+ */
+void VTK::writeCollection( const std::string &outputName ) {
+    writeCollection(outputName, outputName) ;
+}
+
+/*!
  * Writes data only in VTK file
  */
 void VTK::writeData( ){

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -160,6 +160,20 @@ void  VTK::setCounter( int counter){
 }
 
 /*!
+ * Increment the time series' counter. If the time series is not active, it will
+ * be activated and the counter will be reset.
+ */
+void  VTK::incrementCounter( ){
+
+  if (!m_fh.isSeries()) {
+    setCounter(0);
+  } else {
+    m_fh.incrementCounter() ;
+  }
+
+}
+
+/*!
  * De-activates output for time series. 
  * @return last value of counter
  */

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -700,30 +700,30 @@ void VTK::checkAllFields(){
  */
 void VTK::write( VTKWriteMode writeMode ){
 
-    int     counter(0);
-
+    // Initialize counter
+    int counter = getCounter();
     if( writeMode == VTKWriteMode::NO_SERIES ){
-        counter = unsetCounter() ;
-    } 
+        unsetCounter() ;
+    } else if( writeMode == VTKWriteMode::NO_INCREMENT ){
+        setCounter(counter - 1) ;
+    }
 
-    if( writeMode == VTKWriteMode::NO_INCREMENT ){
-        counter = getCounter() -1 ;
-        setCounter( counter) ;
-    } 
-
+    // Write data
     checkAllFields() ;
     calcAppendedOffsets() ;
 
     writeMetaInformation() ;
     writeData() ;
 
-    if( m_procs > 1  && m_rank == 0)  writeCollection() ;
-
-    if( writeMode == VTKWriteMode::DEFAULT || writeMode == VTKWriteMode::NO_INCREMENT ){
-        m_fh.incrementCounter() ;
+    // Write collection
+    if( m_procs > 1  && m_rank == 0){
+        writeCollection() ;
     }
 
-    if( writeMode == VTKWriteMode::NO_SERIES ){
+    // Update counter
+    if( writeMode == VTKWriteMode::DEFAULT || writeMode == VTKWriteMode::NO_INCREMENT ){
+        incrementCounter() ;
+    } else if( writeMode == VTKWriteMode::NO_SERIES ){
         setCounter(counter) ;
     }
 

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -1308,4 +1308,13 @@ bool VTK::readDataArray( std::fstream &str, VTKField &field  ) const {
 
 }
 
+/*!
+ *  Gets the extension of the collection file for parallel output.
+ *
+ *  \result The extension of the collection file for parallel output.
+ */
+std::string VTK::getCollectionExtension() const {
+    return "p" + getExtension();
+}
+
 }

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -179,7 +179,7 @@ void  VTK::incrementCounter( ){
  */
 int  VTK::unsetCounter( ){ 
 
-  int counter = m_fh.getCounter() ;
+  int counter = getCounter() ;
   m_fh.setSeries(false) ;
 
   return counter; 

--- a/src/IO/VTK.cpp
+++ b/src/IO/VTK.cpp
@@ -748,7 +748,7 @@ void VTK::write( const std::string &name, VTKWriteMode writeMode ){
  *  Writes collection file for parallel output.
  *  Is called by rank 0 in VTK::Write()
  */
-void VTK::writeCollection( ) {
+void VTK::writeCollection( ) const {
     writeCollection(getName(), getName()) ;
 }
 
@@ -758,7 +758,7 @@ void VTK::writeCollection( ) {
  *
  *  \param outputName filename to be set for this output only
  */
-void VTK::writeCollection( const std::string &outputName ) {
+void VTK::writeCollection( const std::string &outputName ) const {
     writeCollection(outputName, outputName) ;
 }
 
@@ -964,7 +964,7 @@ void VTK::writeData( ){
  * @param[in] str output stream
  * @param[in] parallel flag for parallel data headers for collection files [true/false]
  */
-void VTK::writeDataHeader( std::fstream &str, bool parallel ){
+void VTK::writeDataHeader( std::fstream &str, bool parallel ) const {
 
     VTKLocation           location ;
     std::stringstream     scalars, vectors ;
@@ -1030,7 +1030,7 @@ void VTK::writeDataHeader( std::fstream &str, bool parallel ){
  * @param[in] str output stream
  * @param[in] field field to be written
  */
-void VTK::writeDataArray( std::fstream &str, VTKField &field ){
+void VTK::writeDataArray( std::fstream &str, const VTKField &field ) const {
 
     str << vtk::convertDataArrayToString( field )  << std::endl ;
     str << "        </DataArray>" << std::endl ;
@@ -1042,7 +1042,7 @@ void VTK::writeDataArray( std::fstream &str, VTKField &field ){
  * @param[in] str output stream
  * @param[in] field field to be written
  */
-void VTK::writePDataArray( std::fstream &str, VTKField &field ){
+void VTK::writePDataArray( std::fstream &str, const VTKField &field ) const {
 
     str << vtk::convertPDataArrayToString( field ) << std::endl ;
     str << "        </PDataArray>" << std::endl ;
@@ -1286,7 +1286,7 @@ void VTK::readDataHeader( std::fstream &str ){
  * @param[in]  str output stream
  * @param[out] field field information
  */
-bool VTK::readDataArray( std::fstream &str, VTKField &field  ){
+bool VTK::readDataArray( std::fstream &str, VTKField &field  ) const {
 
     std::string line ;
 

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -374,12 +374,18 @@ class VTK{
         virtual void            readMetaInformation() = 0 ; 
         void                    readData() ;
 
+        void                    write( VTKWriteMode writeMode, double time )  ;
         void                    write( VTKWriteMode writeMode=VTKWriteMode::DEFAULT )  ;
+        void                    write( const std::string &, VTKWriteMode writeMode, double time )  ;
         void                    write( const std::string &, VTKWriteMode writeMode=VTKWriteMode::NO_INCREMENT )  ;
 
         void                    writeCollection( ) const ;
         void                    writeCollection( const std::string &outputName ) const ;
         virtual void            writeCollection( const std::string &outputName, const std::string &collectionName ) const = 0;
+
+        void                    writeTimeSeries( double time ) const;
+        void                    writeTimeSeries( const std::string &outputName, double time ) const ;
+        void                    writeTimeSeries( const std::string &outputName, const std::string &seriesName, double time ) const ;
 
     protected:
         //For Writing

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -390,6 +390,8 @@ class VTK{
         void                    writeDataArray( std::fstream &, const VTKField &) const ;
         void                    writePDataArray( std::fstream &, const VTKField &) const ;
 
+        FileHandler             createCollectionHandler( const std::string &collectionName) const ;
+
         //For Reading
         void                    readDataHeader( std::fstream &) ;
         bool                    readDataArray( std::fstream &, VTKField &) const ;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -377,12 +377,13 @@ class VTK{
         void                    write( VTKWriteMode writeMode=VTKWriteMode::DEFAULT )  ;
         void                    write( const std::string &, VTKWriteMode writeMode=VTKWriteMode::NO_INCREMENT )  ;
 
-        virtual void            writeMetaInformation() = 0 ;
-        void                    writeData() ;
         virtual void            writeCollection() = 0 ;
 
     protected:
         //For Writing
+        virtual void            writeMetaInformation() = 0 ;
+        void                    writeData() ;
+
         void                    writeDataHeader( std::fstream &, bool parallel=false ) ;
         void                    writeDataArray( std::fstream &, VTKField &) ;
         void                    writePDataArray( std::fstream &, VTKField &) ;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -416,6 +416,9 @@ class VTK{
         virtual uint8_t         calcFieldComponents( const VTKField &) const = 0;
         void                    checkAllFields();
 
+        virtual std::string     getExtension() const = 0 ;
+        virtual std::string     getCollectionExtension() const;
+
 };
 
 class VTKUnstructuredGrid : public VTK {
@@ -450,6 +453,8 @@ class VTKUnstructuredGrid : public VTK {
         uint64_t                readFaceStreamEntries( ) ;
 
         void                    setElementType( VTKElementType ) ;
+
+        std::string             getExtension() const override;
 
     public:
         using                   VTK::setGeomData;
@@ -496,6 +501,9 @@ class VTKRectilinearGrid : public VTK{
         VTKRectilinearGrid( const std::string & , const std::string & , VTKFormat, int, int, int );
         VTKRectilinearGrid( const std::string & , const std::string & , VTKFormat, int, int, int, int );
         VTKRectilinearGrid( const std::string & , const std::string & , VTKFormat, int, int );
+
+    protected:
+        std::string             getExtension() const override;
 
     public:
         using                   VTK::setGeomData;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -377,7 +377,9 @@ class VTK{
         void                    write( VTKWriteMode writeMode=VTKWriteMode::DEFAULT )  ;
         void                    write( const std::string &, VTKWriteMode writeMode=VTKWriteMode::NO_INCREMENT )  ;
 
-        virtual void            writeCollection() = 0 ;
+        void                    writeCollection( ) ;
+        void                    writeCollection( const std::string &outputName ) ;
+        virtual void            writeCollection( const std::string &outputName, const std::string &collectionName ) = 0;
 
     protected:
         //For Writing
@@ -444,8 +446,6 @@ class VTKUnstructuredGrid : public VTK {
     VTKUnstructuredGrid( const std::string &, const std::string &, VTKElementType elementType = VTKElementType::UNDEFINED ) ;
 
     protected:
-        void                    writeCollection() override ;
-
         uint64_t                readConnectivityEntries( ) ;
         uint64_t                readFaceStreamEntries( ) ;
 
@@ -456,6 +456,8 @@ class VTKUnstructuredGrid : public VTK {
 
         void                    readMetaInformation() override ;
         void                    writeMetaInformation() override ;
+
+        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) override ;
 
         void                    setDimensions( uint64_t , uint64_t , uint64_t nconn = 0 , uint64_t nfacestream = 0 ) ;
 
@@ -495,14 +497,13 @@ class VTKRectilinearGrid : public VTK{
         VTKRectilinearGrid( const std::string & , const std::string & , VTKFormat, int, int, int, int );
         VTKRectilinearGrid( const std::string & , const std::string & , VTKFormat, int, int );
 
-    protected:
-        void                    writeCollection() override ;
-
     public:
         using                   VTK::setGeomData;
 
         void                    readMetaInformation() override ;
         void                    writeMetaInformation() override ;
+
+        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) override ;
 
         void                    setDimensions( int, int, int, int, int, int ) ;
         void                    setDimensions( int, int, int ) ;

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -329,6 +329,7 @@ class VTK{
         void                    setName( const std::string & ) ;
         void                    setDirectory( const std::string & ) ;
         void                    setCounter( int c_=0 ) ;
+        void                    incrementCounter( ) ;
         int                     unsetCounter( ) ;
         void                    setParallel( uint16_t , uint16_t ) ;
 

--- a/src/IO/VTK.hpp
+++ b/src/IO/VTK.hpp
@@ -377,22 +377,22 @@ class VTK{
         void                    write( VTKWriteMode writeMode=VTKWriteMode::DEFAULT )  ;
         void                    write( const std::string &, VTKWriteMode writeMode=VTKWriteMode::NO_INCREMENT )  ;
 
-        void                    writeCollection( ) ;
-        void                    writeCollection( const std::string &outputName ) ;
-        virtual void            writeCollection( const std::string &outputName, const std::string &collectionName ) = 0;
+        void                    writeCollection( ) const ;
+        void                    writeCollection( const std::string &outputName ) const ;
+        virtual void            writeCollection( const std::string &outputName, const std::string &collectionName ) const = 0;
 
     protected:
         //For Writing
-        virtual void            writeMetaInformation() = 0 ;
+        virtual void            writeMetaInformation() const = 0 ;
         void                    writeData() ;
 
-        void                    writeDataHeader( std::fstream &, bool parallel=false ) ;
-        void                    writeDataArray( std::fstream &, VTKField &) ;
-        void                    writePDataArray( std::fstream &, VTKField &) ;
+        void                    writeDataHeader( std::fstream &, bool parallel=false ) const ;
+        void                    writeDataArray( std::fstream &, const VTKField &) const ;
+        void                    writePDataArray( std::fstream &, const VTKField &) const ;
 
         //For Reading
         void                    readDataHeader( std::fstream &) ;
-        bool                    readDataArray( std::fstream &, VTKField &);
+        bool                    readDataArray( std::fstream &, VTKField &) const ;
 
         //General Purpose
         std::vector<std::string> getFieldNames( const std::vector<VTKField> &fields ) const;
@@ -411,10 +411,10 @@ class VTK{
         bool                    isASCIIActive() const;
 
         void                    calcAppendedOffsets() ;
-        virtual uint64_t        calcFieldSize( const VTKField &) =0;
-        virtual uint64_t        calcFieldEntries( const VTKField &) =0;
-        virtual uint8_t         calcFieldComponents( const VTKField &) =0;
-        void                    checkAllFields() ;
+        virtual uint64_t        calcFieldSize( const VTKField &) const = 0;
+        virtual uint64_t        calcFieldEntries( const VTKField &) const = 0;
+        virtual uint8_t         calcFieldComponents( const VTKField &) const = 0;
+        void                    checkAllFields();
 
 };
 
@@ -455,9 +455,9 @@ class VTKUnstructuredGrid : public VTK {
         using                   VTK::setGeomData;
 
         void                    readMetaInformation() override ;
-        void                    writeMetaInformation() override ;
+        void                    writeMetaInformation() const override ;
 
-        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) override ;
+        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) const override ;
 
         void                    setDimensions( uint64_t , uint64_t , uint64_t nconn = 0 , uint64_t nfacestream = 0 ) ;
 
@@ -468,13 +468,13 @@ class VTKUnstructuredGrid : public VTK {
         template<class T>
         void setGeomData( VTKUnstructuredField, VTKBaseStreamer* = nullptr );
 
-        uint64_t                calcConnectivityEntries( ) ;
-        uint64_t                calcFieldSize( const VTKField &) override ;
-        uint64_t                calcFieldEntries( const VTKField &) override ;
-        uint8_t                 calcFieldComponents( const VTKField &) override ;
+        uint64_t                calcConnectivityEntries( ) const ;
+        uint64_t                calcFieldSize( const VTKField &) const override ;
+        uint64_t                calcFieldEntries( const VTKField &) const override ;
+        uint8_t                 calcFieldComponents( const VTKField &) const override ;
 
     private:
-        int                     getFieldGeomId( VTKUnstructuredField field ) ;
+        int                     getFieldGeomId( VTKUnstructuredField field ) const ;
 
 };
 
@@ -501,9 +501,9 @@ class VTKRectilinearGrid : public VTK{
         using                   VTK::setGeomData;
 
         void                    readMetaInformation() override ;
-        void                    writeMetaInformation() override ;
+        void                    writeMetaInformation() const override ;
 
-        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) override ;
+        void                    writeCollection( const std::string &outputName, const std::string &collectionName ) const override ;
 
         void                    setDimensions( int, int, int, int, int, int ) ;
         void                    setDimensions( int, int, int ) ;
@@ -523,9 +523,9 @@ class VTKRectilinearGrid : public VTK{
         void                    setGlobalIndex( const std::vector<extension3D_t> & ) ;
         void                    setGlobalIndex( const std::vector<extension2D_t> & ) ;
 
-        uint64_t                calcFieldSize( const VTKField &) override ;
-        uint64_t                calcFieldEntries( const VTKField &) override ;
-        uint8_t                 calcFieldComponents( const VTKField &) override ;
+        uint64_t                calcFieldSize( const VTKField &) const override ;
+        uint64_t                calcFieldEntries( const VTKField &) const override ;
+        uint8_t                 calcFieldComponents( const VTKField &) const override ;
 };
 
 /*!

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -289,15 +289,11 @@ void VTKRectilinearGrid::writeCollection( const std::string &outputName, const s
         return;
     }
 
-    // Initialize file handler
+    // Create file handler
+    FileHandler fhp = createCollectionHandler(collectionName) ;
+
+    // Initialize outout stream
     std::fstream str ;
-
-    FileHandler fhp(m_fh) ;
-    fhp.setSeries(false) ;
-    fhp.setParallel(false) ;
-    fhp.setName(collectionName) ;
-    fhp.setAppendix(getCollectionExtension()) ;
-
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
         throw std::runtime_error("Cannot create file \"" + fhp.getName() + "\"" + " inside the directory \"" + fhp.getDirectory() + "\"");

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -45,7 +45,7 @@ namespace bitpit{
  */
 VTKRectilinearGrid::VTKRectilinearGrid( ) :VTK() {
 
-    m_fh.setAppendix( "vtr" );
+    m_fh.setAppendix( getExtension() );
 
     m_geometry.push_back( VTKField("x_Coord") ) ;
     m_geometry.push_back( VTKField("y_Coord") ) ;
@@ -296,7 +296,7 @@ void VTKRectilinearGrid::writeCollection( const std::string &outputName, const s
     fhp.setSeries(false) ;
     fhp.setParallel(false) ;
     fhp.setName(collectionName) ;
-    fhp.setAppendix("pvtr") ;
+    fhp.setAppendix(getCollectionExtension()) ;
 
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
@@ -574,6 +574,15 @@ uint8_t VTKRectilinearGrid::calcFieldComponents( const VTKField &field ) const {
 
     return comp ;
 
+}
+
+/*!
+ *  Gets the extension of the VTK file.
+ *
+ *  \result The extension of the VTK file.
+ */
+std::string VTKRectilinearGrid::getExtension() const {
+    return "vtr";
 }
 
 }

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -295,6 +295,9 @@ void VTKRectilinearGrid::writeCollection( ){
     fho.setDirectory(".") ;
 
     str.open( fhp.getPath( ), std::ios::out ) ;
+    if (!str.is_open()) {
+        throw std::runtime_error("Cannot create file \"" + fhp.getName() + "\"" + " inside the directory \"" + fhp.getDirectory() + "\"");
+    }
 
     //Writing XML header
     str << "<?xml version=\"1.0\"?>" << std::endl;

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -279,20 +279,19 @@ void VTKRectilinearGrid::writeMetaInformation( ){
 /*!  
  *  Writes collection file for parallel output. 
  *  Is called by rank 0 in VTK::Write()
+ *
+ *  \param outputName filename to be set for this output only
+ *  \param collectionName collection filename to be set for this output only
  */
-void VTKRectilinearGrid::writeCollection( ){
+void VTKRectilinearGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
 
     std::fstream str ;
 
-    FileHandler     fhp, fho ;
-
-    fhp = m_fh ;
-    fho = m_fh ;
-
+    FileHandler fhp(m_fh) ;
+    fhp.setSeries(false) ;
     fhp.setParallel(false) ;
+    fhp.setName(collectionName) ;
     fhp.setAppendix("pvtr") ;
-
-    fho.setDirectory(".") ;
 
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
@@ -323,6 +322,10 @@ void VTKRectilinearGrid::writeCollection( ){
     str << "      </PCoordinates>" << std::endl;
 
 
+    FileHandler fho(m_fh) ;
+    fho.setSeries(false) ;
+    fho.setDirectory(".") ;
+    fho.setName(outputName) ;
     for( int i=0; i<m_procs; i++){
         fho.setBlock(i) ;
         extension3D_t &index = m_procIndex[i] ;

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -278,13 +278,18 @@ void VTKRectilinearGrid::writeMetaInformation( ){
 
 /*!  
  *  Writes collection file for parallel output. 
- *  Is called by rank 0 in VTK::Write()
  *
  *  \param outputName filename to be set for this output only
  *  \param collectionName collection filename to be set for this output only
  */
 void VTKRectilinearGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
 
+    // Only one process in a parallel output should write the collection
+    if (m_procs <= 1 || m_rank != 0) {
+        return;
+    }
+
+    // Initialize file handler
     std::fstream str ;
 
     FileHandler fhp(m_fh) ;

--- a/src/IO/VTKRectilinear.cpp
+++ b/src/IO/VTKRectilinear.cpp
@@ -221,7 +221,7 @@ void VTKRectilinearGrid::readMetaInformation( ){
 /*!  
  *  Writes entire VTR but the data.
  */
-void VTKRectilinearGrid::writeMetaInformation( ){
+void VTKRectilinearGrid::writeMetaInformation( ) const {
 
     std::fstream str;
 
@@ -282,7 +282,7 @@ void VTKRectilinearGrid::writeMetaInformation( ){
  *  \param outputName filename to be set for this output only
  *  \param collectionName collection filename to be set for this output only
  */
-void VTKRectilinearGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
+void VTKRectilinearGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) const {
 
     // Only one process in a parallel output should write the collection
     if (m_procs <= 1 || m_rank != 0) {
@@ -333,7 +333,7 @@ void VTKRectilinearGrid::writeCollection( const std::string &outputName, const s
     fho.setName(outputName) ;
     for( int i=0; i<m_procs; i++){
         fho.setBlock(i) ;
-        extension3D_t &index = m_procIndex[i] ;
+        const extension3D_t &index = m_procIndex[i] ;
 
         str << "    <Piece Extent= \" " 
             << index[0][0] << " " << index[0][1] << " "
@@ -505,7 +505,7 @@ void VTKRectilinearGrid::setGlobalIndex( const std::vector<extension2D_t> &loc )
  * @param[in] field field 
  * @return size of the field
  */
-uint64_t VTKRectilinearGrid::calcFieldSize( const VTKField &field ){
+uint64_t VTKRectilinearGrid::calcFieldSize( const VTKField &field ) const {
 
     uint64_t bytes = calcFieldEntries(field) ;
     bytes *= VTKTypes::sizeOfType( field.getDataType() ) ;
@@ -519,7 +519,7 @@ uint64_t VTKRectilinearGrid::calcFieldSize( const VTKField &field ){
  * @param[in] field field 
  * @return size of the field
  */
-uint64_t VTKRectilinearGrid::calcFieldEntries( const VTKField &field ){
+uint64_t VTKRectilinearGrid::calcFieldEntries( const VTKField &field ) const {
 
     uint64_t entries(0) ;
     const std::string &name = field.getName() ;
@@ -559,7 +559,7 @@ uint64_t VTKRectilinearGrid::calcFieldEntries( const VTKField &field ){
  * @param[in] field field 
  * @return size of the field
  */
-uint8_t VTKRectilinearGrid::calcFieldComponents( const VTKField &field ){
+uint8_t VTKRectilinearGrid::calcFieldComponents( const VTKField &field ) const {
 
     uint8_t comp ;
     const std::string &name = field.getName() ;

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -438,7 +438,7 @@ uint64_t VTKUnstructuredGrid::readFaceStreamEntries( ){
 /*!  
  *  Writes entire VTU but the data.
  */
-void VTKUnstructuredGrid::writeMetaInformation( ){
+void VTKUnstructuredGrid::writeMetaInformation( ) const {
 
     std::fstream str ;
 
@@ -498,7 +498,7 @@ void VTKUnstructuredGrid::writeMetaInformation( ){
  *  \param outputName filename to be set for this output only
  *  \param collectionName collection filename to be set for this output only
  */
-void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
+void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) const {
 
     // Only one process in a parallel output should write the collection
     if (m_procs <= 1 || m_rank != 0) {
@@ -633,7 +633,7 @@ void VTKUnstructuredGrid::readMetaInformation( ){
  *  Returns the size of the connectivity information
  *  @return size of connectivity
  */
-uint64_t VTKUnstructuredGrid::calcConnectivityEntries( ){
+uint64_t VTKUnstructuredGrid::calcConnectivityEntries( ) const {
 
     return calcFieldEntries( m_geometry[getFieldGeomId(VTKUnstructuredField::CONNECTIVITY)] ) ;
 }
@@ -643,7 +643,7 @@ uint64_t VTKUnstructuredGrid::calcConnectivityEntries( ){
  * @param[in] field field 
  * @return size of the field
  */
-uint64_t VTKUnstructuredGrid::calcFieldSize( const VTKField &field ){
+uint64_t VTKUnstructuredGrid::calcFieldSize( const VTKField &field ) const {
 
     uint64_t bytes = calcFieldEntries(field) ;
     bytes *= VTKTypes::sizeOfType( field.getDataType() ) ;
@@ -657,7 +657,7 @@ uint64_t VTKUnstructuredGrid::calcFieldSize( const VTKField &field ){
  * @param[in] field field 
  * @return size of the field
  */
-uint64_t VTKUnstructuredGrid::calcFieldEntries( const VTKField &field ){
+uint64_t VTKUnstructuredGrid::calcFieldEntries( const VTKField &field ) const {
 
     uint64_t entries(0) ;
     const std::string &name = field.getName() ;
@@ -706,7 +706,7 @@ uint64_t VTKUnstructuredGrid::calcFieldEntries( const VTKField &field ){
  * @param[in] field field 
  * @return size of the field
  */
-uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ){
+uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ) const {
 
     uint8_t comp ;
     const std::string &name = field.getName() ;
@@ -749,7 +749,7 @@ uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ){
  *  @param[in] field field
  *  @return geometry index associated to the field
  */
-int VTKUnstructuredGrid::getFieldGeomId( VTKUnstructuredField field ){
+int VTKUnstructuredGrid::getFieldGeomId( VTKUnstructuredField field ) const {
 
     return static_cast<std::underlying_type<VTKElementType>::type>(field) ;
 }

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -494,13 +494,18 @@ void VTKUnstructuredGrid::writeMetaInformation( ){
 
 /*!  
  *  Writes collection file for parallel output. 
- *  Is called by rank 0 in VTK::Write()
  *
  *  \param outputName filename to be set for this output only
  *  \param collectionName collection filename to be set for this output only
  */
 void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
 
+    // Only one process in a parallel output should write the collection
+    if (m_procs <= 1 || m_rank != 0) {
+        return;
+    }
+
+    // Initialize file handler
     std::fstream str ;
 
     FileHandler fhp(m_fh) ;

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -495,20 +495,19 @@ void VTKUnstructuredGrid::writeMetaInformation( ){
 /*!  
  *  Writes collection file for parallel output. 
  *  Is called by rank 0 in VTK::Write()
+ *
+ *  \param outputName filename to be set for this output only
+ *  \param collectionName collection filename to be set for this output only
  */
-void VTKUnstructuredGrid::writeCollection( ){
+void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const std::string &collectionName ) {
 
     std::fstream str ;
 
-    FileHandler     fhp, fho ;
-
-    fhp = m_fh ;
-    fho = m_fh ;
-
+    FileHandler fhp(m_fh) ;
+    fhp.setSeries(false) ;
     fhp.setParallel(false) ;
+    fhp.setName(collectionName) ;
     fhp.setAppendix("pvtu") ;
-
-    fho.setDirectory(".") ;
 
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
@@ -540,6 +539,10 @@ void VTKUnstructuredGrid::writeCollection( ){
     }
     str << "      </PCells>" << std::endl;
 
+    FileHandler fho(m_fh) ;
+    fho.setSeries(false) ;
+    fho.setDirectory(".") ;
+    fho.setName(outputName) ;
     for( int i=0; i<m_procs; i++){
         fho.setBlock(i) ;
         str << "    <Piece  Source=\"" << fho.getPath() <<  "\"/>" << std::endl;

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -132,7 +132,7 @@ void VTKUnstructuredGrid::HomogeneousInfoStreamer::flushData( std::fstream &str,
  */
 VTKUnstructuredGrid::VTKUnstructuredGrid( VTKElementType elementType ) :VTK() {
 
-    m_fh.setAppendix("vtu");
+    m_fh.setAppendix(getExtension());
 
     int nGeomFields = 6;
 
@@ -512,7 +512,7 @@ void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const 
     fhp.setSeries(false) ;
     fhp.setParallel(false) ;
     fhp.setName(collectionName) ;
-    fhp.setAppendix("pvtu") ;
+    fhp.setAppendix(getCollectionExtension()) ;
 
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
@@ -752,6 +752,15 @@ uint8_t VTKUnstructuredGrid::calcFieldComponents( const VTKField &field ) const 
 int VTKUnstructuredGrid::getFieldGeomId( VTKUnstructuredField field ) const {
 
     return static_cast<std::underlying_type<VTKElementType>::type>(field) ;
+}
+
+/*!
+ *  Gets the extension of the VTK file.
+ *
+ *  \result The extension of the VTK file.
+ */
+std::string VTKUnstructuredGrid::getExtension() const {
+    return "vtu";
 }
 
 }

--- a/src/IO/VTKUnstructured.cpp
+++ b/src/IO/VTKUnstructured.cpp
@@ -505,15 +505,11 @@ void VTKUnstructuredGrid::writeCollection( const std::string &outputName, const 
         return;
     }
 
-    // Initialize file handler
+    // Create file handler
+    FileHandler fhp = createCollectionHandler(collectionName) ;
+
+    // Initialize outout stream
     std::fstream str ;
-
-    FileHandler fhp(m_fh) ;
-    fhp.setSeries(false) ;
-    fhp.setParallel(false) ;
-    fhp.setName(collectionName) ;
-    fhp.setAppendix(getCollectionExtension()) ;
-
     str.open( fhp.getPath( ), std::ios::out ) ;
     if (!str.is_open()) {
         throw std::runtime_error("Cannot create file \"" + fhp.getName() + "\"" + " inside the directory \"" + fhp.getDirectory() + "\"");

--- a/src/IO/configuration_XML.cpp
+++ b/src/IO/configuration_XML.cpp
@@ -139,10 +139,6 @@ void writeNode(xmlTextWriterPtr writer, const Config *config, const std::string 
 */
 xmlChar * encodeString(const std::string &in, const std::string &encoding)
 {
-    if (in.empty()) {
-        return nullptr;
-    }
-
     xmlCharEncodingHandlerPtr handler = xmlFindCharEncodingHandler(encoding.c_str());
     if (!handler) {
         return nullptr;

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -89,7 +89,7 @@ FileHandler&    FileHandler::operator=(const FileHandler& other){
  * Checks if file exists.
  * @return  [true/false] if file exists
  */
-bool   FileHandler::exists() {
+bool   FileHandler::exists() const {
     std::ifstream f( getPath() );
     return f.good() ;
 }
@@ -98,7 +98,7 @@ bool   FileHandler::exists() {
  * Composes the filename.
  * @return  complete filename
  */
-std::string  FileHandler::getPath(){
+std::string  FileHandler::getPath() const {
   std::stringstream filename ;
 
   if (!directory.empty()) filename << directory << "/";

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -235,8 +235,8 @@ int    FileHandler::getBlock( ) const {
 }
 
 /*!
- * sets the counter of the series
- * @param[in]   b_      index of block of parallel set
+ * sets the index of the parallel block
+ * @param[in]   b_      index of the parallel block
  */
 void    FileHandler::setBlock( int b_){
     block=b_;

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -86,74 +86,12 @@ FileHandler&    FileHandler::operator=(const FileHandler& other){
 };
 
 /*!
- * sets the directory
- * @param[in]   d_      name of directory
+ * Checks if file exists.
+ * @return  [true/false] if file exists
  */
-void    FileHandler::setDirectory(const std::string &d_){
-    directory=d_; 
-    return;
-} ;
-
-/*!
- * sets the name
- * @param[in]   n_      name of file
- */
-void    FileHandler::setName(const std::string &n_){
-    name=n_; 
-    return;
-} ;
-
-/*!
- * sets the appendix
- * @param[in]   a_      appendix of file
- */
-void    FileHandler::setAppendix(const std::string &a_){
-    appendix=a_; 
-    return;
-} ;
-
-/*!
- * sets if file belongs to a time series
- * @param[in]   s_      [true/false] if series
- */
-void    FileHandler::setSeries( bool s_){ 
-    series=s_; 
-    return;
-} ;
-
-/*!
- * sets the counter of the series
- * @param[in]   c_      index of series
- */
-void    FileHandler::setCounter(int c_){ 
-    counter=c_; 
-    return; 
-};
-
-/*!
- * sets if file belongs to a parallel output
- * @param[in]   p_      [true/false] if parallel
- */
-void    FileHandler::setParallel( bool p_){ 
-    parallel=p_; 
-    return;
-} ;
-
-/*!
- * sets the counter of the series
- * @param[in]   b_      index of block of parallel set
- */
-void    FileHandler::setBlock( int b_){ 
-    block=b_; 
-    return;
-} ;
-
-/*!
- * Increments the counter used for series.
- */
-void    FileHandler::incrementCounter(){ 
-    counter++; 
-    return; 
+bool   FileHandler::exists() {
+    std::ifstream f( getPath() );
+    return f.good() ;
 };
 
 /*!
@@ -174,21 +112,21 @@ std::string  FileHandler::getPath(){
 };
 
 /*!
- * Get the name of the file
- * @return The name of the file.
- */
-std::string  FileHandler::getName() const {
-
-  return name;
-};
-
-/*!
  * Get the directory where the file will be saved
  * @return The directory where the file will be saved.
  */
 std::string  FileHandler::getDirectory() const {
 
   return directory;
+};
+
+/*!
+ * Get the name of the file
+ * @return The name of the file.
+ */
+std::string  FileHandler::getName() const {
+
+  return name;
 };
 
 /*!
@@ -201,21 +139,84 @@ std::string  FileHandler::getAppendix() const {
 };
 
 /*!
- * Get the time index of the following file
+ * sets the directory
+ * @param[in]   d_      name of directory
+ */
+void    FileHandler::setDirectory(const std::string &d_){
+    directory=d_;
+    return;
+}
+
+/*!
+ * sets the name
+ * @param[in]   n_      name of file
+ */
+void    FileHandler::setName(const std::string &n_){
+    name=n_;
+    return;
+}
+
+/*!
+ * sets the appendix
+ * @param[in]   a_      appendix of file
+ */
+void    FileHandler::setAppendix(const std::string &a_){
+    appendix=a_;
+    return;
+}
+
+/*!
+ * sets if file belongs to a time series
+ * @param[in]   s_      [true/false] if series
+ */
+void    FileHandler::setSeries( bool s_){ 
+    series=s_; 
+    return;
+}
+
+/*!
+ * Get the time index of the following file.
+ * If the file doen't belong to a time series, a negative number will
+ * be returned.
  * @return counter
  */
 int  FileHandler::getCounter() const {
-
   return counter;
+}
+
+/*!
+ * sets the counter of the series
+ * @param[in]   c_      index of series
+ */
+void    FileHandler::setCounter(int c_){ 
+    counter=c_; 
+    return; 
 };
 
 /*!
- * Checks if file exists.
- * @return  [true/false] if file exists
+ * Increments the counter used for series.
  */
-bool   FileHandler::exists() {
-    std::ifstream f( getPath() );
-    return f.good() ;
+void    FileHandler::incrementCounter(){ 
+    counter++; 
+    return; 
 };
+
+/*!
+ * sets if file belongs to a parallel output
+ * @param[in]   p_      [true/false] if parallel
+ */
+void    FileHandler::setParallel( bool p_){
+    parallel=p_;
+    return;
+}
+
+/*!
+ * sets the counter of the series
+ * @param[in]   b_      index of block of parallel set
+ */
+void    FileHandler::setBlock( int b_){
+    block=b_;
+    return;
+}
 
 }

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -189,7 +189,11 @@ void    FileHandler::setSeries( bool s_){
  * @return counter
  */
 int  FileHandler::getCounter() const {
-  return counter;
+  if (series) {
+    return counter;
+  } else {
+    return INVALID_COUNTER;
+  }
 }
 
 /*!

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -115,7 +115,7 @@ std::string  FileHandler::getPath(){
  * Get the directory where the file will be saved
  * @return The directory where the file will be saved.
  */
-std::string  FileHandler::getDirectory() const {
+const std::string &  FileHandler::getDirectory() const {
 
   return directory;
 }
@@ -124,7 +124,7 @@ std::string  FileHandler::getDirectory() const {
  * Get the name of the file
  * @return The name of the file.
  */
-std::string  FileHandler::getName() const {
+const std::string &  FileHandler::getName() const {
 
   return name;
 }
@@ -133,7 +133,7 @@ std::string  FileHandler::getName() const {
  * Get the appendix of the file
  * @return The appendix of the file.
  */
-std::string  FileHandler::getAppendix() const {
+const std::string &  FileHandler::getAppendix() const {
 
   return appendix;
 }

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -42,7 +42,7 @@ FileHandler::FileHandler()
     : directory("./"), name("file"), appendix("dat"),
       series(false), parallel(false),
       counter(0), block(0) {
-} ;
+}
 
 /*!
  * Constructor. 
@@ -56,7 +56,7 @@ FileHandler::FileHandler(const std::string &dir_, const std::string &name_, cons
     : directory(dir_), name(name_), appendix(app_),
       series(false), parallel(false),
       counter(0), block(0) {
-};
+}
 
 /*!
  * Copy Constructor. 
@@ -66,7 +66,7 @@ FileHandler::FileHandler(const FileHandler& other){
 
     (*this) = other ;
 
-};
+}
 
 /*!
  * Assignment operator.
@@ -83,7 +83,7 @@ FileHandler&    FileHandler::operator=(const FileHandler& other){
 
 
     return *this ;
-};
+}
 
 /*!
  * Checks if file exists.
@@ -92,7 +92,7 @@ FileHandler&    FileHandler::operator=(const FileHandler& other){
 bool   FileHandler::exists() {
     std::ifstream f( getPath() );
     return f.good() ;
-};
+}
 
 /*!
  * Composes the filename.
@@ -109,7 +109,7 @@ std::string  FileHandler::getPath(){
 
   return filename.str() ;
 
-};
+}
 
 /*!
  * Get the directory where the file will be saved
@@ -118,7 +118,7 @@ std::string  FileHandler::getPath(){
 std::string  FileHandler::getDirectory() const {
 
   return directory;
-};
+}
 
 /*!
  * Get the name of the file
@@ -127,7 +127,7 @@ std::string  FileHandler::getDirectory() const {
 std::string  FileHandler::getName() const {
 
   return name;
-};
+}
 
 /*!
  * Get the appendix of the file
@@ -136,7 +136,7 @@ std::string  FileHandler::getName() const {
 std::string  FileHandler::getAppendix() const {
 
   return appendix;
-};
+}
 
 /*!
  * sets the directory
@@ -191,7 +191,7 @@ int  FileHandler::getCounter() const {
 void    FileHandler::setCounter(int c_){ 
     counter=c_; 
     return; 
-};
+}
 
 /*!
  * Increments the counter used for series.
@@ -199,7 +199,7 @@ void    FileHandler::setCounter(int c_){
 void    FileHandler::incrementCounter(){ 
     counter++; 
     return; 
-};
+}
 
 /*!
  * sets if file belongs to a parallel output

--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -166,6 +166,14 @@ void    FileHandler::setAppendix(const std::string &a_){
 }
 
 /*!
+ * Checks if file belongs to a time series
+ * @return Returns true if the file belongs to a time series, false otherwise
+ */
+bool    FileHandler::isSeries() const {
+    return series;
+}
+
+/*!
  * sets if file belongs to a time series
  * @param[in]   s_      [true/false] if series
  */
@@ -202,12 +210,28 @@ void    FileHandler::incrementCounter(){
 }
 
 /*!
+ * Checks if file belongs to a parallel output
+ * @return Returns true if the file belongs to a parallel output, false otherwise
+ */
+bool    FileHandler::isParallel() const {
+    return parallel;
+}
+
+/*!
  * sets if file belongs to a parallel output
  * @param[in]   p_      [true/false] if parallel
  */
 void    FileHandler::setParallel( bool p_){
     parallel=p_;
     return;
+}
+
+/*!
+ * gets the index of the parallel block
+ * @return the index of the parallel block
+ */
+int    FileHandler::getBlock( ) const {
+    return block;
 }
 
 /*!

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -56,6 +56,8 @@ class FileHandler{
         int                   block  ;         /**< index of the parallel block for distributed data */
 
     public:
+        static const int INVALID_COUNTER = -1; /**< dummy counter associate with files that doesn't belong to a time series*/
+
         FileHandler() ;
         FileHandler( const std::string & dir_, const std::string & name_, const std::string & app_) ;
         FileHandler(  const FileHandler& other ) ;

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -72,14 +72,17 @@ class FileHandler{
         void                setName( const std::string & n_) ;
         void                setAppendix( const std::string & a_) ;
 
+        bool                isSeries( ) const ;
         void                setSeries( bool s_) ;
 
         int                 getCounter() const ;
         void                setCounter(int c_);
         void                incrementCounter();
 
+        bool                isParallel( ) const ;
         void                setParallel( bool p_) ;
 
+        int                 getBlock( ) const ;
         void                setBlock( int b_) ;
 
 };

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -64,9 +64,9 @@ class FileHandler{
 
         FileHandler& operator=( const FileHandler& other) ;
 
-        bool                exists() ;
+        bool                exists() const ;
 
-        std::string         getPath() ;
+        std::string         getPath() const ;
         const std::string & getDirectory() const ;
         const std::string & getName() const ;
         const std::string & getAppendix() const ;

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -67,9 +67,9 @@ class FileHandler{
         bool                exists() ;
 
         std::string         getPath() ;
-        std::string         getDirectory() const ;
-        std::string         getName() const ;
-        std::string         getAppendix() const ;
+        const std::string & getDirectory() const ;
+        const std::string & getName() const ;
+        const std::string & getAppendix() const ;
         void                setDirectory( const std::string & d_) ;
         void                setName( const std::string & n_) ;
         void                setAppendix( const std::string & a_) ;

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -53,7 +53,7 @@ class FileHandler{
         int                   counter ;        /**< counter for time series ; */
 
         bool                  parallel ;       /**< is part of distributed data? */
-        int                   block  ;         /**< index of block if parallel data */
+        int                   block  ;         /**< index of the parallel block for distributed data */
 
     public:
         FileHandler() ;

--- a/src/common/fileHandler.hpp
+++ b/src/common/fileHandler.hpp
@@ -48,11 +48,12 @@ class FileHandler{
         std::string           directory;       /**< name od directory where file resides */
         std::string           name;            /**< name of file; */
         std::string           appendix ;       /**< appendix; */
-        bool                  series ;         /**< is time series? */
-        bool                  parallel ;       /**< is part of distributed data? */
-        int                   counter ;        /**< counter for time series ; */
-        int                   block  ;         /**< index of block if parallel data */
 
+        bool                  series ;         /**< is time series? */
+        int                   counter ;        /**< counter for time series ; */
+
+        bool                  parallel ;       /**< is part of distributed data? */
+        int                   block  ;         /**< index of block if parallel data */
 
     public:
         FileHandler() ;
@@ -61,22 +62,25 @@ class FileHandler{
 
         FileHandler& operator=( const FileHandler& other) ;
 
+        bool                exists() ;
+
+        std::string         getPath() ;
+        std::string         getDirectory() const ;
+        std::string         getName() const ;
+        std::string         getAppendix() const ;
         void                setDirectory( const std::string & d_) ;
         void                setName( const std::string & n_) ;
         void                setAppendix( const std::string & a_) ;
+
         void                setSeries( bool s_) ;
-        void                setParallel( bool p_) ;
-        void                setCounter(int c_);
-        void                setBlock( int b_) ;
 
-        std::string         getPath() ;
-        std::string         getName() const ;
-        std::string         getDirectory() const ;
-        std::string         getAppendix() const ;
         int                 getCounter() const ;
-
+        void                setCounter(int c_);
         void                incrementCounter();
-        bool                exists() ;
+
+        void                setParallel( bool p_) ;
+
+        void                setBlock( int b_) ;
 
 };
 

--- a/src/patchkernel/patch_kernel.cpp
+++ b/src/patchkernel/patch_kernel.cpp
@@ -1173,11 +1173,54 @@ void PatchKernel::write(const std::string &filename, VTKWriteMode mode)
 }
 
 /*!
-	Writes the patch a filename with the same name of the patch.
+	Writes the patch to filename specified in input.
+
+	\param filename the filename where the patch will be written to
+	\param mode is the VTK file mode that will be used for writing the patch
+	\param time is the current time
+*/
+void PatchKernel::write(const std::string &filename, VTKWriteMode mode, double time)
+{
+	std::string oldFilename = m_vtk.getName();
+
+	m_vtk.setName(filename);
+	write(mode, time);
+	m_vtk.setName(oldFilename);
+}
+
+/*!
+	Writes the patch to filename specified in input.
 
 	\param mode is the VTK file mode that will be used for writing the patch
 */
 void PatchKernel::write(VTKWriteMode mode)
+{
+	_writePrepare();
+
+	m_vtk.write(mode);
+
+	_writeFinalize();
+}
+
+/*!
+	Writes the patch a filename with the same name of the patch.
+
+	\param mode is the VTK file mode that will be used for writing the patch
+	\param time is the current time
+*/
+void PatchKernel::write(VTKWriteMode mode, double time)
+{
+	_writePrepare();
+
+	m_vtk.write(mode, time);
+
+	_writeFinalize();
+}
+
+/*!
+	Internal function to be called before writing the patch.
+*/
+void PatchKernel::_writePrepare()
 {
 	// Get VTK cell count
 	long vtkCellCount = 0;
@@ -1246,9 +1289,14 @@ void PatchKernel::write(VTKWriteMode mode)
 	}
 
 	m_vtk.setDimensions(vtkCellCount, vtkVertexCount, vtkConnectSize, vtkFaceStreamSize);
+}
 
-	// Write the mesh
-	m_vtk.write(mode);
+/*!
+	Internal function to be called after writing the patch.
+*/
+void PatchKernel::_writeFinalize()
+{
+	// Nothing to do
 }
 
 /*!

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -682,7 +682,9 @@ public:
 	void setVTKWriteTarget(WriteTarget targetCells);
 	const CellConstRange getVTKCellWriteRange() const;
 	void write(VTKWriteMode mode = VTKWriteMode::DEFAULT);
+	void write(VTKWriteMode mode, double time);
 	void write(const std::string &name, VTKWriteMode mode = VTKWriteMode::DEFAULT);
+	void write(const std::string &name, VTKWriteMode mode, double time);
 
 	void flushData(std::fstream &stream, const std::string &name, VTKFormat format) override;
 
@@ -902,6 +904,9 @@ protected:
 	virtual void _findCellFaceNeighs(long id, int face, const std::vector<long> *blackList, std::vector<long> *neighs) const;
 	virtual void _findCellEdgeNeighs(long id, int edge, const std::vector<long> *blackList, std::vector<long> *neighs) const;
 	virtual void _findCellVertexNeighs(long id, int vertex, const std::vector<long> *blackList, std::vector<long> *neighs) const;
+
+	virtual void _writePrepare();
+	virtual void _writeFinalize();
 
 	void setExpert(bool expert);
 


### PR DESCRIPTION
The VTK class is now able to write [PVD files](https://vtk.org/Wiki/ParaView/Data_formats#PVD_File_Format) containing the  information about the time series.