### PR TITLE
POD: fix pod kernel clear

### DIFF
--- a/src/POD/pod.cpp
+++ b/src/POD/pod.cpp
@@ -143,7 +143,9 @@ void POD::clear()
     m_nModes = 0;
     m_nReconstructionSnapshots = 0;
 
-    m_podkernel->clearMapper();
+    if (m_podkernel) {
+        m_podkernel->clearMapper();
+    }
 
 # if BITPIT_ENABLE_MPI
     freeCommunicator();


### PR DESCRIPTION
The pull request fixes an issue with the pod kernel clearMapper method. Previous implementation caused runtime error when pod objects were instantiated without setting the pod kernel. The current modification prevents this from happening.