### PR TITLE
test/volunstructured: explicitly declare a variable for the halo size

### DIFF
--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00001.cpp
@@ -46,7 +46,9 @@ int subtest_001(int rank, VolUnstructured *patch_2D, VolUnstructured *patch_2D_r
     // Create the patch
     log::cout() << "Creating 2D patch..." << std::endl;
 
-    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD, 2ul);
+    std::size_t haloSize = 2;
+
+    patch_2D = new VolUnstructured(2, MPI_COMM_WORLD, haloSize);
     patch_2D->getVTK().setName("unstructured_patch_2D");
 
     patch_2D->setVertexAutoIndexing(false);
@@ -324,7 +326,9 @@ int subtest_002(int rank, VolUnstructured *patch_3D, VolUnstructured *patch_3D_r
     // Create the patch
     log::cout() << "\n\n:: 3D unstructured mesh ::\n";
 
-    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD, 2ul);
+    std::size_t haloSize = 2;
+
+    patch_3D = new VolUnstructured(3, MPI_COMM_WORLD, haloSize);
     patch_3D->getVTK().setName("unstructured_patch_3D");
 
     patch_3D->setVertexAutoIndexing(false);

--- a/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
+++ b/test/integration_tests/volunstructured/test_volunstructured_parallel_00002.cpp
@@ -112,7 +112,9 @@ int subtest_001(int rank)
     // Create the patch
     log::cout() << "Creating patch..." << std::endl;
 
-    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD, 3ul));
+    std::size_t haloSize = 3;
+
+    std::unique_ptr<VolUnstructured> patch = std::unique_ptr<VolUnstructured>(new VolUnstructured(3, MPI_COMM_WORLD, haloSize));
     if (rank == 0) {
         fillMesh(patch.get());
     }


### PR DESCRIPTION
This should allow MSVC to select the right constructor VolUnstructured.