### PR TITLE
common: fix initialization order of FileHandler members

### DIFF
--- a/src/common/fileHandler.cpp
+++ b/src/common/fileHandler.cpp
@@ -40,8 +40,8 @@ namespace bitpit{
  */
 FileHandler::FileHandler()
     : directory("./"), name("file"), appendix("dat"),
-      series(false), parallel(false),
-      counter(0), block(0) {
+      series(false), counter(0),
+      parallel(false), block(0) {
 }
 
 /*!
@@ -54,8 +54,8 @@ FileHandler::FileHandler()
  */
 FileHandler::FileHandler(const std::string &dir_, const std::string &name_, const std::string &app_)
     : directory(dir_), name(name_), appendix(app_),
-      series(false), parallel(false),
-      counter(0), block(0) {
+      series(false), counter(0),
+      parallel(false), block(0) {
 }
 
 /*!
@@ -77,8 +77,8 @@ FileHandler&    FileHandler::operator=(const FileHandler& other){
     name        = other.name ;
     appendix    = other.appendix ;
     series      = other.series ;
-    parallel    = other.parallel ;
     counter     = other.counter ;
+    parallel    = other.parallel ;
     block       = other.block ;
 
 


### PR DESCRIPTION
Fixes the following warning:
```
In file included from /opt/bitpit/src/common/bitpit_common.hpp:45,
                 from /opt/bitpit/src/common/fileHandler.cpp:30:
/opt/bitpit/src/common/fileHandler.hpp: In constructor 'bitpit::FileHandler::FileHandler()': /opt/bitpit/src/common/fileHandler.hpp:55:31: warning: 'bitpit::FileHandler::parallel' will be initialized after [-Wreorder]
   55 |         bool                  parallel ;       /**< is part of distributed data? */
      |                               ^~~~~~~~
/opt/bitpit/src/common/fileHandler.hpp:53:31: warning:   'int bitpit::FileHandler::counter' [-Wreorder]
   53 |         int                   counter ;        /**< counter for time series ; */
```