### PR TITLE
levelset: interface intersection

### DIFF
--- a/src/CG/CG.hpp
+++ b/src/CG/CG.hpp
@@ -201,6 +201,29 @@ bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, arr
 bool intersectSegmentBox( array3D const &, array3D const &, array3D const &, array3D const &, bool, bool, 
         std::vector<array3D> &, std::vector<int> &, int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
 
+bool intersectPlanePixel(array3D const &Pp, array3D const &nP, array3D const *V, std::array<array3D, 2> &intersection,
+                         std::array<int, 2> &edges_of_intersection, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlanePixel(array3D const &Pp, array3D const &nP, array3D const *V,
+                        std::array<array3D, 2> &intersection, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlanePixel(array3D const &Pp, array3D const &nP, array3D const *V, 
+                         std::array<array3D, 2> &intersection, std::vector<array3D> &poly, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlaneTriangle(array3D const &P0, array3D const &P1, array3D const &P2, array3D const &Pp, array3D const &nP, std::array<array3D, 2> &intersection,
+                            std::array<int, 2> &edges_of_intersection, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlaneTriangle(array3D const &P0, array3D const &P1, array3D const &P2, array3D const &Pp, array3D const &nP, std::array<array3D, 2> &intersection,
+                            const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlaneTriangle(array3D const &P0, array3D const &P1, array3D const &P2, array3D const &Pp, array3D const &nP,
+                            std::array<array3D, 2> &intersection, std::vector<array3D> &poly, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlanePolygon(array3D const &P, array3D const &nP, std::size_t nV, array3D const *V, std::vector<std::array<array3D, 2>> &Qs,
+                           std::vector<std::array<int, 2>> &edges_of_Qs, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlanePolygon(array3D const &P, array3D const &nP, std::size_t nV, array3D const *V,
+                           std::vector<std::array<array3D, 2>> &Qs, const double distanceTolerance = DEFAULT_COPLANARITY_TOLERANCE);
+bool intersectPlanePolygon(array3D const &P, array3D const &nP, std::size_t nV, array3D const *V,
+                           std::vector<std::array<array3D, 2>> &Qs, std::vector< std::vector<array3D> > &polys, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+array3D computePolygonNormal(std::size_t nV, const array3D *V);
+void reconstructPlaneIntersectedPolygons(std::size_t nV, array3D const *V, std::vector<std::array<array3D, 2>> const &Qs,
+                                         std::vector<std::array<int, 2>> const &edges_of_Qs,
+                                         std::vector< std::vector<array3D> > &polys, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE);
+
 bool intersectPlanePlane( array3D const &, array3D const &, array3D const &, array3D const &, 
         array3D &, array3D &, const double coplanarityTolerance = DEFAULT_COPLANARITY_TOLERANCE) ;
 bool intersectPlaneBox( array3D const &, array3D const &, array3D const &, array3D const &, int dim=3, 
@@ -212,7 +235,6 @@ bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D
         const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
 bool intersectBoxBox( array3D const &, array3D const &, array3D const &, array3D const &, 
         array3D &, array3D &, int  dim = 3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;
-
 
 bool intersectBoxTriangle( array3D const &, array3D const &, array3D const &, array3D const &, array3D const &, 
         int dim=3, const double distanceTolerance = DEFAULT_DISTANCE_TOLERANCE) ;

--- a/src/levelset/levelSetCommon.hpp
+++ b/src/levelset/levelSetCommon.hpp
@@ -102,7 +102,7 @@ enum class LevelSetBooleanOperation{
 /*!
  * @ingroup levelsetEnums
  * Enum class defining the intersection between a cell and the zero levelset.
- * For details see LevelSetObject::intersectSurface()
+ * For details see LevelSetObject::isCellIntersected()
  */
 enum class LevelSetIntersectionStatus{
     FALSE=0,                                                            /**< Cell does not intersect zero levelset */

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -90,7 +90,8 @@ public:
     virtual bool                                isCellInNarrowBand(long id) const;
     virtual bool                                isInNarrowBand(const std::array<double,3> &point) const;
 
-    LevelSetIntersectionStatus                  intersectSurface(long, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
+    BITPIT_DEPRECATED(LevelSetIntersectionStatus intersectSurface(long, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const);
+    LevelSetIntersectionStatus                  isCellIntersected(long, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
 
     virtual short                               evalCellSign(long id) const;
     virtual double                              evalCellValue(long id, bool signedLevelSet) const;
@@ -179,7 +180,7 @@ protected:
     virtual void                                dump(std::ostream &);
     virtual void                                restore(std::istream &);
 
-    virtual LevelSetIntersectionStatus          _intersectSurface(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
+    virtual LevelSetIntersectionStatus          _isCellIntersected(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
 
     virtual short                               _evalCellSign(long id) const = 0;
     virtual double                              _evalCellValue(long id, bool signedLevelSet) const = 0;

--- a/src/levelset/levelSetObject.hpp
+++ b/src/levelset/levelSetObject.hpp
@@ -90,8 +90,10 @@ public:
     virtual bool                                isCellInNarrowBand(long id) const;
     virtual bool                                isInNarrowBand(const std::array<double,3> &point) const;
 
-    BITPIT_DEPRECATED(LevelSetIntersectionStatus intersectSurface(long, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const);
-    LevelSetIntersectionStatus                  isCellIntersected(long, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
+    BITPIT_DEPRECATED(LevelSetIntersectionStatus intersectSurface(long id, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const);
+    LevelSetIntersectionStatus                  isCellIntersected(long id, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
+    LevelSetIntersectionStatus                  isInterfaceIntersected(long id, bool invert, std::array<std::array<double, 3>, 2> *intersection, std::vector<std::array<double, 3>> *polygon) const;
+    LevelSetIntersectionStatus                  isInterfaceIntersected(long id) const;
 
     virtual short                               evalCellSign(long id) const;
     virtual double                              evalCellValue(long id, bool signedLevelSet) const;
@@ -181,6 +183,7 @@ protected:
     virtual void                                restore(std::istream &);
 
     virtual LevelSetIntersectionStatus          _isCellIntersected(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const;
+    virtual LevelSetIntersectionStatus          _isInterfaceIntersected(long id, bool positivePart, std::array<std::array<double, 3>, 2> *intersection, std::vector<std::array<double, 3>> *polygon) const;
 
     virtual short                               _evalCellSign(long id) const = 0;
     virtual double                              _evalCellValue(long id, bool signedLevelSet) const = 0;

--- a/src/levelset/levelSetSegmentationObject.cpp
+++ b/src/levelset/levelSetSegmentationObject.cpp
@@ -1803,7 +1803,7 @@ int LevelSetSegmentationBaseObject::evalCellPart(long id) const
  * @param[in] mode describes the types of check that should be performed
  * @return indicator regarding intersection
  */
-LevelSetIntersectionStatus LevelSetSegmentationBaseObject::_intersectSurface(long id, double distance, LevelSetIntersectionMode mode) const
+LevelSetIntersectionStatus LevelSetSegmentationBaseObject::_isCellIntersected(long id, double distance, LevelSetIntersectionMode mode) const
 {
     // Get surface information
     const SurfUnstructured &surface = evalCellSurface(id);
@@ -1814,7 +1814,7 @@ LevelSetIntersectionStatus LevelSetSegmentationBaseObject::_intersectSurface(lon
     }
 
     // Evaluate intersection using base class
-    return LevelSetObject::_intersectSurface(id, distance, mode);
+    return LevelSetObject::_isCellIntersected(id, distance, mode);
 }
 
 /*!
@@ -2790,7 +2790,7 @@ LevelSetCellLocation LevelSetSegmentationObject::fillCellGeometricNarrowBandLoca
     // geometrically inside the narrow band and as such it's up to the caller of this function to
     // identify their cell location.
     LevelSetCellLocation cellLocation = LevelSetCellLocation::UNKNOWN;
-    if (_intersectSurface(id, cellUnsigendValue, CELL_LOCATION_INTERSECTION_MODE) == LevelSetIntersectionStatus::TRUE) {
+    if (_isCellIntersected(id, cellUnsigendValue, CELL_LOCATION_INTERSECTION_MODE) == LevelSetIntersectionStatus::TRUE) {
         cellLocation = LevelSetCellLocation::NARROW_BAND_INTERSECTED;
     } else if (cellUnsigendValue <= m_narrowBandSize) {
         cellLocation = LevelSetCellLocation::NARROW_BAND_DISTANCE;

--- a/src/levelset/levelSetSegmentationObject.hpp
+++ b/src/levelset/levelSetSegmentationObject.hpp
@@ -165,6 +165,7 @@ protected:
     using LevelSetObject::fillFieldCellCache;
 
     LevelSetIntersectionStatus _isCellIntersected(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const override;
+    virtual LevelSetIntersectionStatus _isInterfaceIntersected(long id, bool invert, std::array<std::array<double, 3>, 2> *intersection, std::vector<std::array<double, 3>> *polygon) const override;
 
     virtual const SurfUnstructured & _evalCellSurface(long id) const = 0;
     virtual int _evalCellPart(long id) const;
@@ -231,6 +232,8 @@ protected:
     long _evalSupport(const std::array<double,3> &point) const override;
     long _evalSupport(const std::array<double,3> &point, double searchRadius) const override;
     void _evalProjection(const std::array<double,3> &point, bool signedLevelSet, std::array<double, 3> *projectionPoint, std::array<double, 3> *projectionNormal) const override;
+
+    LevelSetIntersectionStatus _isInterfaceIntersected(long id, bool invert, std::array<std::array<double, 3>, 2> *intersection, std::vector<std::array<double, 3>> *polygon) const override;
 
 private:
     std::unique_ptr<LevelSetSegmentationSurfaceInfo> m_surfaceInfo;

--- a/src/levelset/levelSetSegmentationObject.hpp
+++ b/src/levelset/levelSetSegmentationObject.hpp
@@ -164,7 +164,7 @@ protected:
     void fillFieldCellCache(LevelSetField field, long id) override;
     using LevelSetObject::fillFieldCellCache;
 
-    LevelSetIntersectionStatus _intersectSurface(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const override;
+    LevelSetIntersectionStatus _isCellIntersected(long, double distance, LevelSetIntersectionMode=LevelSetIntersectionMode::FAST_FUZZY) const override;
 
     virtual const SurfUnstructured & _evalCellSurface(long id) const = 0;
     virtual int _evalCellPart(long id) const;

--- a/src/operators/Operators.tpp
+++ b/src/operators/Operators.tpp
@@ -27,7 +27,8 @@
     \ingroup MathFunctions
     Sign function.
     Given a a variable of integral type, val, returns:
-    1 if val > 0
+    1 if val > T(0)
+    0 if val == T(0)
     -1, othersize.
 
     Template parameters can be any integral type such that operator< is defined.

--- a/src/patchkernel/cell.cpp
+++ b/src/patchkernel/cell.cpp
@@ -632,9 +632,9 @@ long * Cell::getInterfaces(int face)
 	\param interface is the interface to look for
 	\result The position in the interface face list of the specfied interface.
 */
-int Cell::findInterface(int face, int interface)
+int Cell::findInterface(int face, long interface) const
 {
-	long *faceInterfaces = getInterfaces(face);
+	const long *faceInterfaces = getInterfaces(face);
 	int nFaceInterfaces = getInterfaceCount(face);
 	for (int i = 0; i < nFaceInterfaces; i++) {
 		if (faceInterfaces[i] == interface) {
@@ -655,7 +655,7 @@ int Cell::findInterface(int face, int interface)
 	\param interface is the interface to look for
 	\result The position in the interface cell list of the specfied interface.
 */
-int Cell::findInterface(int interface)
+int Cell::findInterface(long interface) const
 {
 	int nCellInterfaces = getInterfaceCount();
 	const long *interfaces = getInterfaces();

--- a/src/patchkernel/cell.hpp
+++ b/src/patchkernel/cell.hpp
@@ -80,8 +80,8 @@ public:
 	long * getInterfaces();
 	const long * getInterfaces(int face) const;
 	long * getInterfaces(int face);
-	int findInterface(int face, int interface);
-	int findInterface(int interface);
+	int findInterface(int face, long interface) const;
+	int findInterface(long interface) const;
 
 	void deleteAdjacencies();
 	void resetAdjacencies(bool storeAdjacencies = true);

--- a/src/patchkernel/patch_kernel.hpp
+++ b/src/patchkernel/patch_kernel.hpp
@@ -619,6 +619,7 @@ public:
 	BITPIT_DEPRECATED(ConstProxyVector<std::array<double BITPIT_COMMA 3>> getInterfaceVertexCoordinates(long id) const);
 	void getInterfaceVertexCoordinates(long id, std::unique_ptr<std::array<double, 3>[]> *coordinates) const;
 	void getInterfaceVertexCoordinates(long id, std::array<double, 3> *coordinates) const;
+        bool intersectInterfacePlane(long id, std::array<double, 3> P, std::array<double, 3> nP, std::array<std::array<double, 3>, 2> *intersection, std::vector<std::array<double, 3>> *polygon) const;
 
 	InterfaceIterator getInterfaceIterator(long id);
 	InterfaceIterator interfaceBegin();


### PR DESCRIPTION
1. Introduce the pixel, triangle and polygon intersection with plane.
2. Allow the intersection of interfaces with smoothed continuous surface. It's mandatory for the conversion of Immerflow to a cut-cell software.