### PR TITLE
RBF: fix initialization order of RBF members

### DIFF
--- a/src/RBF/rbf.hpp
+++ b/src/RBF/rbf.hpp
@@ -105,8 +105,8 @@ protected:
     int m_maxFields;                                /**< fix the maximum number of fields that can be added to your class*/
     int m_nodes;                                    /**<Number of RBF nodes.*/
     bool m_polyEnabled;                             /**< Enable/disable the use of the linear polynomial term in interpolation */
-    LinearPolynomial m_polynomial;                  /**< Linear polynomial object */
     std::vector<int> m_polyActiveBasis;             /**< Active terms of linear polynomial, 0 is constant, i+1 the i-th system coordinate */
+    LinearPolynomial m_polynomial;                  /**< Linear polynomial object */
 
 public:
     RBFKernel();


### PR DESCRIPTION
Fixes the following warning:
```
In file included from /opt/bitpit/code/src/RBF/rbf.cpp:34:0: 
/opt/bitpit/code/src/RBF/rbf.hpp: In copy constructor ‘bitpit::RBFKernel::RBFKernel(const bitpit::RBFKernel&)’: /opt/bitpit/code/src/RBF/rbf.hpp:109:22: warning: ‘bitpit::RBFKernel::m_polyActiveBasis’ will be initialized after [-Wreorder]
     std::vector<int> m_polyActiveBasis;             /**< Active terms of linear polynomial, 0 is constant, i+1 the i-th system coordinate */
                      ^~~~~~~~~~~~~~~~~
/opt/bitpit/code/src/RBF/rbf.hpp:108:22: warning:   ‘bitpit::RBFKernel::LinearPolynomial bitpit::RBFKernel::m_polynomial’ [-Wreorder]
     LinearPolynomial m_polynomial;                  /**< Linear polynomial object */
                      ^~~~~~~~~~~~
/opt/bitpit/code/src/RBF/rbf.cpp:87:1: warning:   when initialized here [-Wreorder]
 RBFKernel::RBFKernel(const RBFKernel & other)
```