### PR TITLE
containers: add binary stream operators for containers of the standard library

### DIFF
--- a/src/containers/binary_stream.cpp
+++ b/src/containers/binary_stream.cpp
@@ -39,7 +39,7 @@ namespace bitpit {
 template<>
 bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &value)
 {
-    int size = 0;
+    std::size_t size;
     stream.read(reinterpret_cast<char *>(&size), sizeof(size));
 
     if (size > 0) {
@@ -60,7 +60,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &va
 template<>
 bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::string &value)
 {
-    int size = value.size();
+    std::size_t size = data.size();
     stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
 
     if (size > 0) {

--- a/src/containers/binary_stream.cpp
+++ b/src/containers/binary_stream.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <limits>
 #include <cmath>
+#include <cstring>
 
 #include "binary_stream.hpp"
 

--- a/src/containers/binary_stream.cpp
+++ b/src/containers/binary_stream.cpp
@@ -34,10 +34,10 @@ namespace bitpit {
 * Stream a string from the binary stream.
 *
 * \param[in] stream input stream
-* \param[in] value is the string to be streamed
+* \param[in] data is the string to be streamed
 */
 template<>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &value)
+bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &data)
 {
     std::size_t size;
     stream.read(reinterpret_cast<char *>(&size), sizeof(size));
@@ -45,9 +45,9 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &va
     if (size > 0) {
         std::vector<char> buffer(size);
         stream.read(buffer.data(), size);
-        value.assign(buffer.data(), size);
+        data.assign(buffer.data(), size);
     } else {
-        value = "";
+        data = "";
     }
 
     return stream;
@@ -57,16 +57,16 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &va
 * Stream a string to the binary stream.
 *
 * \param[in] stream is the output stream
-* \param[in] value is the string to be streamed
+* \param[in] data is the string to be streamed
 */
 template<>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::string &value)
+bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &stream, const std::string &data)
 {
     std::size_t size = data.size();
     stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
 
     if (size > 0) {
-        stream.write(value.c_str(), size);
+        stream.write(data.c_str(), size);
     }
 
     return stream;

--- a/src/containers/binary_stream.cpp
+++ b/src/containers/binary_stream.cpp
@@ -46,6 +46,8 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &stream, std::string &va
         std::vector<char> buffer(size);
         stream.read(buffer.data(), size);
         value.assign(buffer.data(), size);
+    } else {
+        value = "";
     }
 
     return stream;

--- a/src/containers/binary_stream.hpp
+++ b/src/containers/binary_stream.hpp
@@ -39,22 +39,22 @@ class IBinaryStream;
 class OBinaryStream;
 
 template<typename T>
-IBinaryStream & operator>>(IBinaryStream &stream, T &value);
+IBinaryStream & operator>>(IBinaryStream &stream, T &data);
 
 template<typename T>
-IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &vector);
+IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &data);
 
 template<>
-IBinaryStream & operator>>(IBinaryStream &stream, std::string &value);
+IBinaryStream & operator>>(IBinaryStream &stream, std::string &data);
 
 template<typename T>
-OBinaryStream & operator<<(OBinaryStream &stream, const T &value);
+OBinaryStream & operator<<(OBinaryStream &stream, const T &data);
 
 template<typename T>
-OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &vector);
+OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &data);
 
 template<>
