### PR TITLE
levelset: fix dump/restore of caches 

### DIFF
--- a/src/levelset/levelSetCache.hpp
+++ b/src/levelset/levelSetCache.hpp
@@ -657,7 +657,7 @@ public:
     const Item & at(std::size_t index) const;
 
     template<typename container_t, typename... Args>
-    std::size_t insert(Args&&... args);
+    std::size_t insert(std::size_t index, Args&&... args);
     void erase(std::size_t index);
 
     void clear();
@@ -682,9 +682,9 @@ public:
     ElementCacheCollection(const PiercedKernel<key_type> *kernel);
 
     template<typename container_t, typename... Args, typename std::enable_if<std::is_same<bitpit::PiercedStorage<typename container_t::value_type>, container_t>::value>::type * = nullptr>
-    std::size_t insert(Args&&... args);
+    std::size_t insert(std::size_t index, Args&&... args);
     template<typename container_t, typename... Args, typename std::enable_if<!std::is_same<bitpit::PiercedStorage<typename container_t::value_type>, container_t>::value>::type * = nullptr>
-    std::size_t insert(Args&&... args);
+    std::size_t insert(std::size_t index, Args&&... args);
 
 protected:
     const PiercedKernel<long> *m_kernel;

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -3064,16 +3064,16 @@ void LevelSetObject::fillFieldCellCache(LevelSetField field, const std::vector<l
     }
 
     // Get list of ghost exchange sources
-    std::set<long> ghostExchangeSources;
-    std::set<long> ghostExchangeTargets;
+    std::unordered_set<long> ghostExchangeSources;
+    std::unordered_set<long> ghostExchangeTargets;
 #if BITPIT_ENABLE_MPI
     for (const auto &entry : mesh.getGhostCellExchangeSources()) {
-        const std::vector<long> rankSourceList = entry.second;
+        const std::vector<long> &rankSourceList = entry.second;
         ghostExchangeSources.insert(rankSourceList.begin(), rankSourceList.end());
     }
 
     for (const auto &entry : mesh.getGhostCellExchangeTargets()) {
-        const std::vector<long> rankTargetList = entry.second;
+        const std::vector<long> &rankTargetList = entry.second;
         ghostExchangeTargets.insert(rankTargetList.begin(), rankTargetList.end());
     }
 #endif

