### PR TITLE
cmake: add support for self-containment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ include(GNUInstallDirs)
 
 include(CTest)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(DependencyResolution)
+
 #------------------------------------------------------------------------------------#
 # Variables visible to the user
 #
@@ -653,6 +656,17 @@ else()
     endforeach()
 endif()
 
+# Initialize dependency resolution
+set(SELF_CONTAINMENT_THIRD_PARTY_PATTERNS ".*mpi.*;.*blas.*;.*cblas.*;.*lapack.*;.*lapacke.*;.*petsc.*;.*boost.*;.*metis.*")
+set(SELF_CONTAINMENT_THIRD_PARTY_DIR "${CMAKE_INSTALL_LIBDIR}/bitpit/third_party")
+set(RUNTIME_DLLS_EXCLUDE_PATTERNS ".*bitpit.*")
+set(RUNTIME_DLLS_DIR "${CMAKE_INSTALL_LIBDIR}/bitpit/third_party")
+initialize_dependency_resolution(BITPIT
+                                 "${SELF_CONTAINMENT_THIRD_PARTY_PATTERNS}"
+                                 "${SELF_CONTAINMENT_THIRD_PARTY_DIR}"
+                                 "${RUNTIME_DLLS_EXCLUDE_PATTERNS}"
+                                 "${RUNTIME_DLLS_DIR}")
+
 # Find external dependencies
 #
 # Low-level dependencies are processed first.
@@ -769,6 +783,7 @@ set(BITPIT_LIBRARY ${PROJECT_NAME} CACHE INTERNAL "bitpit library name" FORCE)
 
 add_library(${BITPIT_LIBRARY})
 configureBitpitTargetDependencies(${BITPIT_LIBRARY} PUBLIC)