-OBinaryStream & operator<<(OBinaryStream &stream, const std::string &value);
+OBinaryStream & operator<<(OBinaryStream &stream, const std::string &data);
 
 // Binary stream
 class BinaryStream {
@@ -102,7 +102,7 @@ private:
 class IBinaryStream : public BinaryStream {
 
 template<typename T>
-friend IBinaryStream & (operator>>)(IBinaryStream &stream, T &value);
+friend IBinaryStream & (operator>>)(IBinaryStream &stream, T &data);
 
 public:
     IBinaryStream(void);
@@ -120,7 +120,7 @@ public:
 class OBinaryStream : public BinaryStream {
 
 template<typename T>
-friend OBinaryStream & (operator<<)(OBinaryStream &stream, const T &value);
+friend OBinaryStream & (operator<<)(OBinaryStream &stream, const T &data);
 
 public:
     OBinaryStream();

--- a/src/containers/binary_stream.hpp
+++ b/src/containers/binary_stream.hpp
@@ -25,12 +25,13 @@
 #ifndef __BITPIT_BINARY_STREAM_HPP__
 #define __BITPIT_BINARY_STREAM_HPP__
 
-#include <vector>
-#include <string>
-#include <fstream>
-#include <cstring>
+#include <array>
 #include <iostream>
-#include <stdexcept>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace bitpit {
 
@@ -38,21 +39,43 @@ namespace bitpit {
 class IBinaryStream;
 class OBinaryStream;
 
-template<typename T>
-IBinaryStream & operator>>(IBinaryStream &stream, T &data);
+template<typename T, std::size_t d>
+IBinaryStream &operator>>(IBinaryStream &stream, std::array<T, d> &data);
+template<typename T, std::size_t d>
+OBinaryStream &operator<<(OBinaryStream &stream, const std::array<T, d> &data);
 
 template<typename T>
 IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &data);
-
-template<>
-IBinaryStream & operator>>(IBinaryStream &stream, std::string &data);
-
-template<typename T>
-OBinaryStream & operator<<(OBinaryStream &stream, const T &data);
-
 template<typename T>
 OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &data);
 
+template<typename K, typename T>
+IBinaryStream &operator>>(IBinaryStream &stream, std::pair<K, T> &data);
+template<typename K, typename T>
+OBinaryStream &operator<<(OBinaryStream &stream, const std::pair<K, T> &data);
+
+template<typename K, typename T>
+IBinaryStream &operator>>(IBinaryStream &stream, std::map<K, T> &data);
+template<typename K, typename T>
+OBinaryStream &operator<<(OBinaryStream &stream, const std::map<K, T> &data);
+
+template<typename K, typename T>
+IBinaryStream &operator>>(IBinaryStream &stream, std::unordered_map<K, T> &data);
+template<typename K, typename T>
+OBinaryStream &operator<<(OBinaryStream &stream, const std::unordered_map<K, T> &data);
+
+template<typename T>
+IBinaryStream &operator>>(IBinaryStream &stream, std::unordered_set<T> &data);
+template<typename T>
+OBinaryStream &operator<<(OBinaryStream &stream, const std::unordered_set<T> &data);
+
+template<typename T>
+IBinaryStream & operator>>(IBinaryStream &stream, T &data);
+template<typename T>
+OBinaryStream & operator<<(OBinaryStream &stream, const T &data);
+
+template<>
+IBinaryStream & operator>>(IBinaryStream &stream, std::string &data);
 template<>
 OBinaryStream & operator<<(OBinaryStream &stream, const std::string &data);
 

--- a/src/containers/binary_stream.tpp
+++ b/src/containers/binary_stream.tpp
@@ -25,16 +25,35 @@
 namespace bitpit {
 
 /*!
-* Read the specified value from the stream.
+* Read the specified array from the stream.
 *
 * \param[in] stream is the input stream
 * \param[in] data is the data to be streamed
-* \result Returns the updated input stream.
+* \result Returns the same input stream received in input.
 */
-template<typename T>
-IBinaryStream& operator>>(IBinaryStream &stream, T &data)
+template<typename T, std::size_t SIZE>
+IBinaryStream & operator>>(IBinaryStream &stream, std::array<T, SIZE> &data)
 {
-    stream.read(reinterpret_cast<char *>(&data), sizeof(T));
+    for (T &value : data) {
+        stream >> value;
+    }
+
+    return stream;
+}
+
+/*!
+* Write the specified array into the stream.
+*
+* \param[in] stream is the output stream
+* \param[in] data is the data to be streamed
+* \result Returns the same output stream received in input.
+*/
+template<typename T, std::size_t SIZE>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::array<T, SIZE> &data)
+{
+    for (const T &value : data) {
+        stream << value;
+    }
 
     return stream;
 }
@@ -50,13 +69,243 @@ IBinaryStream& operator>>(IBinaryStream &stream, T &data)
 * \result Returns the updated input stream.
 */
 template<typename T>
-IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &data)
+IBinaryStream & operator>>(IBinaryStream &stream, std::vector<T> &data)
 {
     std::size_t size;
     stream.read(reinterpret_cast<char *>(&size), sizeof(size));
     data.resize(size);
 
-    stream.read(reinterpret_cast<char *>(data.data()), size * sizeof(T));
+    for (T &value : data) {
+        stream >> value;
+    }
+
+    return stream;
+}
+
+/*!
+* Write the specified vector into the stream.
+*
+* Along with vector data, also the size of the vector is stored into the
+* stream.
+*
+* \param[in] stream is the output stream
+* \param[in] data is the vector to be streamed
+* \result Returns the updated output stream.
+*/
+template<typename T>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::vector<T> &data)
+{
+    std::size_t size = data.size();
+    stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
+
+    for (const T &value : data) {
+        stream << value;
+    }
+
+    return stream;
+}
+
+/*!
+* Read the specified pair from the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the pair to be streamed
+* \result Returns the same input stream received in input.
+*/
+template<typename T1, typename T2>
+IBinaryStream & operator>>(IBinaryStream &stream, std::pair<T1, T2> &data)
+{
+    T1 first;
+    T2 second;
+    stream >> first;
+    stream >> second;
+    data = std::make_pair(std::move(first), std::move(second));
+
+    return stream;
+}
+
+/*!
+* Write the specified pair into the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the data to be streamed
+* \result Returns the same input stream received in input.
+*/
+template<typename T1, typename T2>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::pair<T1, T2> &data)
+{
+    stream << data.first;
+    stream << data.second;
+
+    return stream;
+}
+
+/*!
+* Read the specified map from the stream.
+*
+* Input map will be clear and its contents will be replaced with the ones stored into
+* the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the data to be streamed
+* \result Returns the same input stream received in input.
+*/
+template<typename K, typename T>
+IBinaryStream & operator>>(IBinaryStream &stream, std::unordered_map<K, T> &data)
+{
+    std::size_t size;
+    stream.read(reinterpret_cast<char *>(&size), sizeof(size));
+
+    data.clear();
+    data.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        K key;
+        T value;
+        stream >> key;
+        stream >> value;
+        data[key] = std::move(value);
+    }
+
+    return stream;
+}
+
+/*!
+* Write the specified map into the stream.
+*
+* Along with map data, also the size of the map is stored into the
+* stream.
+*
+* \param[in] stream is the output stream
+* \param[in] data is the data to be streamed
+* \result Returns the same output stream received in input.
+*/
+template<typename K, typename T>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::unordered_map<K, T> &data)
+{
+    std::size_t size = data.size();
+    stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
+
+    for (const auto &entry : data) {
+        stream << entry.first;
+        stream << entry.second;
+    }
+
+    return stream;
+}
+
+/*!
+* Read the specified map from the stream.
+*
+* Input map will be clear and its contents will be replaced with the ones stored into
+* the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the data to be streamed
+* \result Returns the same input stream received in input.
+*/
+template<typename K, typename T>
+IBinaryStream & operator>>(IBinaryStream &stream, std::map<K, T> &data)
+{
+    std::size_t size;
+    stream.read(reinterpret_cast<char *>(&size), sizeof(size));
+
+    data.clear();
+    for (std::size_t i = 0; i < size; ++i) {
+        K key;
+        T value;
+        stream >> key;
+        stream >> value;
+        data[key] = std::move(value);
+    }
+
+    return stream;
+}
+
+/*!
+* Write the specified map into the stream.
+*
+* Along with map data, also the size of the map is stored into the
+* stream.
+*
+* \param[in] stream is the output stream
+* \param[in] data is the data to be streamed
+* \result Returns the same output stream received in input.
+*/
+template<typename K, typename T>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::map<K, T> &data)
+{
+    std::size_t size = data.size();
+    stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
+
+    for (const auto &entry : data) {
+        stream << entry.first;
+        stream << entry.second;
+    }
+
+    return stream;
+}
+
+/*!
+* Read the specified set from the stream.
+*
+* Input set will be clear and its contents will be replaced with the ones stored into
+* the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the data to be streamed
+* \result Returns the same input stream received in input.
+*/
+template<typename T>
+IBinaryStream & operator>>(IBinaryStream &stream, std::unordered_set<T> &data)
+{
+    std::size_t size;
+    stream.read(reinterpret_cast<char *>(&size), sizeof(size));
+
+    data.clear();
+    data.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        T value;
+        stream >> value;
+        data.insert(std::move(value));
+    }
+
+    return stream;
+}
+
+/*!
+* Write the specified set into the stream.
+*
+* Along with set data, also the size of the map is stored into the
+* stream.
+*
+* \param[in] stream is the output stream
+* \param[in] data is the data to be streamed
+* \result Returns the same output stream received in input.
+*/
+template<typename T>
+OBinaryStream & operator<<(OBinaryStream &stream, const std::unordered_set<T> &data)
+{
+    std::size_t size = data.size();
+    stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
+
+    for (const auto &value : data) {
+        stream << value;
+    }
+
+    return stream;
+}
+
+/*!
+* Read the specified value from the stream.
+*
+* \param[in] stream is the input stream
+* \param[in] data is the value to be streamed
+* \result Returns the updated input stream.
+*/
+template<typename T>
+IBinaryStream & operator>>(IBinaryStream &stream, T &data)
+{
+    stream.read(reinterpret_cast<char *>(&data), sizeof(T));
 
     return stream;
 }
