### PR TITLE
Get rank and processes count from DataCommunicator

### DIFF
--- a/src/communications/communications.cpp
+++ b/src/communications/communications.cpp
@@ -76,6 +76,32 @@ DataCommunicator::~DataCommunicator()
 }
 
 /*!
+    Gets the rank in the MPI communicator
+
+    \return the MPI rank.
+*/
+int DataCommunicator::getRank() const
+{
+    int rank;
+    MPI_Comm_rank(m_communicator, &rank);
+
+    return rank;
+}
+
+/*!
+    Gets the number of processes in the MPI communicator
+
+    \return The number of processes in the MPI communicator.
+*/
+int DataCommunicator::getProcessorCount() const
+{
+    int nProcs;
+    MPI_Comm_size(m_communicator, &nProcs);
+
+    return nProcs;
+}
+
+/*!
 	Gets the MPI communicator
 
 	\return The MPI communicator.

--- a/src/communications/communications.hpp
+++ b/src/communications/communications.hpp
@@ -49,6 +49,9 @@ public:
 
     const MPI_Comm & getCommunicator() const;
 
+    int getRank() const;
+    int getProcessorCount() const;
+
     void finalize(bool synchronous = false);
 
     void setTag(int exchangeTag);


### PR DESCRIPTION
Add two methods to get rank and number of processes.