### PR TITLE
PABLO: fix mapping when refine function is called mutliple times

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -425,7 +425,12 @@ namespace bitpit {
     // =================================================================================== //
 
     /*! Refine local tree: refine one time octants with marker >0
-     * \param[out] mapidx mapidx[i] = index in old octants vector of the new i-th octant (index of father if octant is new after refinement)
+     * \param[in,out] mapidx mapidx[i] = index in old octants vector of the new i-th octant (index
+     * of father if octant is new after refinement). On output the mapping will be updated to
+     * refelect the changes performed during the refinement. The mapping received in input should
+     * always define a valid mapping, this means that during the first refinement the identity
+     * mapping (mapidx[i] = i) should be provided. If an empty mapping is provided, the mapping
+     * will not be filled.
      * \return	true if additional refinement is needed in order to satisfy
      * the specified markers
      */
@@ -505,7 +510,7 @@ namespace bitpit {
 
                 // Update the mapping
                 if(!mapidx.empty()){
-                    mapidx[futureIdx] = idx;
+                    mapidx[futureIdx] = mapidx[idx];
                 }
 
                 // Update future octant index
@@ -522,7 +527,7 @@ namespace bitpit {
                 // Update the mapping
                 if(!mapidx.empty()){
                     for (uint8_t i=0; i<nChildren; i++){
-                        mapidx[firstChildIdx + i] = idx;
+                        mapidx[firstChildIdx + i] = mapidx[idx];
                     }
                 }
 
@@ -539,13 +544,6 @@ namespace bitpit {
 
                 // Update future octant index
                 futureIdx -= nChildren;
-            }
-        }
-
-        // Update the mapping for cells that have not been modified
-        if(!mapidx.empty()){
-            for (uint32_t idx=0; idx<firstRefinedIdx; ++idx) {
-                mapidx[idx] = idx;
             }
         }
 

--- a/test/integration_tests/PABLO/test_PABLO_00005.cpp
+++ b/test/integration_tests/PABLO/test_PABLO_00005.cpp
@@ -49,13 +49,13 @@ int subtest_001()
 
     /**<Compute the connectivity and write the para_tree.*/
     pablo.computeConnectivity();
-    pablo.write("Pablo006_iter0");
+    pablo.write("Pablo005_iter0");
 
     /**<Refine globally one level and write the para_tree.*/
     for (int iter=1; iter<2; iter++){
         pablo.adaptGlobalRefine();
         pablo.updateConnectivity();
-        pablo.write("Pablo006_iter"+to_string(static_cast<unsigned long long>(iter)));
+        pablo.write("Pablo005_iter"+to_string(static_cast<unsigned long long>(iter)));
     }
 
     /**<Define a center point and a radius.*/
@@ -83,7 +83,7 @@ int subtest_001()
 
         /**<Update the connectivity and write the para_tree.*/
         pablo.updateConnectivity();
-        pablo.write("Pablo006_iter"+to_string(static_cast<unsigned long long>(iter)));
+        pablo.write("Pablo005_iter"+to_string(static_cast<unsigned long long>(iter)));
     }
 
     /**<Simple adapt() [coarse] 2 times the octants with at least one node inside the 2nd circle.*/
@@ -109,7 +109,7 @@ int subtest_001()
 
         /**<Update the connectivity and write the para_tree.*/
         pablo.updateConnectivity();
-        pablo.write("Pablo006_iter"+to_string(static_cast<unsigned long long>(iter)));
+        pablo.write("Pablo005_iter"+to_string(static_cast<unsigned long long>(iter)));
         fiter = iter;
     }
 
@@ -123,7 +123,7 @@ int subtest_001()
 
     /**<Update the connectivity and write the para_tree.*/
     pablo.updateConnectivity();
-    pablo.writeTest("Pablo006_iter"+to_string(static_cast<unsigned long long>(fiter+1)),data);
+    pablo.writeTest("Pablo005_iter"+to_string(static_cast<unsigned long long>(fiter+1)),data);
 
     /**<Adapt octree.*/
     pablo.adapt(true);
@@ -143,7 +143,7 @@ int subtest_001()
 
     /**<Update the connectivity and write the para_tree.*/
     pablo.updateConnectivity();
-    pablo.writeTest("Pablo006_iter"+to_string(static_cast<unsigned long long>(fiter+2)), data);
+    pablo.writeTest("Pablo005_iter"+to_string(static_cast<unsigned long long>(fiter+2)), data);
 
     return 0;
 }


### PR DESCRIPTION
The LocalTree::refine function can be called several times in a row. Therefore, it should properly update the mapper received in input rather than creating a new map from scratch.