### PR TITLE
LA: set block size information even when a flat internal storage is used

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1458,7 +1458,6 @@ void SystemSolver::matrixCreate(const SystemMatrixAssembler &assembler)
         }
     }
 
-
 #if BITPIT_ENABLE_MPI == 1
     std::vector<int> o_nnz(nPreallocationRows, 0);
     if (m_partitioned) {
@@ -1473,7 +1472,6 @@ void SystemSolver::matrixCreate(const SystemMatrixAssembler &assembler)
             if (rowReordering) {
                 matrixRow = rowReordering[matrixRow];
             }
-
 
             assembler.getRowPattern(n, &assemblerRowPattern);
             int nAssemblerRowNZ = assemblerRowPattern.size();

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -1490,22 +1490,20 @@ void SystemSolver::matrixCreate(const SystemMatrixAssembler &assembler)
     }
 #endif
 
+    MatType matrixType;
+    MatGetType(m_A, &matrixType);
+    if (strcmp(matrixType, MATSEQAIJ) == 0) {
+        MatSeqAIJSetPreallocation(m_A, 0, d_nnz.data());
+    } else if (strcmp(matrixType, MATSEQBAIJ) == 0) {
+        MatSeqBAIJSetPreallocation(m_A, matrixBlockSize, 0, d_nnz.data());
 #if BITPIT_ENABLE_MPI == 1
-    if (m_partitioned) {
-        if (matrixBlockSize == 1) {
-            MatMPIAIJSetPreallocation(m_A, 0, d_nnz.data(), 0, o_nnz.data());
-        } else {
-            MatMPIBAIJSetPreallocation(m_A, matrixBlockSize, 0, d_nnz.data(), 0, o_nnz.data());
-        }
-    } else
+    } else if (strcmp(matrixType, MATMPIAIJ) == 0) {
+        MatMPIAIJSetPreallocation(m_A, 0, d_nnz.data(), 0, o_nnz.data());
+    } else if (strcmp(matrixType, MATMPIBAIJ) == 0) {
+        MatMPIBAIJSetPreallocation(m_A, matrixBlockSize, 0, d_nnz.data(), 0, o_nnz.data());
 #endif
-    {
-        if (matrixBlockSize == 1) {
-            MatSeqAIJSetPreallocation(m_A, 0, d_nnz.data());
-        } else {
-            MatSeqBAIJSetPreallocation(m_A, matrixBlockSize, 0, d_nnz.data());
-        }
-
+    } else {
+        throw std::runtime_error("Matrix format not supported.");
     }
 
     // Each process will only set values for its own rows


### PR DESCRIPTION
When the argument "flatten" is set to true, block size will not be taken into account when allocating the internal storage of the system matrix. Even when the internal storage is flat, block size information are available and can be used by the solver to speed up the solution of the system. However, since the internal storage doesn't take blocks into account, some low level operations (e.g., matrix-matrix multiplications) cannot use block information. Some algorithms for the solution of the system (e.g., mutligrid) requires a flat storage.