--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -858,11 +858,13 @@ LevelSetCellLocation LevelSetObject::fillCellGeometricNarrowBandLocationCache(lo
 /**
  * Create the cache that will be used for storing cell location information.
  *
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the cache.
  */
-std::size_t LevelSetObject::createCellLocationCache()
+std::size_t LevelSetObject::createCellLocationCache(std::size_t cacheId)
 {
-    m_cellLocationCacheId = createCellCache<char>(LevelSetFillIn::DENSE);
+    m_cellLocationCacheId = createCellCache<char>(LevelSetFillIn::DENSE, cacheId);
 
     return m_cellLocationCacheId;
 }
@@ -1283,11 +1285,13 @@ void LevelSetObject::fillCellPropagatedSignCache()
 /**
  * Create the cache that will be used for storing cell propagated sign.
  *
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the cache.
  */
-std::size_t LevelSetObject::createCellPropagatedSignCache()
+std::size_t LevelSetObject::createCellPropagatedSignCache(std::size_t cacheId)
 {
-    m_cellPropagatedSignCacheId = createCellCache<char>(LevelSetFillIn::DENSE);
+    m_cellPropagatedSignCacheId = createCellCache<char>(LevelSetFillIn::DENSE, cacheId);
 
     return m_cellPropagatedSignCacheId;
 }
@@ -1795,14 +1799,11 @@ void LevelSetObject::restore( std::istream &stream ){
         if (hasCache) {
             // Create the cache
             if (cacheId == expectedCellLocationCacheId) {
-                createCellLocationCache();
-                assert(m_cellLocationCacheId == cacheId);
+                createCellLocationCache(cacheId);
             } else if (cacheId == expectedCellPropagatedSignCacheId) {
-                createCellPropagatedSignCache();
-                assert(cacheId == m_cellPropagatedSignCacheId);
+                createCellPropagatedSignCache(cacheId);
             } else if (field != LevelSetField::UNDEFINED) {
-                createFieldCellCache(field);
-                assert(cacheId == getFieldCellCacheId(field));
+                createFieldCellCache(field, cacheId);
             } else {
                 throw std::runtime_error("Unable to restore levelset object " + std::to_string(getId()) + "!");
             }
@@ -1810,6 +1811,7 @@ void LevelSetObject::restore( std::istream &stream ){
             // Restore cache contents
             CellCacheCollection::Cache *cache = getCellCache(cacheId);
             cache->restore(stream);
+        } else {
         }
     }
 
@@ -2833,20 +2835,22 @@ std::size_t LevelSetObject::getFieldCellCacheId(LevelSetField field) const
  * Create the cache that will be used for storing cell information of the specified field.
  *
  * \param field is the field for which the caches will be added
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the cache.
  */
-std::size_t LevelSetObject::createFieldCellCache(LevelSetField field)
+std::size_t LevelSetObject::createFieldCellCache(LevelSetField field, std::size_t cacheId)
 {
     switch(field) {
 
     case LevelSetField::VALUE:
-        return createFieldCellCache<double>(field);
+        return createFieldCellCache<double>(field, cacheId);
 
     case LevelSetField::SIGN:
-        return createFieldCellCache<short>(field);
+        return createFieldCellCache<short>(field, cacheId);
 
     case LevelSetField::GRADIENT:
-        return createFieldCellCache<std::array<double, 3>>(field);
+        return createFieldCellCache<std::array<double, 3>>(field, cacheId);
 
     default:
         throw std::runtime_error("The requested field is not supported!");

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -165,7 +165,7 @@ protected:
     virtual void                                fillCellLocationCache();
     virtual void                                fillCellLocationCache(const std::vector<adaption::Info> &adaptionData);
     virtual LevelSetCellLocation                fillCellGeometricNarrowBandLocationCache(long id);
-    virtual std::size_t                         createCellLocationCache();
+    virtual std::size_t                         createCellLocationCache(std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID);
     void                                        destroyCellLocationCache();
 
     void                                        evaluateCellBulkData();
@@ -173,7 +173,7 @@ protected:
     void                                        destroyCellBulkData();
 
     virtual void                                fillCellPropagatedSignCache();
-    virtual std::size_t                         createCellPropagatedSignCache();
+    virtual std::size_t                         createCellPropagatedSignCache(std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID);
     void                                        destroyCellPropagatedSignCache();
 
     virtual void                                dump(std::ostream &);
@@ -230,9 +230,9 @@ protected:
     CellCacheCollection::ValueCache<value_t> *  getFieldCellCache(LevelSetField field) const;
     CellCacheCollection::Cache *                getFieldCellCache(LevelSetField field) const;
     std::size_t                                 getFieldCellCacheId(LevelSetField field) const;
-    virtual std::size_t                         createFieldCellCache(LevelSetField field);
+    virtual std::size_t                         createFieldCellCache(LevelSetField field, std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID);
     template<typename value_t>
-    std::size_t                                 createFieldCellCache(LevelSetField field);
+    std::size_t                                 createFieldCellCache(LevelSetField field, std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID);
     virtual void                                destroyFieldCellCache(LevelSetField field);
 
 
@@ -241,7 +241,7 @@ protected:
     CellCacheCollection::ValueCache<value_t> *  getCellCache(std::size_t cacheId) const;
     CellCacheCollection::Cache *                getCellCache(std::size_t cacheId) const;
     template<typename value_t>
-    std::size_t                                 createCellCache(LevelSetFillIn expectedFillIn);
+    std::size_t                                 createCellCache(LevelSetFillIn expectedFillIn, std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID);
     void                                        destroyCellCache(std::size_t cacheId);
 
     bool                                        hasVTKOutputData(LevelSetField field, const std::string &objectName) const;

--- a/src/levelset/levelSetObject.tpp
+++ b/src/levelset/levelSetObject.tpp
@@ -71,15 +71,15 @@ typename LevelSetObject::CellCacheCollection::ValueCache<value_t> * LevelSetObje
  * Create the cache that will be used for storing cell information of the specified field.
  *
  * \param field is the field for which the caches will be added
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the registered cache.
  */
 template<typename value_t>
-std::size_t LevelSetObject::createFieldCellCache(LevelSetField field)
+std::size_t LevelSetObject::createFieldCellCache(LevelSetField field, std::size_t cacheId)
 {
     // Create cache
     LevelSetCacheMode cacheMode = getFieldCellCacheMode(field);
-
-    std::size_t cacheId;
     if (cacheMode != LevelSetCacheMode::NONE) {
         LevelSetFillIn expectedFillIn;
         if (m_kernel->getExpectedFillIn() == LevelSetFillIn::DENSE || cacheMode == LevelSetCacheMode::NARROW_BAND) {
@@ -88,7 +88,7 @@ std::size_t LevelSetObject::createFieldCellCache(LevelSetField field)
             expectedFillIn = LevelSetFillIn::SPARSE;
         }
 
-        cacheId = createCellCache<value_t>(expectedFillIn);
+        cacheId = createCellCache<value_t>(expectedFillIn, cacheId);
     } else {
         cacheId = CellCacheCollection::NULL_CACHE_ID;
     }
@@ -104,31 +104,43 @@ std::size_t LevelSetObject::createFieldCellCache(LevelSetField field)
  * Create the cache that will be used for storing cell information of the specified field.
  *
  * \param expectedFillIn is the expected fill-in of the cache
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the registered cache.
  */
 template<typename value_t>
-std::size_t LevelSetObject::createCellCache(LevelSetFillIn expectedFillIn)
+std::size_t LevelSetObject::createCellCache(LevelSetFillIn expectedFillIn, std::size_t cacheId)
 {
-    // Create the cache
-    std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID;
     if (dynamic_cast<const LevelSetCartesianKernel *>(m_kernel)){
         if (expectedFillIn == LevelSetFillIn::DENSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetCartesianKernel::CellDenseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetCartesianKernel::CellDenseCacheContainer<value_t>>(cacheId);
         } else if (expectedFillIn == LevelSetFillIn::SPARSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetCartesianKernel::CellSparseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetCartesianKernel::CellSparseCacheContainer<value_t>>(cacheId);
+        } else {
+            BITPIT_UNREACHABLE("The fill in type is not supported!");
+            throw std::runtime_error("The fill in type is not supported!");
         }
     } else if (dynamic_cast<const LevelSetOctreeKernel *>(m_kernel)){
         if (expectedFillIn == LevelSetFillIn::DENSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetOctreeKernel::CellDenseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetOctreeKernel::CellDenseCacheContainer<value_t>>(cacheId);
         } else if (expectedFillIn == LevelSetFillIn::SPARSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetOctreeKernel::CellSparseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetOctreeKernel::CellSparseCacheContainer<value_t>>(cacheId);
+        } else {
+            BITPIT_UNREACHABLE("The fill in type is not supported!");
+            throw std::runtime_error("The fill in type is not supported!");
         }
     } else if (dynamic_cast<const LevelSetUnstructuredKernel *>(m_kernel)){
         if (expectedFillIn == LevelSetFillIn::DENSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetUnstructuredKernel::CellDenseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetUnstructuredKernel::CellDenseCacheContainer<value_t>>(cacheId);
         } else if (expectedFillIn == LevelSetFillIn::SPARSE) {
-            cacheId = m_cellCacheCollection->insert<LevelSetUnstructuredKernel::CellSparseCacheContainer<value_t>>();
+            cacheId = m_cellCacheCollection->insert<LevelSetUnstructuredKernel::CellSparseCacheContainer<value_t>>(cacheId);
+        } else {
+            BITPIT_UNREACHABLE("The fill in type is not supported!");
+            throw std::runtime_error("The fill in type is not supported!");
         }
+    } else {
+        BITPIT_UNREACHABLE("The kernel type is not supported!");
+        throw std::runtime_error("The kernel type is not supported!");
     }
 
     return cacheId;

--- a/src/levelset/levelSetOctreeKernel.cpp
+++ b/src/levelset/levelSetOctreeKernel.cpp
@@ -46,9 +46,9 @@ LevelSetOctreeKernel::LevelSetOctreeKernel(VolOctree &patch, LevelSetFillIn fill
     // Initialize cache
     CellCacheCollection &cacheCollection = getCellCacheCollection();
     if (fillIn == LevelSetFillIn::SPARSE) {
-        m_cellCentroidCacheId = cacheCollection.insert<CellSparseCacheContainer<std::array<double, 3>>>();
+        m_cellCentroidCacheId = cacheCollection.insert<CellSparseCacheContainer<std::array<double, 3>>>(CellCacheCollection::NULL_CACHE_ID);
     } else if (fillIn == LevelSetFillIn::DENSE) {
-        m_cellCentroidCacheId = cacheCollection.insert<CellDenseCacheContainer<std::array<double, 3>>>();
+        m_cellCentroidCacheId = cacheCollection.insert<CellDenseCacheContainer<std::array<double, 3>>>(CellCacheCollection::NULL_CACHE_ID);
     } else {
         m_cellCentroidCacheId = CellCacheCollection::NULL_CACHE_ID;
     }

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -549,17 +549,19 @@ const double LevelSetSegmentationBaseObject::AUTOMATIC_SEARCH_RADIUS = -1;
  * Create the cache that will be used for storing cell information of the specified field.
  *
  * \param field is the field for which the caches will be registered
+ * \param cacheId is the id that will be associated with the cache, if a NULL_ID is specified
+ * the cache id will be assigned automatically
  * \result The id associated with the registered cache.
  */
-std::size_t LevelSetSegmentationBaseObject::createFieldCellCache(LevelSetField field)
+std::size_t LevelSetSegmentationBaseObject::createFieldCellCache(LevelSetField field, std::size_t cacheId)
 {
     switch(field) {
 
     case LevelSetField::SUPPORT:
-        return createFieldCellCache<long>(field);
+        return createFieldCellCache<long>(field, cacheId);
 
     default:
-        return LevelSetObject::createFieldCellCache(field);
+        return LevelSetObject::createFieldCellCache(field, cacheId);
 
     }
 }

--- a/src/levelset/levelSetSegmentationObject.hpp
+++ b/src/levelset/levelSetSegmentationObject.hpp
@@ -140,7 +140,7 @@ protected:
     LevelSetSegmentationBaseObject(int, const LevelSetSegmentationSurfaceInfo *surfaceInfo);
 
     using LevelSetObject::createFieldCellCache;
-    std::size_t createFieldCellCache(LevelSetField field) override;
+    std::size_t createFieldCellCache(LevelSetField field, std::size_t cacheId = CellCacheCollection::NULL_CACHE_ID) override;
     void fillFieldCellCache(LevelSetField field, long id) override;
     using LevelSetObject::fillFieldCellCache;
 

--- a/src/levelset/levelSetUnstructuredKernel.cpp
+++ b/src/levelset/levelSetUnstructuredKernel.cpp
@@ -44,13 +44,13 @@ LevelSetUnstructuredKernel::LevelSetUnstructuredKernel(VolUnstructured &patch, L
 
     CellCacheCollection &cacheCollection = getCellCacheCollection();
     if (fillIn == LevelSetFillIn::SPARSE) {
-        m_cellCentroidCacheId       = cacheCollection.insert<CellSparseCacheContainer<std::array<double, 3>>>();
-        m_cellTangentRadiusCacheId  = cacheCollection.insert<CellSparseCacheContainer<double>>();
-        m_cellBoundingRadiusCacheId = cacheCollection.insert<CellSparseCacheContainer<double>>();
+        m_cellCentroidCacheId       = cacheCollection.insert<CellSparseCacheContainer<std::array<double, 3>>>(CellCacheCollection::NULL_CACHE_ID);
+        m_cellTangentRadiusCacheId  = cacheCollection.insert<CellSparseCacheContainer<double>>(CellCacheCollection::NULL_CACHE_ID);
+        m_cellBoundingRadiusCacheId = cacheCollection.insert<CellSparseCacheContainer<double>>(CellCacheCollection::NULL_CACHE_ID);
     } else if (fillIn == LevelSetFillIn::DENSE) {
-        m_cellCentroidCacheId       = cacheCollection.insert<CellDenseCacheContainer<std::array<double, 3>>>();
-        m_cellTangentRadiusCacheId  = cacheCollection.insert<CellDenseCacheContainer<double>>();
-        m_cellBoundingRadiusCacheId = cacheCollection.insert<CellDenseCacheContainer<double>>();
+        m_cellCentroidCacheId       = cacheCollection.insert<CellDenseCacheContainer<std::array<double, 3>>>(CellCacheCollection::NULL_CACHE_ID);
+        m_cellTangentRadiusCacheId  = cacheCollection.insert<CellDenseCacheContainer<double>>(CellCacheCollection::NULL_CACHE_ID);
+        m_cellBoundingRadiusCacheId = cacheCollection.insert<CellDenseCacheContainer<double>>(CellCacheCollection::NULL_CACHE_ID);
     } else {
         m_cellCentroidCacheId       = CellCacheCollection::NULL_CACHE_ID;
         m_cellTangentRadiusCacheId  = CellCacheCollection::NULL_CACHE_ID;


### PR DESCRIPTION
The index associated with the caches should be preserved during the dump/restore procedure.