### PR TITLE
LA: fix initialization of PETSc KSP

### DIFF
--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -3169,9 +3169,6 @@ void SystemSolver::prepareKSP()
 
     // Set up
     if (setupNeeded) {
-        // Initialization
-        KSPSetFromOptions(m_KSP);
-
         // Perform actions before preconditioner set up
         prePreconditionerSetupActions();
 
@@ -3183,6 +3180,9 @@ void SystemSolver::prepareKSP()
 
         // Perform actions before Krylov subspace method set up set up
         preKrylovSetupActions();
+
+        // Initialize Krylov subspace from options
+        KSPSetFromOptions(m_KSP);
 
         // Set up the Krylov subspace method
         setupKrylov();

--- a/src/LA/system_solvers_large.cpp
+++ b/src/LA/system_solvers_large.cpp
@@ -3172,6 +3172,11 @@ void SystemSolver::prepareKSP()
         // Perform actions before preconditioner set up
         prePreconditionerSetupActions();
 
+        // Initialize preconditioner from options
+        PC pc;
+        KSPGetPC(m_KSP, &pc);
+        PCSetFromOptions(pc);
+
         // Set up preconditioner
         setupPreconditioner();
 


### PR DESCRIPTION
KSP/PC options should be set before calling KSPSetFromOptions/PCSetFromOptions.