@@ -69,29 +318,9 @@ IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &data)
 * \result Returns the updated output stream.
 */
 template<typename T>
-OBinaryStream& operator<<(OBinaryStream &stream, const T &data)
+OBinaryStream & operator<<(OBinaryStream &stream, const T &data)
 {
     stream.write(reinterpret_cast<const char *>(&data), sizeof(T));
-
-    return stream;
-}
-
-/*!
-* Write the specified vector into the stream.
-*
-* Along with vector data, also the size of the vector is stored into the
-* stream.
-*
-* \param[in] data is the data to be streamed
-* \result Returns the updated output stream.
-*/
-template<typename T>
-OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &data)
-{
-    std::size_t size = data.size();
-    stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
-
-    stream.write(reinterpret_cast<const char *>(data.data()), size * sizeof(T));
 
     return stream;
 }

--- a/src/containers/binary_stream.tpp
+++ b/src/containers/binary_stream.tpp
@@ -28,13 +28,13 @@ namespace bitpit {
 * Read the specified value from the stream.
 *
 * \param[in] stream is the input stream
-* \param[in] value is the value to be streamed
+* \param[in] data is the data to be streamed
 * \result Returns the updated input stream.
 */
 template<typename T>
-IBinaryStream& operator>>(IBinaryStream &stream, T &value)
+IBinaryStream& operator>>(IBinaryStream &stream, T &data)
 {
-    stream.read(reinterpret_cast<char *>(&value), sizeof(T));
+    stream.read(reinterpret_cast<char *>(&data), sizeof(T));
 
     return stream;
 }
@@ -46,17 +46,17 @@ IBinaryStream& operator>>(IBinaryStream &stream, T &value)
 * stream.
 *
 * \param[in] stream is the input stream
-* \param[in] vector is the vector to be streamed
+* \param[in] data is the data to be streamed
 * \result Returns the updated input stream.
 */
 template<typename T>
-IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &vector)
+IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &data)
 {
     std::size_t size;
     stream.read(reinterpret_cast<char *>(&size), sizeof(size));
-    vector.resize(size);
+    data.resize(size);
 
-    stream.read(reinterpret_cast<char *>(vector.data()), size * sizeof(T));
+    stream.read(reinterpret_cast<char *>(data.data()), size * sizeof(T));
 
     return stream;
 }
