### PR TITLE
PABLO: mark octants as "new for refinement" only if they are generated by a refinement

### DIFF
--- a/src/PABLO/LocalTree.cpp
+++ b/src/PABLO/LocalTree.cpp
@@ -524,6 +524,11 @@ namespace bitpit {
                 uint32_t firstChildIdx = futureIdx - (nChildren - 1);
                 fatherOctant.buildChildren(m_octants.data() + firstChildIdx);
 
+                // Set children information
+                for (int i = 0; i < nChildren; ++i) {
+                    m_octants[firstChildIdx + i].m_info[Octant::INFO_NEW4REFINEMENT] = true;
+                }
+
                 // Update the mapping
                 if(!mapidx.empty()){
                     for (uint8_t i=0; i<nChildren; i++){

--- a/src/PABLO/Octant.cpp
+++ b/src/PABLO/Octant.cpp
@@ -844,8 +844,6 @@ void	Octant::buildChildren(Octant *children) const {
 		uint32_t dh = oct.getLogicalSize();
 		oct.m_morton = PABLO::computeMorton(m_dim, coords[0] + dh * dx, coords[1] + dh * dy, coords[2] + dh * dz);
 
-		oct.m_info[OctantInfo::INFO_NEW4REFINEMENT] = true;
-
 		oct.m_info[INFO_BOUNDFACE0 + xf] = false;
 		oct.m_info[INFO_BOUNDFACE0 + yf] = false;
 		oct.m_info[INFO_BOUNDFACE0 + zf] = false;


### PR DESCRIPTION
The flag Octant::INFO_NEW4REFINEMENT should only be set for the octants that are generated after a refinement.