### PR TITLE
patchkernel: fix evaluation of barycentric coordinates

### DIFF
--- a/src/patchkernel/surface_kernel.cpp
+++ b/src/patchkernel/surface_kernel.cpp
@@ -311,7 +311,7 @@ void SurfaceKernel::evalBarycentricCoordinates(long id, const std::array<double,
 
     default:
     {
-        ConstProxyVector<long> vertexIds = cell_->getVertexIds();
+        ConstProxyVector<long> vertexIds = getFacetOrderedVertexIds(*cell_);
 
         std::size_t nVertices = vertexIds.size();
         BITPIT_CREATE_WORKSPACE(vertexCoords, std::array<double BITPIT_COMMA 3>, nVertices, ReferenceElementInfo::MAX_ELEM_VERTICES);


### PR DESCRIPTION
CG functions expect vertices ordered in CCW order.