@@ -65,13 +65,13 @@ IBinaryStream& operator>>(IBinaryStream &stream, std::vector<T> &vector)
 * Write the specified value into the stream.
 *
 * \param[in] stream is the output stream
-* \param[in] value is the value to be streamed
+* \param[in] data is the data to be streamed
 * \result Returns the updated output stream.
 */
 template<typename T>
-OBinaryStream& operator<<(OBinaryStream &stream, const T &value)
+OBinaryStream& operator<<(OBinaryStream &stream, const T &data)
 {
-    stream.write(reinterpret_cast<const char *>(&value), sizeof(T));
+    stream.write(reinterpret_cast<const char *>(&data), sizeof(T));
 
     return stream;
 }
@@ -82,16 +82,16 @@ OBinaryStream& operator<<(OBinaryStream &stream, const T &value)
 * Along with vector data, also the size of the vector is stored into the
 * stream.
 *
-* \param[in] vector is the vector to be streamed
+* \param[in] data is the data to be streamed
 * \result Returns the updated output stream.
 */
 template<typename T>
-OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &vector)
+OBinaryStream& operator<<(OBinaryStream &stream, const std::vector<T> &data)
 {
-    std::size_t size = vector.size();
+    std::size_t size = data.size();
     stream.write(reinterpret_cast<const char *>(&size), sizeof(size));
 
-    stream.write(reinterpret_cast<const char *>(vector.data()), size * sizeof(T));
+    stream.write(reinterpret_cast<const char *>(data.data()), size * sizeof(T));
 
     return stream;
 }

