### PR TITLE
levelset: miscellaneous fixes

### DIFF
--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -903,6 +903,14 @@ bool LevelSetObject::isCellInNarrowBand(long id)const
  *
  * The value of the levelset is evaluated and compared with the specified narrow band size.
  *
+ * If a point is inside a cell that belongs to the narrow band because it is a neighbour of a
+ * cell with a different levelset sign, its function may identify the point as outside the
+ * narrow band. That's because it will only compare the levelset of the point with the narrow
+ * band size. The extreme case is when the narrow band size is set to zero and being a neighbour
+ * of a cell with a different levelset sign is the only criterion to identify cells inside the
+ * narrow band. In this situation, this function will identify as inside the narrow band only
+ * the points that lie on the levelset-zero iso surface.
+ *
  * \param point are the coordinates of the point
  * \result Return true if the cell is in the narrow band, false otherwise.
  */

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -914,7 +914,7 @@ bool LevelSetObject::isInNarrowBand(const std::array<double,3> &point)const
     }
 
     // Early return if no narrow band was set
-    if (m_narrowBandSize != LEVELSET_NARROW_BAND_UNLIMITED) {
+    if (m_narrowBandSize == LEVELSET_NARROW_BAND_UNLIMITED) {
         return true;
     }
 

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -1111,9 +1111,11 @@ void LevelSetObject::fillCellPropagatedSignCache()
                 // Set the sign of the cell
                 //
                 // If the sign of the cell has already been set, we check if it matches
-                // the seed sign and then we skip the cell.
-                //
-                // If the cell is a seed, we remove it from the seed list.
+                // the seed sign and then we skip the cell, otherwise we set the sign of
+                // the cell and we process its neighoburs. Once the sign of a cell is
+                // set, we can remove it form the seed list (there is no need to start
+                // again the porpagation from that cell, beause it will not reach any
+                // new portions of the domain).
                 if (cellId != seedId) {
                     CellCacheCollection::ValueCache<char>::Entry cellSignEntry = propagatedSignCache->findEntry(cellId);
                     if (cellSignEntry.isValid()) {
@@ -1125,10 +1127,9 @@ void LevelSetObject::fillCellPropagatedSignCache()
                         } else {
                             continue;
                         }
-
-                        seedIds.erase(cellId);
                     } else {
                         propagatedSignCache->insertEntry(cellId, seedSign);
+                        seedIds.erase(cellId);
                     }
                 }
 

--- a/src/levelset/levelSetSegmentationObject.hpp
+++ b/src/levelset/levelSetSegmentationObject.hpp
@@ -70,7 +70,7 @@ public:
 
     double getFeatureAngle() const;
 
-    double evalDistance(const std::array<double, 3> &point, const SegmentConstIterator &segmentItr) const;
+    double evalDistance(const std::array<double, 3> &point, const SegmentConstIterator &segmentItr, bool signedDistance) const;
     std::array<double, 3> evalDistanceVector(const std::array<double, 3> &point, const SegmentConstIterator &segmentItr) const;
 
     std::array<double, 3> evalNormal(const std::array<double, 3> &point, const SegmentConstIterator &segmentItr) const;


### PR DESCRIPTION
Some fixes gathered in the last weeks:
 - fixed the check that identifies if a point is inside the narrow band;
 - improved robustness of unsigned distance evaluation;
 - small optimization in sign propagation.