### PR TITLE
 volcartesian: properly update patch data structures when switching memory mode

### DIFF
--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -957,6 +957,13 @@ void VolCartesian::switchMemoryMode(MemoryMode mode)
 
 	// Set the requested memory mode
 	setMemoryMode(mode);
+
+	// Update the patch
+	//
+	// This will update all data structures (e.g., the interface) associated with the patch.
+	if (mode == MemoryMode::MEMORY_NORMAL) {
+		update();
+	}
 }
 
 /*!

--- a/src/volcartesian/volcartesian.cpp
+++ b/src/volcartesian/volcartesian.cpp
@@ -58,6 +58,7 @@ namespace bitpit {
 	- writing of VTK files.
 	When in light memory mode, updating the patch will automatically switch
 	to normal memory mode.
+	A newly constructed patch will operate in light memory mode.
 */
 
 /*!

--- a/test/unit_tests/volcartesian/test_volcartesian_general.cpp
+++ b/test/unit_tests/volcartesian/test_volcartesian_general.cpp
@@ -87,13 +87,26 @@ BOOST_FIXTURE_TEST_CASE(method_getSpacing_2, NormalTestPatch)
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(method_switchMemoryMode, NormalTestPatch)
+BOOST_FIXTURE_TEST_CASE(method_switchMemoryMode_1, NormalTestPatch)
 {
     BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
 
     const VolCartesian::MemoryMode EXPECTED_RESULT = VolCartesian::MEMORY_LIGHT;
 
     patch->switchMemoryMode(VolCartesian::MEMORY_LIGHT);
+    VolCartesian::MemoryMode result = patch->getMemoryMode();
+    if (result != EXPECTED_RESULT) {
+        throw std::runtime_error("Function 'switchMemoryMode(MemoryMode mode)' failed unit test.");
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(method_switchMemoryMode_2, LightTestPatch)
+{
+    BITPIT_UNIT_TEST_DISPLAY_NAME(log::cout());
+
+    const VolCartesian::MemoryMode EXPECTED_RESULT = VolCartesian::MEMORY_NORMAL;
+
+    patch->switchMemoryMode(VolCartesian::MEMORY_NORMAL);
     VolCartesian::MemoryMode result = patch->getMemoryMode();
     if (result != EXPECTED_RESULT) {
         throw std::runtime_error("Function 'switchMemoryMode(MemoryMode mode)' failed unit test.");


### PR DESCRIPTION
After switching to normal memory mode, we need to update the patch to make sure all data structures (e.g. interfaces) are properly updated.