--- a/test/unit_tests/containers/CMakeLists.txt
+++ b/test/unit_tests/containers/CMakeLists.txt
@@ -1,0 +1,40 @@
+#---------------------------------------------------------------------------
+#
+#  bitpit
+#
+#  Copyright (C) 2015-2014 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of bitpit.
+#
+#  bitpit is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  bitpit is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Name of the current module
+get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# List of tests
+set(TESTS "")
+list(APPEND TESTS "test_binary_stream")
+
+# Test extra modules
+set(TEST_EXTRA_MODULES "")
+
+# Test extra libraries
+set(TEST_EXTRA_LIBRARIES "")
+
+# Add tests
+addModuleUnitTests(${MODULE_NAME} "${TESTS}" "${TEST_EXTRA_MODULES}" "${TEST_EXTRA_LIBRARIES}")
+unset(TESTS)

--- a/test/unit_tests/containers/test_binary_stream.cpp
+++ b/test/unit_tests/containers/test_binary_stream.cpp
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  bitpit
+ *
+ *  Copyright (C) 2015-2024 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of bitpit.
+ *
+ *  bitpit is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  bitpit is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include "bitpit_containers.hpp"
+
+#include <array>
+
+#define BITPIT_UNIT_TEST_SUITE_NAME unit_test_containers_binary_stream
+#include "helpers/unit_test.hpp"
+
+using namespace bitpit;
+
+BOOST_AUTO_TEST_SUITE(binaryStream)
+
+BOOST_AUTO_TEST_CASE(binary_stream_array_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::array<double, 3> EXPECTED_RESULT = {{1., 2., 3.}};
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::array<double, 3> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::array into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_vector_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::vector<double> EXPECTED_RESULT;
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::vector<double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::vector into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_vector_2)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::vector<double> EXPECTED_RESULT;
+    EXPECTED_RESULT.push_back(1.);
+    EXPECTED_RESULT.push_back(2.);
+    EXPECTED_RESULT.push_back(3.);
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::vector<double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::vector into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_pair_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::pair<int, double> EXPECTED_RESULT = std::make_pair(1, 11.);
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::pair<int, double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::pair into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_map_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::map<int, double> EXPECTED_RESULT;
+    EXPECTED_RESULT[0] = 11.;
+    EXPECTED_RESULT[1] = 22.;
+    EXPECTED_RESULT[2] = 33.;
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::map<int, double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::map into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_unordered_map_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::unordered_map<int, double> EXPECTED_RESULT;
+    EXPECTED_RESULT[0] = 11.;
+    EXPECTED_RESULT[1] = 22.;
+    EXPECTED_RESULT[2] = 33.;
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::unordered_map<int, double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::unordered_map into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_unordered_set_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::unordered_set<double> EXPECTED_RESULT;
+    EXPECTED_RESULT.insert(0.);
+    EXPECTED_RESULT.insert(1.),
+    EXPECTED_RESULT.insert(2.);
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::unordered_set<double> result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::unordered_set into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_double_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    double EXPECTED_RESULT = 108.;
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    double result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a double into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_long_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    long EXPECTED_RESULT = 108;
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    long result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a long into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_string_1)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::string EXPECTED_RESULT = "";
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::string result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::string into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(binary_stream_string_2)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    std::string EXPECTED_RESULT = "test_string";
+
+    OBinaryStream outputStream;
+    outputStream << EXPECTED_RESULT;
+
+    std::string result;
+    IBinaryStream inputStream(outputStream.data(), outputStream.getSize());
+    inputStream >> result;
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Streaming a std::string into/from a binary stream failed unit test.");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit_tests/helpers/unit_test.hpp
+++ b/test/unit_tests/helpers/unit_test.hpp
@@ -44,7 +44,7 @@
 
 #include "helpers/unit_test_common.hpp"
 
-#include "bitpit_IO.hpp"
+#include "bitpit_common.hpp"
 
 /*!
  * Main program.


### PR DESCRIPTION
Having operators for streaming containers of the standard library seems useful.