+configure_dependency_resolution(${BITPIT_LIBRARY} "${CMAKE_INSTALL_LIBDIR}")
 
 set_target_properties(${BITPIT_LIBRARY}
     PROPERTIES

--- a/cmake/CopyDependencies.cmake
+++ b/cmake/CopyDependencies.cmake
@@ -1,0 +1,183 @@
+#---------------------------------------------------------------------------
+#
+#  bitpit
+#
+#  Copyright (C) 2015-2025 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of bitpit.
+#
+#  bitpit is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  bitpit is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+#---------------------------------------------------------------------------
+#       CMake script used to copy dependencies into a designated folder
+#---------------------------------------------------------------------------
+#       What does this script do?
+#
+#           It copies the dependencies of the indicated executables and libraries into the
+#           designated folder.
+#
+#           Should one specify some files to be excluded, the dependencies with the same name
+#           as one of the specified files will be ignored and not copied (e.g. if, as input,
+#           this module receives a path to boost_unit_test_framework-vc142-mt-gd-x64-1_77.dll,
+#           then it will ignore any other versions of that same library it finds during the
+#           search).
+#
+#           In addition to searching the usual OS-specific directories for libraries, it also
+#           searches the directories specified in the additional_search_directories variable.
+#
+#           This module cycles through all of the excluded file paths, and appends the folder
+#           that contains each one to the additional_search_directories.
+#
+#           It automatically excludes all libraries. You must explicitly include libraries you
+#           wish to copy. You must also include libraries for which you wish to find transitive
+#           dependencies otherwise they will not be considered. When the search encounters a
+#           library/exe not in the include list, it ignores that file and continues the search.
+#           Therefore all of its dependencies are not included.
+#
+#       When to use it?
+#
+#           During install, as a custom command, or as a custom target. Because it makes use of
+#           GET_RUNTIME_DEPENDENCIES, it cannot be used during cmake configuration.
+#           Example:
+#               add_custom_target(copy_dependencies COMMAND
+#                       ${CMAKE_COMMAND}
+#                       -D executable_list="$<TARGET_FILE:Executable>"
+#                       -D library_list="$<TARGET_FILE:Library>"
+#                       -D copy_to_directory="${CMAKE_BINARY_DIR}/$<CONFIG>"
+#                       -D additional_search_directories="${OMP_DLL_DIR}"
+#                       -D exclude_filepath_list="$<TARGET_RUNTIME_DLLS:RomboxTests>"
+#                       -D include_filename_patterns=".*rombox.*$<SEMICOLON>.*romby.*$<SEMICOLON>
+#                                                   .*boost.*$<SEMICOLON>.*vtk.*"
+#                       -P ${PROJECT_SOURCE_DIR}/cmake/copy_dependencies.cmake
+#                )
+#
+#       What are the inputs?
+#
+#           NOTE: Almost all these inputs are lists. Be sure to use $<SEMICOLON> instead of ";"
+#                 so that the lists get resolved properly during the build phase. You can always
+#                 perform a replace with string (REPLACE ";" "$<SEMICOLON>" my_list "${my_list}")
+#
+#           NOTE: Include in the include_filename_patterns your libraries that you need to include in
+#                 the search. e.g. Calling this script on a unit tests exe doesn't really need the
+#                 library since it's being built as well, but if you don't include the library,
+#                 then that library's dependencies will not be included.
+#
+#           executable_list -               A list of executable files to find dependencies for
+#           library_list -                  A list of libraries to find dependencies for
+#           include_filename_patterns -     A list of regex patterns that identify dependency names
+#                                           that should be included in the search. At least one
+#                                           pattern should be specified otherwise an error is
+#                                           raised
+#           exclude_filepath_list -         A list of absolute paths of dependencies that are
+#                                           already resolved and should not be copied if their
+#                                           filename matches one of the requested search patterns.
+#                                           Any other dependency with the same name found during
+#                                           the search will be ignored.
+#           copy_to_directory -             The directory where the dependencies should be copied
+#                                           If not specified, position of first target.
+#           additional_search_directories - Extra directories where cmake should search for
+#                                           dependencies
+#
+#---------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+if (NOT include_filename_patterns)
+    message(FATAL_ERROR "You have specified no dependencies to include. That means that no dependencies will be copied. Calling this script is pointless")
+endif()
+if (NOT additional_search_directories)
+    set(additional_search_directories " ")
+endif()
+if((NOT executable_list) AND (NOT library_list))
+    message(FATAL_ERROR "You have specified neither a executable nor a library list. This script is therefore pointless.")
+endif()
+
+if(NOT copy_to_directory)
+    if (executable_list)
+        foreach(executable ${executable_list})
+            get_filename_component(folder ${executable} DIRECTORY)
+            continue()
+        endforeach()
+    else()
+        foreach(executable ${library_list})
+            get_filename_component(folder ${executable} DIRECTORY)
+            continue()
+        endforeach()
+    endif()
+    set(copy_to_directory "${folder}/")
+    message(STATUS "Because you didn't specify a directory, the dependencies will be copied to folder ${copy_to_directory}")
+endif()
+
+set(exclude_filename_list "")
+foreach (filepath ${exclude_filepath_list})
+    get_filename_component(directory ${filepath} DIRECTORY)
+    list(APPEND additional_search_directories ${directory})
+
+    get_filename_component(filename ${filepath} NAME)
+    string(TOLOWER "${filename}" filename)
+    list(APPEND exclude_filename_list "${filename}")
+endforeach()
+
+if (executable_list AND library_list)
+    file(GET_RUNTIME_DEPENDENCIES
+            EXECUTABLES ${executable_list}
+            LIBRARIES ${library_list}
+            RESOLVED_DEPENDENCIES_VAR resolved_dependencies
+            UNRESOLVED_DEPENDENCIES_VAR unresolved_dependencies
+            PRE_EXCLUDE_REGEXES ".*"
+            PRE_INCLUDE_REGEXES ${include_filename_patterns}
+            POST_EXCLUDE_REGEXES ".*"
+            POST_INCLUDE_REGEXES ${include_filename_patterns}
+            DIRECTORIES ${additional_search_directories}
+            )
+elseif(executable_list)
+    file(GET_RUNTIME_DEPENDENCIES
+            EXECUTABLES ${executable_list}
+            RESOLVED_DEPENDENCIES_VAR resolved_dependencies
+            UNRESOLVED_DEPENDENCIES_VAR unresolved_dependencies
+            PRE_EXCLUDE_REGEXES ".*"
+            PRE_INCLUDE_REGEXES ${include_filename_patterns}
+            POST_EXCLUDE_REGEXES ".*"
+            POST_INCLUDE_REGEXES ${include_filename_patterns}
+            DIRECTORIES ${additional_search_directories}
+            )
+else()
+    file(GET_RUNTIME_DEPENDENCIES
+            LIBRARIES ${library_list}
+            RESOLVED_DEPENDENCIES_VAR resolved_dependencies
+            UNRESOLVED_DEPENDENCIES_VAR unresolved_dependencies
+            PRE_EXCLUDE_REGEXES ".*"
+            PRE_INCLUDE_REGEXES ${include_filename_patterns}
+            POST_EXCLUDE_REGEXES ".*"
+            POST_INCLUDE_REGEXES ${include_filename_patterns}
+            DIRECTORIES ${additional_search_directories}
+            )
+endif()
+
+foreach (filepath ${resolved_dependencies})
+    get_filename_component(filename ${filepath} NAME)
+    string(TOLOWER "${filename}" filename)
+    if (NOT filename IN_LIST exclude_filename_list)
+        message("Copying resolved dependency ${filepath}")
+        file(COPY "${filepath}" DESTINATION "${copy_to_directory}" FOLLOW_SYMLINK_CHAIN)
+    endif()
+endforeach ()
+
+list(LENGTH unresolved_dependencies unresolved_dependency_count)
+if("${unresolved_dependency_count}" GREATER 0)
+    message(WARNING "Unresolved dependencies detected: ${unresolved_dependencies}")
+endif()

--- a/cmake/DependencyResolution.cmake
+++ b/cmake/DependencyResolution.cmake
@@ -1,0 +1,103 @@
+#---------------------------------------------------------------------------
+#
+#  bitpit
+#
+#  Copyright (C) 2015-2025 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of bitpit.
+#
+#  bitpit is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  bitpit is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Initialize dependency resolution
+#
+# This function sets up the collection of third-party libraries and Windows runtime DLLs.
+#
+# \param PREFIX is the prefix used to create unique variable names for dependency resolution
+# \param DEFAULT_THIRD_PARTY_PATTERNS is a semicolon separated list that is used to initialize
+# the patterns to identify the third-party libraries
+# \param DEFAULT_THIRD_PARTY_DIR is the value that will be used to initialize the path of the
+# directory where the third-party libraries will be installed. This can be an absolute path or
+# a path relative to the CMake install prefix
+# \param DEFAULT_RUNTIME_DLL_EXCLUDE_PATTERNS is a semicolon separated list that is used to
+# initialize the patterns to exclude certain DLLs from being collected.
+# \param DEFAULT_RUNTIME_DLL_DIR is the value that will be used to initialize the path of the
+# directory where the runtime DLLs will be installed. This can be an absolute path or a path
+# relative to the CMake install prefix
+function(initialize_dependency_resolution PREFIX DEFAULT_THIRD_PARTY_PATTERNS DEFAULT_THIRD_PARTY_DIR DEFAULT_RUNTIME_DLL_EXCLUDE_PATTERNS DEFAULT_RUNTIME_DLL_DIR)
+
+    string(TOUPPER ${PREFIX} UPPER_PREFIX)
+    set(DEPENDENCY_RESOLUTION_PREFIX ${UPPER_PREFIX} CACHE INTERNAL "Prefix prepended to the names of the variables related to dependency resolution")
+
+    option(${DEPENDENCY_RESOLUTION_PREFIX}_ENABLE_SELF_CONTAINMENT "If set, a curated list of third-party libraries will be copied in the installation \
+    directory and the library will use their symbols in preference to global symbols with the same name." OFF)
+    set(${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_PATTERNS "${DEFAULT_THIRD_PARTY_PATTERNS}" CACHE STRING "A semicolon-separated \
+    list of patterns that will be used to identify the libraries needed for self-containment")
+    mark_as_advanced(${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_PATTERNS)
+    set(${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_DIR "${DEFAULT_THIRD_PARTY_DIR}" CACHE STRING "The path of the directory where \
+    third-party libraries needed for self-containment will be installed, it can be an absolute path or a path relative to the CMake install prefix")
+    mark_as_advanced(${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_DIR)
+    if (${DEPENDENCY_RESOLUTION_PREFIX}_ENABLE_SELF_CONTAINMENT)
+        message(STATUS "Self containment is enabled")
+        message(STATUS "Third-party libraries will be selected using the following patterns \"${${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_PATTERNS}\"")
+        message(STATUS "Third-party libraries needed for self containment will be installed into \"${${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_DIR}\"")
+    else()
+        message(STATUS "Self containment is disabled")
+    endif()
+
+    if (${WIN32})
+        set(${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_EXCLUDE_PATTERNS "${DEFAULT_RUNTIME_DLL_EXCLUDE_PATTERNS}" CACHE STRING "A semicolon-separated \
+        list of patterns used to exclude runtime DLLs from being copied")
+        mark_as_advanced(${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_EXCLUDE_PATTERNS)
+        message(STATUS  "Windows runtime DLLs that match the following patterns \"${${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_EXCLUDE_PATTERNS}\" \
+        will not be copied")
+        set(${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_DIR "${DEFAULT_RUNTIME_DLL_DIR}" CACHE STRING "The path of the directory \
+        where runtime DLLs will be installed, it can be an absolute path or a path relative to the CMake install prefix")
+        mark_as_advanced(${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_DIR)
+        message(STATUS  "Windows runtime DLLs will be installed into \"${${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_DIR}\"")
+    endif()
+
+endfunction()
+
+# Configure dependency resolution for the specified target
+#
+# \param TARGET_NAME is the name of the target for which dependency resolution will be configured
+# \param TARGET_INSTALL_DIR is the directory where the target will be installed, the directory
+# can be an absolute path or a path relative to the CMake install prefix
+function(configure_dependency_resolution TARGET_NAME TARGET_INSTALL_DIR)
+
+    # Collect Windows runtime DLLs
+    if (${WIN32})
+        include(WindowsRuntime)
+        windows_runtime_collect_dlls(${TARGET_NAME}
+                                     "${${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_EXCLUDE_PATTERNS}"
+                                     "${${DEPENDENCY_RESOLUTION_PREFIX}_WINDOWS_RUNTIME_DLLS_DIR}"
+                                     "INSTALL")
+    endif()
+
+    # Configure dependency search path
+    if (${DEPENDENCY_RESOLUTION_PREFIX}_ENABLE_SELF_CONTAINMENT)
+        include(SelfContainment)
+        configure_self_containment(${TARGET_NAME} "${TARGET_INSTALL_DIR}"
+                                   "${${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_PATTERNS}"
+                                   "${${DEPENDENCY_RESOLUTION_PREFIX}_SELF_CONTAINMENT_THIRD_PARTY_DIR}")
+    else()
+       # Append to the runtime search path (rpath) of installed binaries any directories outside the
+       # project that are in the linker search path or contain linked library files.
+       set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif()
+
+endfunction()

--- a/cmake/SelfContainment.cmake
+++ b/cmake/SelfContainment.cmake
@@ -1,0 +1,127 @@
+#---------------------------------------------------------------------------
+#
+#  bitpit
+#
+#  Copyright (C) 2015-2025 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of bitpit.
+#
+#  bitpit is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  bitpit is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Configure self containment for the specified target
+#
+# \param TARGET_NAME is the name of the target for which the self-containment will be configured
+# \param TARGET_INSTALL_DIR is the directory where the target will be installed, the directory
+# can be an absolute path or a path relative to the CMake install prefix
+# \param THIRD_PARTY_PATTERNS is a semi-color separated list of patterns that will be used to
+# identify the third party libraries
+# \param THIRD_PARTY_INSTALL_DIR is the directory where the third-party libraries will be
+# installed, the directory can be an absolute path or a path relative to the CMake install
+# prefix
+function(configure_self_containment TARGET_NAME TARGET_INSTALL_DIR THIRD_PARTY_PATTERNS THIRD_PARTY_INSTALL_DIR)
+    get_self_containment_additional_search_dirs(ADDITIONAL_SEARCH_DIRS)
+
+    set(COLLECT_THIRD_PARTY_LIBRARIES_TARGET ${TARGET_NAME}_self_containment_third_party_collection)
+
+    string(REPLACE ";" "$<SEMICOLON>" THIRD_PARTY_PATTERNS "${THIRD_PARTY_PATTERNS}")
+
+    if(NOT IS_ABSOLUTE "${THIRD_PARTY_INSTALL_DIR}")
+        get_filename_component(ABSOLUTE_THIRD_PARTY_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${THIRD_PARTY_INSTALL_DIR}" ABSOLUTE)
+    else()
+        set(ABSOLUTE_THIRD_PARTY_INSTALL_DIR "${THIRD_PARTY_INSTALL_DIR}")
+    endif()
+
+    get_target_property(TARGET_TYPE ${TARGET_NAME} TYPE)
+    if(TARGET_TYPE STREQUAL "EXECUTABLE")
+        set(LIBRARY_FILES "")
+        set(EXECUTABLE_FILES "$<TARGET_FILE:${TARGET_NAME}>")
+    else()
+        set(LIBRARY_FILES "$<TARGET_FILE:${TARGET_NAME}>")
+        set(EXECUTABLE_FILES "")
+    endif()
+
+    if (${WIN32})
+        set(EXCLUDED_DEPENDENCIES "$<JOIN:$<TARGET_RUNTIME_DLLS:${TARGET_NAME}>,$<SEMICOLON>>")
+    else()
+        set(EXCLUDED_DEPENDENCIES "")
+    endif()
+
+    add_custom_target(${COLLECT_THIRD_PARTY_LIBRARIES_TARGET} COMMAND
+        ${CMAKE_COMMAND} -E echo "Collecting third-party libraries for target ${TARGET_NAME}" &&
+        ${CMAKE_COMMAND} -E echo "Third-party libraries will be copied to ${ABSOLUTE_THIRD_PARTY_INSTALL_DIR}" &&
+        ${CMAKE_COMMAND}
+        -D executable_list="${EXECUTABLE_FILES}"
+        -D library_list="${LIBRARY_FILES}"
+        -D include_filename_patterns="${THIRD_PARTY_PATTERNS}"
+        -D exclude_filepath_list="${EXCLUDED_DEPENDENCIES}"
+        -D copy_to_directory="${ABSOLUTE_THIRD_PARTY_INSTALL_DIR}"
+        -D additional_search_directories="${ADDITIONAL_SEARCH_DIRS}"
+        -P ${PROJECT_SOURCE_DIR}/cmake/CopyDependencies.cmake
+    )
+
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --config $<CONFIG> --target ${COLLECT_THIRD_PARTY_LIBRARIES_TARGET})")
+
+    set_run_path(${TARGET_NAME} "${TARGET_INSTALL_DIR}" "${CMAKE_INSTALL_LIBDIR};${THIRD_PARTY_INSTALL_DIR}")
+endfunction()
+
+# Get additional search directories in which to search for third-party libraries.
+#
+# \param ADDITIONAL_SEARCH_DIRS on output will contain the search directories
+function(get_self_containment_additional_search_dirs ADDITIONAL_SEARCH_DIRS)
+    if(WIN32 AND MKL_FOUND)
+        set(${ADDITIONAL_SEARCH_DIRS} "${OMP_DLL_DIR}" PARENT_SCOPE)
+    elseif(NOT "$ENV{LD_LIBRARY_PATH}" STREQUAL "")
+        string(REPLACE ":" "$<SEMICOLON>" ENV_SEARCH_DIRS $ENV{LD_LIBRARY_PATH})
+        set(${ADDITIONAL_SEARCH_DIRS} ${ENV_SEARCH_DIRS} PARENT_SCOPE)
+    else()
+        set(${ADDITIONAL_SEARCH_DIRS} "." PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Set the run path (rpath) option for the specified target
+#
+# \param TARGET_NAME is the name of the target for which the run path will be set
+# \param ORIGIN_DIR is the directory where the target will be installed, the directory can be
+# an absolute path or a path relative to the CMake install prefix
+# \param LIBRARY_DIRS are the directories that will be added to the run path, directories can
+# be an absolute paths or a paths relative to the CMake install prefix
+function(set_run_path TARGET_NAME ORIGIN_DIR LIBRARY_DIRS)
+    if(NOT IS_ABSOLUTE "${ORIGIN_DIR}")
+        get_filename_component(ABSOLUTE_ORIGIN_DIR "${CMAKE_INSTALL_PREFIX}/${ORIGIN_DIR}" ABSOLUTE)
+    else()
+        set(ABSOLUTE_ORIGIN_DIR "${ORIGIN_DIR}")
+    endif()
+
+    set(INSTALL_RPATH "$ORIGIN")
+    foreach (LIBRARY_DIR IN LISTS LIBRARY_DIRS)
+        if(NOT IS_ABSOLUTE "${LIBRARY_DIR}")
+            get_filename_component(ABSOLUTE_LIBRARY_DIR "${CMAKE_INSTALL_PREFIX}/${LIBRARY_DIR}" ABSOLUTE)
+        else()
+            set(ABSOLUTE_LIBRARY_DIR "${LIBRARY_DIR}")
+        endif()
+
+        file(RELATIVE_PATH RELATIVE_LIBRARY_DIR ${ABSOLUTE_ORIGIN_DIR} ${ABSOLUTE_LIBRARY_DIR})
+        if(NOT "${RELATIVE_LIBRARY_DIR}" STREQUAL "")
+            set(INSTALL_RPATH "${INSTALL_RPATH}:$ORIGIN/${RELATIVE_LIBRARY_DIR}")
+        endif()
+    endforeach()
+
+    set_target_properties(${TARGET_NAME} PROPERTIES SKIP_BUILD_RPATH FALSE)
+    set_target_properties(${TARGET_NAME} PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE)
+    set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "${INSTALL_RPATH}")
+    set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
+endfunction()

--- a/cmake/WindowsRuntime.cmake
+++ b/cmake/WindowsRuntime.cmake
@@ -1,0 +1,58 @@
+#---------------------------------------------------------------------------
+#
+#  bitpit
+#
+#  Copyright (C) 2015-2025 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of bitpit.
+#
+#  bitpit is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  bitpit is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with bitpit. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Collects Windows runtime DLLs for the specified target
+#
+# \param TARGET_NAME is the name of the target for which DLLs will be collected
+# \param RUNTIME_DLLS_EXCLUDE_PATTERNS is a list of patterns to exclude from the DLL collection
+# \param RUNTIME_DLLS_INSTALL_DIR is the directory where the runtime DLLs will be installed,
+# the directory can be an absolute path or a path relative to the CMake install prefix
+# \param COLLECTION_TIME specifies when the command should be executed: "POST_BUILD" or "INSTALL"
+function(windows_runtime_collect_dlls TARGET_NAME RUNTIME_DLLS_EXCLUDE_PATTERNS RUNTIME_DLLS_INSTALL_DIR COLLECTION_TIME)
+    if(NOT IS_ABSOLUTE "${RUNTIME_DLLS_INSTALL_DIR}")
+        get_filename_component(ABSOLUTE_RUNTIME_DLLS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${RUNTIME_DLLS_INSTALL_DIR}" ABSOLUTE)
+    else()
+        set(ABSOLUTE_RUNTIME_DLLS_INSTALL_DIR "${RUNTIME_DLLS_INSTALL_DIR}")
+    endif()
+
+    SET(COLLECT_RUNTIME_DLLS_COMMAND
+        ${CMAKE_COMMAND} -E echo "Collecting runtime DLLs for target ${TARGET_NAME}" &&
+        ${CMAKE_COMMAND} -E echo "Runtime DLLs will be copied to ${ABSOLUTE_RUNTIME_DLLS_INSTALL_DIR}" &&
+        ${CMAKE_COMMAND}
+        -D filepath_list="$<JOIN:$<TARGET_RUNTIME_DLLS:${TARGET_NAME}>,$<SEMICOLON>>"
+        -D destination_directory="${ABSOLUTE_RUNTIME_DLLS_INSTALL_DIR}"
+        -D exclude_filename_regex_list="${RUNTIME_DLLS_EXCLUDE_PATTERNS}"
+        -P ${PROJECT_SOURCE_DIR}/cmake/CopyFiles.cmake
+    )
+
+    if(COLLECTION_TIME STREQUAL "POST_BUILD")
+        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${COLLECT_RUNTIME_DLLS_COMMAND})
+    elseif(COLLECTION_TIME STREQUAL "INSTALL")
+        set(COLLECT_RUNTIME_DLLS_TARGET ${TARGET_NAME}_windows_runtime_dlls_collection)
+        add_custom_target(${COLLECT_RUNTIME_DLLS_TARGET} COMMAND ${COLLECT_RUNTIME_DLLS_COMMAND})
+        install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --config $<CONFIG> --target ${COLLECT_RUNTIME_DLLS_TARGET})")
+    else()
+        message(FATAL_ERROR "Invalid COLLECTION_TIME specified. Use 'POST_BUILD' or 'INSTALL'.")
+    endif()
+endfunction()


### PR DESCRIPTION
Self-containment is an optional feature that copies a curated list of third-party libraries in the installation directory and forces bitpit to use the symbols contained in these libraries in preference to global symbols with the same name. The directory to which third-party libraries are copied should be customizable by the user (potentially multiple applications may use the same directory to store third-party libraries).

Relevant CMake variables are:

    BITPIT_ENABLE_SELF_CONTAINMENT: allows to enable self containment;
    BITPIT_SELF_CONTAINMENT_THIRD_PARTY_DIR: specify the directory where third-party libraries will be copied (the path is relative to the CMAKE_INSTALL_PREFIX directory).

To ensure that the symbols contained in the collected third-party libraries are preferred over the global symbols with the same name, CMake sets a proper rpath in the iolib dynamic libraries.