### PR TITLE
levelset: fix evaluation of cell sign in the bulk

### DIFF
--- a/src/levelset/levelSetObject.cpp
+++ b/src/levelset/levelSetObject.cpp
@@ -1609,21 +1609,6 @@ short LevelSetObject::evalCellSign(long id) const {
                 }
             }
 
-            // Try fetching the sign from the cached value
-            if (getCellBulkEvaluationMode() == LevelSetBulkEvaluationMode::EXACT) {
-                CellCacheCollection::ValueCache<double> *valueCache = getFieldCellCache<double>(LevelSetField::VALUE);
-                if (valueCache) {
-                    LevelSetCacheMode signCacheMode  = getFieldCellCacheMode(LevelSetField::SIGN);
-                    LevelSetCacheMode valueCacheMode = getFieldCellCacheMode(LevelSetField::VALUE);
-                    if (valueCacheMode == LevelSetCacheMode::FULL || signCacheMode == valueCacheMode) {
-                        CellCacheCollection::ValueCache<double>::Entry valueCacheEntry = valueCache->findEntry(id);
-                        if (valueCacheEntry.isValid()) {
-                            return evalValueSign(*valueCacheEntry);
-                        }
-                    }
-                }
-            }
-
             // Evaluate the sign
             return _evalCellSign(id);
         };


### PR DESCRIPTION
The value stored in the cache is an absolute value, we cannot use it to evaluate the sign. 