### PR TITLE
patchkernel: find all the closest cells to a given point

### DIFF
--- a/src/patchkernel/patch_skd_tree.hpp
+++ b/src/patchkernel/patch_skd_tree.hpp
@@ -127,6 +127,7 @@ public:
 
     void findPointClosestCell(const std::array<double, 3> &point, bool interiorCellsOnly, long *closestId, double *closestDistance) const;
     void updatePointClosestCell(const std::array<double, 3> &point, bool interiorCellsOnly, long *closestId, double *closestDistance) const;
+    void updatePointClosestCells(const std::array<double, 3> &point, bool interiorCellsOnly, std::vector<long> &closestId, double *closestDistance) const;
 
 private:
     const SkdPatchInfo *m_patchInfo;
@@ -139,6 +140,7 @@ private:
     void initializeBoundingBox();
 
     void updatePointClosestCell(const std::array<double, 3> &point, const Cell &cell, long *closestId, double *closestDistance) const;
+    void updatePointClosestCells(const std::array<double, 3> &point, const Cell &cell, std::vector<long> &closestId, double *closestDistance) const;
 
 };
 

--- a/src/patchkernel/surface_skd_tree.hpp
+++ b/src/patchkernel/surface_skd_tree.hpp
@@ -57,6 +57,10 @@ public:
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, double maxDistance, long *ids, double *distances) const;
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, long *ids, double *distances) const;
     long findPointClosestCell(int nPoints, const std::array<double, 3> *points, const double *maxDistances, bool interorOnly, long *ids, double *distances) const;
+
+    long findPointClosestCells(const std::array<double,3> &point, std::vector<long> &ids, double *distance) const;
+    long findPointClosestCells(const std::array<double, 3> &point, double maxDistance, std::vector<long> &ids, double *distance) const;
+    long findPointClosestCells(const std::array<double, 3> &point, double maxDistance, bool interorOnly, std::vector<long> &ids,  double *distance) const;
 #if BITPIT_ENABLE_MPI
     long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, long *ids, int *ranks, double *distances) const;
     long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, double maxDistance, long *ids, int *ranks, double *distances) const;
@@ -67,6 +71,15 @@ private:
     mutable std::vector<std::size_t> m_nodeStack;
     mutable std::vector<std::size_t> m_candidateIds;
     mutable std::vector<double> m_candidateMinDistances;
+
+    struct Candidates {
+        std::vector<std::size_t> *candidateIds = nullptr;
+        std::vector<double> *candidateMinDistances = nullptr;
+        std::vector<std::size_t> privateCandidateIds;
+        std::vector<double> privateCandidateMinDistances;
+    };
+
+    void findPointClosestCandidates(const std::array<double, 3> &point, double maxDistance, double *distance, Candidates &candidates) const;
 
 };
 


### PR DESCRIPTION
This pull request adds methods to SurfaceSkdTree to find all the closest cells to a given point. The aim is to provide external applications with the the chance to select the the closest cell using its criteria. Existing methods select the closest cell using a specific criterium: the cell more "aligned" with the line that connect the specified point and its projection onto the cell will be chosen.

