### PR TITLE
common: add a custom implementation of std::void_t for C++11 backwards compatibility

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -3291,8 +3291,20 @@ void SystemSolver::setupPreconditioner(PC pc, const KSPOptions &options) const
             PC subPC;
             KSPGetPC(subKSP, &subPC);
             PCSetType(subPC, PCILU);
-            if (options.levels != PETSC_DEFAULT) {
+            if (options.sublevels != PETSC_DEFAULT) {
+                log::warning() << " Setting ASM ILU levels using the member \"sublevels\" is deprecated."
+                               << " ASM ILU levels should be set using the member \"levels\"." << std::endl;
+
+                PCFactorSetLevels(subPC, options.sublevels);
+            } else if (options.levels != PETSC_DEFAULT) {
                 PCFactorSetLevels(subPC, options.levels);
+            }
+
+            if (options.subrtol != PETSC_DEFAULT) {
+                log::warning() << " The member \"subrtol\" is deprecated. Since ASM is only use a a preconditioner"
+                               << " setting the tolerance of the Krylov subspace doens't have any effect on the"
+                               << " solution of the system."
+                               << std::endl;
             }
         }
     }

--- a/src/LA/system_solvers_large.hpp
+++ b/src/LA/system_solvers_large.hpp
@@ -47,10 +47,14 @@ struct KSPOptions {
     PetscScalar rtol; //! Relative convergence tolerance, relative decrease in the preconditioned residual norm
     PetscScalar atol; //! Absolute convergence tolerance, absolute size of the preconditioned residual norm
 
+    PetscInt sublevels; //! Deprecated, ASM ILU levels should be set using the "levels" member
+    PetscScalar subrtol; //! Deprecated, it has never had any effect on the solution of the system
+
     KSPOptions()
         : overlap(PETSC_DEFAULT), levels(PETSC_DEFAULT),
           initial_non_zero(PETSC_TRUE), restart(PETSC_DEFAULT),
-          maxits(PETSC_DEFAULT), rtol(PETSC_DEFAULT), atol(PETSC_DEFAULT)
+          maxits(PETSC_DEFAULT), rtol(PETSC_DEFAULT), atol(PETSC_DEFAULT),
+          sublevels(PETSC_DEFAULT), subrtol(PETSC_DEFAULT)
     {
     }
 };

--- a/src/common/compiler.hpp
+++ b/src/common/compiler.hpp
@@ -96,4 +96,24 @@ do {                  \
  */
 #define BITPIT_COMMA ,
 
+
+/*!
+ * \ingroup common_misc
+ *
+ * Custom implementation of std::void_t for C++11 backwards compatibility.
+ */
+#if __cplusplus < 201703L
+template <class...>
+struct make_void { using type = void; };
+
+template <typename... T>
+using void_t = typename make_void<T...>::type;
+
+template <typename... T>
+using bitpit_void_t = void_t<T...>;
+#else
+template <typename... T>
+using bitpit_void_t = std::void_t<T...>;
+#endif
+
 #endif

--- a/src/discretization/stencil_weight.hpp
+++ b/src/discretization/stencil_weight.hpp
@@ -67,7 +67,7 @@ public:
 };
 
 template <typename weight_t>
-class DiscreteStencilWeightValueInfo<weight_t, std::void_t<typename weight_t::value_type>>
+class DiscreteStencilWeightValueInfo<weight_t, bitpit_void_t<typename weight_t::value_type>>
 {
 public:
     using type = typename weight_t::value_type;


### PR DESCRIPTION
Since void_t is the only C++17 feature used in bitpit, this change will allow to keep C++11 compatibility.